### PR TITLE
fix: wire auth, rate limiting, and security hardening for ws-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,14 @@
 .git
 .gitignore
 node_modules
-apps/web/node_modules
-apps/web/.next
 **/node_modules
+**/dist
 **/.next
+**/.turbo
+**/coverage
 *.md
 .env*
 !.env.example
 .github
+.worktrees
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ scripts/signals.db
 apps/web/data/signal-history.json
 
 # Build output
-dist/
+**/dist/

--- a/Dockerfile.ws-server
+++ b/Dockerfile.ws-server
@@ -18,7 +18,7 @@ COPY packages/signals/ packages/signals/
 COPY apps/ws-server/ apps/ws-server/
 
 # Build
-RUN npm run build --workspace=packages/signals 2>/dev/null || true
+RUN npm run build --workspace=packages/signals
 RUN npm run build --workspace=apps/ws-server
 
 ## Stage 2: Production

--- a/apps/ws-server/src/middleware/auth.ts
+++ b/apps/ws-server/src/middleware/auth.ts
@@ -1,8 +1,13 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
-const AUTH_SECRET = process.env.AUTH_SECRET || '';
+const AUTH_SECRET = process.env.AUTH_SECRET;
 const IS_DEV = process.env.NODE_ENV !== 'production';
+
+// Fail fast in production if secret is missing
+if (!IS_DEV && !AUTH_SECRET) {
+  throw new Error('AUTH_SECRET environment variable is required in production');
+}
 
 interface TokenPayload {
   sub: string;
@@ -10,8 +15,14 @@ interface TokenPayload {
   iat: number;
 }
 
+declare module 'fastify' {
+  interface FastifyRequest {
+    userId?: string;
+  }
+}
+
 export async function wsAuth(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  // Skip auth in development
+  // Skip auth in development when no secret is configured
   if (IS_DEV && !AUTH_SECRET) return;
 
   const query = request.query as { token?: string };
@@ -28,8 +39,7 @@ export async function wsAuth(request: FastifyRequest, reply: FastifyReply): Prom
     return;
   }
 
-  // Attach user info to request
-  (request as any).userId = payload.sub;
+  request.userId = payload.sub;
 }
 
 function verifyToken(token: string): TokenPayload | null {
@@ -38,7 +48,7 @@ function verifyToken(token: string): TokenPayload | null {
     if (parts.length !== 3) return null;
 
     const [header, payload, signature] = parts;
-    const expected = createHmac('sha256', AUTH_SECRET)
+    const expected = createHmac('sha256', AUTH_SECRET!)
       .update(`${header}.${payload}`)
       .digest('base64url');
 

--- a/apps/ws-server/src/middleware/rate-limit.ts
+++ b/apps/ws-server/src/middleware/rate-limit.ts
@@ -1,5 +1,3 @@
-import type { WebSocket } from 'ws';
-
 const CONNECTION_WINDOW_MS = 60_000;
 const MAX_CONNECTIONS_PER_IP = 5;
 const MAX_MESSAGES_PER_SECOND = 10;
@@ -42,10 +40,23 @@ export class MessageRateLimiter {
   }
 }
 
-// Cleanup stale entries periodically
-setInterval(() => {
-  const now = Date.now();
-  for (const [ip, entry] of connectionCounts) {
-    if (now > entry.resetAt) connectionCounts.delete(ip);
+// Cleanup stale entries periodically — unref so it doesn't keep process alive
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+export function startCleanup(): void {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [ip, entry] of connectionCounts) {
+      if (now > entry.resetAt) connectionCounts.delete(ip);
+    }
+  }, 60_000);
+  cleanupTimer.unref();
+}
+
+export function stopCleanup(): void {
+  if (cleanupTimer) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
   }
-}, 60_000);
+}

--- a/apps/ws-server/src/server.ts
+++ b/apps/ws-server/src/server.ts
@@ -6,6 +6,7 @@ import { symbolsRoutes } from './routes/symbols.js';
 import { relayPlugin } from './websocket/relay.js';
 import { ProviderManager } from './websocket/manager.js';
 import { RedisService } from './services/redis.js';
+import { DatabaseService } from './services/db.js';
 
 const PORT = parseInt(process.env.WS_SERVER_PORT || '4000', 10);
 const HOST = process.env.WS_SERVER_HOST || '0.0.0.0';
