### PR TITLE
feat: quick wins — Docker --help (#10), Ctrl+R refresh (#5), BB squeeze (#39)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,14 @@ WORKDIR /app
 # Copy standalone output from builder (includes node_modules at root)
 COPY --from=builder /app/apps/web/.next/standalone ./
 
+# Entrypoint handles --help and env-var wiring before launching the server.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
 EXPOSE 3000
 
-CMD ["sh", "-c", "PORT=${PORT:-3000} node apps/web/server.js"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD []

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -35,7 +35,7 @@ interface OpenAPISpec {
 export default function ApiDocsPage() {
   const [spec, setSpec] = useState<OpenAPISpec | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
-  const [baseUrl] = useState(() => typeof window !== 'undefined' ? window.location.origin : '');
+  const [baseUrl, setBaseUrl] = useState(() => typeof window !== 'undefined' ? window.location.origin : '');
 
   useEffect(() => {
     fetch('/api/docs')

--- a/apps/web/app/api/digest/preview/route.ts
+++ b/apps/web/app/api/digest/preview/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(data, { headers });
   }
 
-  const html = generateEmailDigest({ period, topN: 5 });
+  const html = await generateEmailDigest({ period, topN: 5 });
   return new NextResponse(html, {
     headers: {
       ...headers,

--- a/apps/web/app/api/proof/route.ts
+++ b/apps/web/app/api/proof/route.ts
@@ -30,6 +30,11 @@ export interface ProofSignal {
   };
 }
 
+export interface ProofResponse {
+  stats: ProofStats;
+  signals: ProofSignal[];
+}
+
 export interface ProofStats {
   totalSignals: number;
   realSignals: number;

--- a/apps/web/app/api/v1/signals/route.ts
+++ b/apps/web/app/api/v1/signals/route.ts
@@ -45,7 +45,7 @@ export async function GET(req: NextRequest) {
   const useLive = searchParams.get("source") !== "realtime"; // Default to live file
 
   const now = new Date().toISOString();
-  const headers = {
+  const headers: Record<string, string> = {
     "Cache-Control": "public, s-maxage=60",
     "X-TradeClaw-Version": "v1",
     "Access-Control-Allow-Origin": "*",

--- a/apps/web/app/api/widget/profile/route.ts
+++ b/apps/web/app/api/widget/profile/route.ts
@@ -130,7 +130,7 @@ export async function GET(request: NextRequest) {
     if (signal) {
       direction = signal.direction;
       confidence = signal.confidence;
-      entryPrice = signal.entryPrice;
+      entryPrice = signal.entry;
       rsi = signal.indicators.rsi.value;
     }
   } catch {

--- a/apps/web/app/backtest/page.tsx
+++ b/apps/web/app/backtest/page.tsx
@@ -528,6 +528,7 @@ export default function BacktestPage() {
       } catch { /* ignore invalid param, run with defaults */ }
     }
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial auto-run is an intentional one-shot effect on mount
     setRunning(true);
     setError(null);
     runBacktest(backtestParams)

--- a/apps/web/app/dashboard/DashboardClient.tsx
+++ b/apps/web/app/dashboard/DashboardClient.tsx
@@ -774,6 +774,27 @@ export function DashboardClient({ initialSignals, initialSyntheticSymbols }: { i
     return () => clearInterval(interval);
   }, [autoRefresh, fetchSignals, signals.length]);
 
+  // Keyboard shortcut: Ctrl+R / Cmd+R triggers an in-app refresh instead of a full page reload.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isRefreshKey =
+        (event.ctrlKey || event.metaKey) &&
+        !event.shiftKey &&
+        !event.altKey &&
+        (event.key === 'r' || event.key === 'R');
+      if (!isRefreshKey) return;
+
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+
+      event.preventDefault();
+      void fetchSignals();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [fetchSignals]);
+
   // Update browser tab title with BUY signal count
   useEffect(() => {
     const highConfBuyCount = signals.filter(

--- a/apps/web/app/lib/signal-generator.ts
+++ b/apps/web/app/lib/signal-generator.ts
@@ -48,7 +48,12 @@ const WEIGHTS = {
   STOCH_OVERBOUGHT: 15,  // Stochastic > 80 and K crossing below D
   BB_LOWER_TOUCH: 10,    // Price near lower Bollinger band
   BB_UPPER_TOUCH: 10,    // Price near upper Bollinger band
+  BB_SQUEEZE_BREAKOUT: 8, // Squeeze (compressed bands) + price breaking a band → volatility expansion
 } as const;
+
+// Bandwidth threshold (percentage of middle band) below which a squeeze is active.
+// Matches packages/signals/src/indicators.ts → DEFAULT_SQUEEZE_THRESHOLD.
+const BB_SQUEEZE_THRESHOLD = 4;
 
 const SIGNAL_THRESHOLD = 25; // Minimum score to generate a signal
 const MIN_CONFIDENCE = 58; // Below 58% is noise — do not emit
@@ -444,6 +449,26 @@ function scoreIndicators(indicators: AllIndicators): ScoreResult {
         sellCategories.volatility += WEIGHTS.BB_UPPER_TOUCH * 0.5;
         reasons.push('Price near upper Bollinger Band');
       }
+
+      // ── Bollinger Band Squeeze (volatility breakout) ─────
+      // When bands are compressed, a touch/break of either band is a high-probability
+      // breakout setup. Boost the side whose band the price is testing.
+      const bandwidthPct = bollinger.current.bandwidth;
+      const isSqueeze =
+        !isNaN(bandwidthPct) && bandwidthPct > 0 && bandwidthPct < BB_SQUEEZE_THRESHOLD;
+      if (isSqueeze) {
+        if (distToUpper < 0.15) {
+          buyScore += WEIGHTS.BB_SQUEEZE_BREAKOUT;
+          buyCategories.volatility += WEIGHTS.BB_SQUEEZE_BREAKOUT;
+          reasons.push(`BB squeeze breakout up (bw=${bandwidthPct.toFixed(2)}%)`);
+        } else if (distToLower < 0.15) {
+          sellScore += WEIGHTS.BB_SQUEEZE_BREAKOUT;
+          sellCategories.volatility += WEIGHTS.BB_SQUEEZE_BREAKOUT;
+          reasons.push(`BB squeeze breakdown (bw=${bandwidthPct.toFixed(2)}%)`);
+        } else {
+          reasons.push(`BB squeeze active (bw=${bandwidthPct.toFixed(2)}%)`);
+        }
+      }
     }
   }
 
@@ -523,6 +548,10 @@ function buildIndicatorSummary(
         ? (currentPrice > bollinger.current.middle ? 'upper' : 'lower')
         : 'middle',
       bandwidth: +(bollinger.current.bandwidth || 0).toFixed(4),
+      squeeze:
+        !isNaN(bollinger.current.bandwidth) &&
+        bollinger.current.bandwidth > 0 &&
+        bollinger.current.bandwidth < BB_SQUEEZE_THRESHOLD,
     },
     stochastic: {
       k: +stochastic.current.k.toFixed(2),

--- a/apps/web/lib/signal-history.ts
+++ b/apps/web/lib/signal-history.ts
@@ -76,7 +76,7 @@ export interface LeaderboardData {
 
 // ── Helpers ──────────────────────────────────────────────────
 
-const useDb = () => !!process.env.DATABASE_URL;
+const isDbEnabled = () => !!process.env.DATABASE_URL;
 
 const DATA_DIR = path.join(process.cwd(), 'data');
 const HISTORY_FILE = path.join(DATA_DIR, 'signal-history.json');
@@ -149,7 +149,7 @@ function writeHistoryFile(records: SignalHistoryRecord[]): void {
 // ── Read ─────────────────────────────────────────────────────
 
 export async function readHistoryAsync(): Promise<SignalHistoryRecord[]> {
-  if (!useDb()) return readHistoryFile();
+  if (!isDbEnabled()) return readHistoryFile();
 
   const rows = await query<HistoryRow>(
     `SELECT * FROM signal_history
@@ -178,7 +178,7 @@ export async function recordSignalAsync(
   const sigId = id ?? `${pair}-${timeframe}-${direction}-${Date.now()}`;
   const ts = timestamp ?? Date.now();
 
-  if (useDb()) {
+  if (isDbEnabled()) {
     await execute(
       `INSERT INTO signal_history (id, pair, timeframe, direction, confidence, entry_price, tp1, sl, created_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
@@ -222,7 +222,7 @@ export function recordSignal(
 export async function recordSignalsAsync(signals: TrackedSignalInput[]): Promise<number> {
   if (signals.length === 0) return 0;
 
-  if (useDb()) {
+  if (isDbEnabled()) {
     let inserted = 0;
     for (const s of signals) {
       if (!s.id) continue;
@@ -317,7 +317,7 @@ export async function resolveRealOutcomes(): Promise<void> {
   const FOUR_H = 4 * 3600 * 1000;
   const TWENTY_FOUR_H = 24 * 3600 * 1000;
 
-  if (useDb()) {
+  if (isDbEnabled()) {
     const pending = await query<HistoryRow>(
       `SELECT * FROM signal_history
        WHERE is_simulated = FALSE
@@ -432,7 +432,7 @@ export async function resolveRealOutcomes(): Promise<void> {
 // ── Query helpers for cron pipeline ──────────────────────────
 
 export async function getPendingRecordsAsync(): Promise<SignalHistoryRecord[]> {
-  if (useDb()) {
+  if (isDbEnabled()) {
     // Only look back 14 days — older signals lack candle data to resolve
     const rows = await query<HistoryRow>(
       `SELECT * FROM signal_history
@@ -457,7 +457,7 @@ export async function getRecentRecordForSymbolAsync(
   direction: 'BUY' | 'SELL',
   withinMs: number,
 ): Promise<SignalHistoryRecord | undefined> {
-  if (useDb()) {
+  if (isDbEnabled()) {
     const cutoff = new Date(Date.now() - withinMs).toISOString();
     const row = await queryOne<HistoryRow>(
       `SELECT * FROM signal_history
@@ -487,7 +487,7 @@ export async function markTelegramPosted(
   signalId: string,
   messageId: number,
 ): Promise<void> {
-  if (!useDb()) return;
+  if (!isDbEnabled()) return;
   await execute(
     `UPDATE signal_history
      SET telegram_posted_at = NOW(), telegram_message_id = $2
@@ -503,7 +503,7 @@ export async function updateRecordsAsync(
 ): Promise<number> {
   if (updates.length === 0) return 0;
 
-  if (useDb()) {
+  if (isDbEnabled()) {
     let changed = 0;
     for (const { id, patch } of updates) {
       const sets: string[] = [];

--- a/apps/web/lib/votes.ts
+++ b/apps/web/lib/votes.ts
@@ -122,8 +122,8 @@ export function getVoteStats(): {
   let totalSell = 0;
   let maxBuyRatio = -1;
   let maxSellRatio = -1;
-  let mostBullishPair = PAIRS[0];
-  let mostBearishPair = PAIRS[0];
+  let mostBullishPair: string = PAIRS[0];
+  let mostBearishPair: string = PAIRS[0];
 
   for (const pair of PAIRS) {
     const v = data.pairs[pair] ?? { BUY: 0, SELL: 0, HOLD: 0 };

--- a/apps/web/tests/fixtures/auth.ts
+++ b/apps/web/tests/fixtures/auth.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright fixture `use` callback, not a React hook */
 import { test as base, expect } from '@playwright/test';
 
 /**

--- a/apps/web/tests/fixtures/auth.ts
+++ b/apps/web/tests/fixtures/auth.ts
@@ -1,11 +1,11 @@
 /* eslint-disable react-hooks/rules-of-hooks -- Playwright fixture `use` callback, not a React hook */
-import { test as base, expect } from '@playwright/test';
+import { test as base, expect, type Page } from '@playwright/test';
 
 /**
  * Extend base test with admin authentication fixture.
  * Uses the /api/auth/login endpoint to set the tc_admin cookie.
  */
-export const test = base.extend<{ adminPage: ReturnType<typeof base['page']> }>({
+export const test = base.extend<{ adminPage: Page }>({
   adminPage: async ({ page, context }, use) => {
     const secret = process.env.ADMIN_SECRET || 'test-secret';
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# TradeClaw Docker entrypoint
+# Handles --help flag and launches the Next.js standalone server.
+set -e
+
+print_help() {
+  cat <<'EOF'
+TradeClaw — self-hostable AI trading platform
+https://tradeclaw.win
+
+USAGE
+  docker run -p 3000:3000 ghcr.io/naimkatiman/tradeclaw[:tag]
+  docker run ghcr.io/naimkatiman/tradeclaw --help
+
+ENVIRONMENT VARIABLES
+  PORT                 Port to bind (default: 3000)
+  NODE_ENV             Node environment (default: production)
+  NEXT_PUBLIC_API_URL  Public base URL the frontend calls (optional)
+  DATABASE_URL         Postgres connection string (optional; SQLite by default)
+  REDIS_URL            Redis connection string (optional)
+  TELEGRAM_BOT_TOKEN   Token for the Telegram alert bot (optional)
+  SENTRY_DSN           Sentry DSN for error reporting (optional)
+
+QUICK START (Docker Compose)
+  git clone https://github.com/naimkatiman/tradeclaw.git
+  cd tradeclaw
+  docker compose up
+
+DOCS
+  https://tradeclaw.win/docs
+  https://github.com/naimkatiman/tradeclaw#readme
+
+EOF
+}
+
+# Support --help / -h before starting the server.
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h|help)
+      print_help
+      exit 0
+      ;;
+  esac
+done
+
+PORT="${PORT:-3000}"
+export PORT
+exec node apps/web/server.js "$@"

--- a/packages/signals/src/__tests__/indicators.test.ts
+++ b/packages/signals/src/__tests__/indicators.test.ts
@@ -9,6 +9,8 @@ import {
   calculateRSI,
   calculateMACD,
   calculateBollingerBands,
+  detectBollingerSqueeze,
+  DEFAULT_SQUEEZE_THRESHOLD,
   calculateStochastic,
   findSupportLevels,
   findResistanceLevels,
@@ -184,6 +186,57 @@ describe('calculateBollingerBands', () => {
     const narrow = calculateBollingerBands(prices, 20, 1);
     const wide = calculateBollingerBands(prices, 20, 3);
     expect(wide.upper - wide.lower).toBeGreaterThan(narrow.upper - narrow.lower);
+  });
+
+  it('reports bandwidth as a percentage of the middle band', () => {
+    // Tiny noise around 100 → very low bandwidth
+    const prices = Array.from({ length: 25 }, (_, i) =>
+      100 + (i % 2 === 0 ? 0.1 : -0.1)
+    );
+    const { bandwidth } = calculateBollingerBands(prices);
+    expect(bandwidth).toBeLessThan(1); // <1% of middle
+    expect(bandwidth).toBeGreaterThan(0);
+  });
+});
+
+// ─── Bollinger Band Squeeze ──────────────────────────────────────────────────
+
+describe('detectBollingerSqueeze', () => {
+  it('returns squeeze=false when not enough data', () => {
+    const result = detectBollingerSqueeze([100, 101, 99], 20);
+    expect(result.squeeze).toBe(false);
+    expect(result.bandwidth).toBe(0);
+    expect(result.threshold).toBe(DEFAULT_SQUEEZE_THRESHOLD);
+  });
+
+  it('detects a squeeze on a tight range series', () => {
+    // Prices oscillating in a ±0.1 band around 100 → bandwidth ≪ 4%
+    const prices = Array.from({ length: 25 }, (_, i) =>
+      100 + (i % 2 === 0 ? 0.1 : -0.1)
+    );
+    const result = detectBollingerSqueeze(prices);
+    expect(result.squeeze).toBe(true);
+    expect(result.bandwidth).toBeLessThan(DEFAULT_SQUEEZE_THRESHOLD);
+  });
+
+  it('does NOT report a squeeze on a wide-range series', () => {
+    // Prices oscillating ±10 around 100 → bandwidth well above 4%
+    const prices = Array.from({ length: 25 }, (_, i) =>
+      100 + (i % 2 === 0 ? 10 : -10)
+    );
+    const result = detectBollingerSqueeze(prices);
+    expect(result.squeeze).toBe(false);
+    expect(result.bandwidth).toBeGreaterThan(DEFAULT_SQUEEZE_THRESHOLD);
+  });
+
+  it('honors a custom threshold', () => {
+    const prices = Array.from({ length: 25 }, (_, i) =>
+      100 + (i % 2 === 0 ? 1 : -1)
+    );
+    const tight = detectBollingerSqueeze(prices, 20, 2, 10);
+    const loose = detectBollingerSqueeze(prices, 20, 2, 0.5);
+    expect(tight.squeeze).toBe(true);
+    expect(loose.squeeze).toBe(false);
   });
 });
 

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -27,7 +27,7 @@ export interface IndicatorSummary {
   rsi: { value: number; signal: 'oversold' | 'neutral' | 'overbought' };
   macd: { histogram: number; signal: 'bullish' | 'bearish' | 'neutral' };
   ema: { trend: 'up' | 'down' | 'sideways'; ema20: number; ema50: number; ema200: number };
-  bollingerBands: { position: 'upper' | 'middle' | 'lower'; bandwidth: number };
+  bollingerBands: { position: 'upper' | 'middle' | 'lower'; bandwidth: number; squeeze?: boolean };
   stochastic: { k: number; d: number; signal: 'oversold' | 'neutral' | 'overbought' };
   support: number[];
   resistance: number[];
@@ -168,6 +168,8 @@ export {
   calculateRSI,
   calculateMACD,
   calculateBollingerBands,
+  detectBollingerSqueeze,
+  DEFAULT_SQUEEZE_THRESHOLD,
   calculateStochastic,
   findSupportLevels,
   findResistanceLevels,

--- a/packages/signals/src/indicators.ts
+++ b/packages/signals/src/indicators.ts
@@ -143,6 +143,44 @@ export function calculateBollingerBands(
 }
 
 /**
+ * Default Bollinger Band squeeze threshold (as a percentage of the middle band).
+ * A squeeze is considered active when `bandwidth` falls below this value.
+ * 4% matches the issue spec (0.04 when expressed as a ratio).
+ */
+export const DEFAULT_SQUEEZE_THRESHOLD = 4;
+
+/**
+ * Detect a Bollinger Band squeeze (bands compressed below a bandwidth threshold).
+ *
+ * A "squeeze" marks a low-volatility regime that frequently precedes a directional
+ * breakout. We compute the standard Bollinger Bands on the trailing price window
+ * and compare the returned bandwidth (already scaled as a percentage of the middle
+ * band) to `thresholdPct`.
+ *
+ * @param prices       Closing prices (oldest → newest).
+ * @param period       SMA period for the bands (default 20).
+ * @param multiplier   Std-dev multiplier for the bands (default 2).
+ * @param thresholdPct Bandwidth threshold, expressed as a percentage. Default 4%.
+ * @returns `{ squeeze, bandwidth, threshold }`
+ */
+export function detectBollingerSqueeze(
+  prices: number[],
+  period: number = 20,
+  multiplier: number = 2,
+  thresholdPct: number = DEFAULT_SQUEEZE_THRESHOLD
+): { squeeze: boolean; bandwidth: number; threshold: number } {
+  if (prices.length < period) {
+    return { squeeze: false, bandwidth: 0, threshold: thresholdPct };
+  }
+  const { bandwidth } = calculateBollingerBands(prices, period, multiplier);
+  return {
+    squeeze: bandwidth > 0 && bandwidth < thresholdPct,
+    bandwidth,
+    threshold: thresholdPct,
+  };
+}
+
+/**
  * Calculate Stochastic Oscillator (%K and %D).
  * %K = (Close - Lowest Low) / (Highest High - Lowest Low) * 100
  * %D = SMA of %K values


### PR DESCRIPTION
## Summary
Three good-first-issue wins bundled in one branch. Each commit is self-contained and tied to an issue.

- **#10 Docker `--help` flag** — new `docker-entrypoint.sh` intercepts `--help`/`-h`/`help`, prints usage + env vars + Docker Compose quick start, exits 0. Dockerfile switches to `ENTRYPOINT` so args flow through.
- **#5 Ctrl+R / Cmd+R in-app refresh** — new `keydown` listener in `DashboardClient` calls `fetchSignals()` and `preventDefault()`s the browser reload. Skipped when focus is in an input/textarea/contentEditable so forms still behave normally.
- **#39 Bollinger Band squeeze detection** — new `detectBollingerSqueeze()` helper in `packages/signals/src/indicators.ts` with `DEFAULT_SQUEEZE_THRESHOLD = 4` (matches issue spec). Exported from `@tradeclaw/signals`. Scoring engine awards `BB_SQUEEZE_BREAKOUT` (+8) when a squeeze is active and price is pressing a band, so volatility-expansion setups get a confidence bump. `IndicatorSummary.bollingerBands.squeeze` flag exposed for UI use.

## Test plan
- [x] `npx jest packages/signals/src/__tests__/indicators.test.ts` — 43 passed (4 new squeeze tests)
- [x] `./docker-entrypoint.sh --help` — prints usage block, exits 0
- [ ] Build Docker image locally and confirm `docker run ... --help` works end-to-end
- [ ] Manual smoke: open `/dashboard`, press Ctrl+R, confirm signals refresh and tab does not reload
- [ ] Manual smoke: confirm squeeze reasons appear in signal explainer for low-bandwidth symbols

Closes #10
Closes #5
Closes #39