@@ -23,11 +24,22 @@ async function main() {
   // Redis (optional — degrades gracefully)
   const redis = new RedisService(process.env.REDIS_URL);
 
+  // Database (optional — degrades gracefully)
+  const db = new DatabaseService(process.env.DATABASE_URL);
+  if (process.env.DATABASE_URL) {
+    await db.ensureTable();
+  }
+
   // Provider manager — connects to upstream market data
   const providerManager = new ProviderManager(app.log, redis);
 
+  // Store ticks in database
+  providerManager.onTick((tick) => db.addTick(tick));
+
   // Plugins
-  await app.register(fastifyWebsocket);
+  await app.register(fastifyWebsocket, {
+    options: { maxPayload: 4096 },
+  });
 
   // Routes
   await app.register(healthRoutes, { prefix: '/', providerManager, redis });
@@ -38,6 +50,7 @@ async function main() {
   const shutdown = async () => {
     app.log.info('Shutting down...');
     await providerManager.disconnectAll();
+    await db.disconnect();
     redis.disconnect();
     await app.close();
     process.exit(0);

--- a/apps/ws-server/src/services/db.ts
+++ b/apps/ws-server/src/services/db.ts
@@ -5,6 +5,7 @@ const { Pool } = pg;
 
 const BATCH_SIZE = 100;
 const FLUSH_INTERVAL_MS = 1_000;
+const MAX_BUFFER_SIZE = 10_000;
 
 export class DatabaseService {
   private pool: pg.Pool | null = null;
@@ -85,8 +86,11 @@ export class DatabaseService {
         params,
       );
     } catch {
-      // Re-add failed batch for next flush
+      // Re-add failed batch, but cap total buffer to prevent memory exhaustion
       this.buffer.unshift(...batch);
+      if (this.buffer.length > MAX_BUFFER_SIZE) {
+        this.buffer.splice(MAX_BUFFER_SIZE);
+      }
     }
   }
 

--- a/apps/ws-server/src/services/redis.ts
+++ b/apps/ws-server/src/services/redis.ts
@@ -8,7 +8,8 @@ type TickHandler = (tick: NormalizedTick) => void;
 export class RedisService {
   private pub: Redis | null = null;
   private sub: Redis | null = null;
-  private connected = false;
+  private pubConnected = false;
+  private subConnected = false;
   private tickHandlers: Set<TickHandler> = new Set();
 
   constructor(url?: string) {
@@ -18,8 +19,12 @@ export class RedisService {
       this.pub = new Redis(url, { maxRetriesPerRequest: 3, lazyConnect: true });
       this.sub = new Redis(url, { maxRetriesPerRequest: 3, lazyConnect: true });
 
-      this.pub.on('connect', () => { this.connected = true; });
-      this.pub.on('error', () => { this.connected = false; });
+      this.pub.on('ready', () => { this.pubConnected = true; });
+      this.pub.on('close', () => { this.pubConnected = false; });
+      this.pub.on('error', () => {});
+
+      this.sub.on('ready', () => { this.subConnected = true; });
+      this.sub.on('close', () => { this.subConnected = false; });
       this.sub.on('error', () => {});
 
       // Connect
@@ -43,7 +48,7 @@ export class RedisService {
   }
 
   async publishTick(tick: NormalizedTick): Promise<void> {
-    if (!this.pub || !this.connected) return;
+    if (!this.pub || !this.pubConnected) return;
     const channel = `${TICK_CHANNEL_PREFIX}${tick.symbol}`;
     await this.pub.publish(channel, JSON.stringify(tick));
   }
@@ -57,12 +62,13 @@ export class RedisService {
   }
 
   isConnected(): boolean {
-    return this.connected;
+    return this.pubConnected && this.subConnected;
   }
 
   disconnect(): void {
     this.pub?.disconnect();
     this.sub?.disconnect();
-    this.connected = false;
+    this.pubConnected = false;
+    this.subConnected = false;
   }
 }

--- a/apps/ws-server/src/websocket/relay.ts
+++ b/apps/ws-server/src/websocket/relay.ts
@@ -5,6 +5,8 @@ import { getAllSymbols } from '@tradeclaw/signals';
 import { SubscriptionManager } from './subscriptions.js';
 import type { ProviderManager } from './manager.js';
 import type { RedisService } from '../services/redis.js';
+import { wsAuth } from '../middleware/auth.js';
+import { checkConnectionRate, MessageRateLimiter, startCleanup } from '../middleware/rate-limit.js';
 
 interface RelayOptions extends FastifyPluginOptions {
   providerManager: ProviderManager;
@@ -13,6 +15,7 @@ interface RelayOptions extends FastifyPluginOptions {
 
 const MAX_BUFFERED_AMOUNT = 64 * 1024; // 64KB backpressure threshold
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_SUBSCRIPTIONS_PER_CLIENT = 20;
 const validSymbols = new Set(getAllSymbols());
 
 let clientCounter = 0;
@@ -22,6 +25,10 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
   const subs = new SubscriptionManager();
   const clients: Map<string, WebSocket> = new Map();
   const idleTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  const rateLimiter = new MessageRateLimiter();
+
+  // Start rate-limit cleanup timer
+  startCleanup();
 
   // Connect to all symbols on startup
   const allSymbols = getAllSymbols();
@@ -46,8 +53,14 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
     }
   });
 
-  // WebSocket route
-  app.get('/ws', { websocket: true }, (socket, request) => {
+  // WebSocket route — auth preHandler + connection rate limiting
+  app.get('/ws', { websocket: true, preHandler: [wsAuth] }, (socket, request) => {
+    // Connection rate limiting (per IP)
+    if (!checkConnectionRate(request.ip)) {
+      socket.close(4029, 'Too many connections');
+      return;
+    }
+
     const clientId = `c_${++clientCounter}_${Date.now().toString(36)}`;
     clients.set(clientId, socket);
     resetIdleTimer(clientId);
@@ -55,6 +68,12 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
     app.log.info({ clientId, ip: request.ip }, 'Client connected');
 
     socket.on('message', (data) => {
+      // Message rate limiting (per client)
+      if (!rateLimiter.check(clientId)) {
+        sendError(socket, 'Rate limited — too many messages');
+        return;
+      }
+
       resetIdleTimer(clientId);
 
       let msg: WsClientMessage;
@@ -78,7 +97,14 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
       }
 
       if (msg.action === 'subscribe') {
-        const subscribed = subs.subscribe(clientId, validRequested);
+        // Enforce per-client subscription cap
+        const currentCount = subs.getClientSymbols(clientId).length;
+        const allowed = validRequested.slice(0, MAX_SUBSCRIPTIONS_PER_CLIENT - currentCount);
+        if (allowed.length === 0) {
+          sendError(socket, `Subscription limit reached (max ${MAX_SUBSCRIPTIONS_PER_CLIENT} symbols)`);
+          return;
+        }
+        const subscribed = subs.subscribe(clientId, allowed);
         const response: WsServerMessage = { type: 'subscribed', symbols: subscribed };
         socket.send(JSON.stringify(response));
         app.log.info({ clientId, symbols: subscribed }, 'Client subscribed');
@@ -95,6 +121,7 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
     socket.on('close', () => {
       subs.removeClient(clientId);
       clients.delete(clientId);
+      rateLimiter.remove(clientId);
       clearIdleTimer(clientId);
       app.log.info({ clientId }, 'Client disconnected');
     });
@@ -103,6 +130,7 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
       app.log.error({ clientId, err }, 'Client socket error');
       subs.removeClient(clientId);
       clients.delete(clientId);
+      rateLimiter.remove(clientId);
       clearIdleTimer(clientId);
     });
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       REDIS_URL: redis://redis:6379
       WS_SERVER_PORT: "4000"
       NODE_ENV: production
+      AUTH_SECRET: ${AUTH_SECRET:?Set AUTH_SECRET in .env}
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

PR #49 was merged before code review findings could be addressed. This PR applies all critical and high-priority security fixes:

- **Wire auth + rate limiting** — `wsAuth` preHandler and `checkConnectionRate`/`MessageRateLimiter` are now actually applied to the `/ws` endpoint (they were defined but never imported or used)
- **JWT secret validation** — fail fast at startup if `AUTH_SECRET` is missing in production (was defaulting to empty string, allowing forged tokens)
- **Per-client subscription cap** — max 20 symbols per client to prevent fan-out abuse
- **Database integration** — wire `DatabaseService` into server.ts for tick persistence, with 10k buffer cap to prevent OOM
- **Redis connection tracking** — track both pub and sub client state (was only tracking pub)
- **Rate-limit cleanup lifecycle** — use `setInterval().unref()` with start/stop instead of module-level interval
- **WebSocket maxPayload** — set to 4KB (default was 100MB)
- **Dockerfile** — remove `2>/dev/null || true` error suppression on signals build
- **Docker context** — add `**/dist/`, `.worktrees/`, `**/coverage/` to `.dockerignore`
- **Gitignore** — use `**/dist/` pattern to catch nested dist directories
- **docker-compose** — pass `AUTH_SECRET` to ws-server service

## Test plan

- [x] 27 unit tests pass (normalizer + subscriptions)
- [x] TypeScript compiles with zero errors
- [x] Web app build passes (no regressions)
- [ ] Manual: verify `/ws` rejects connections without valid token in production mode
- [ ] Manual: verify rate limiting kicks in after 5 connections/min per IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)