### PR TITLE
feat(track-record): per-strategy breakdown + Railway web auto-deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,45 @@
+name: Deploy Web (Railway)
+
+# Forces a redeploy of the `web` Railway service on every push to main.
+# Exists because Railway's GitHub auto-deploy integration was only firing on
+# the ws-server service — `web` was silently stuck on stale code, which meant
+# audit fixes that lived only in the Next.js app never reached tradeclaw.win.
+#
+# Requires the `RAILWAY_TOKEN` repo secret: create one in Railway dashboard
+# (Account → Tokens), then add it under GitHub → Settings → Secrets → Actions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'packages/**'
+      - 'scripts/**'
+      - 'Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-web-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Redeploy web service
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install Railway CLI
+        run: curl -fsSL https://railway.com/install.sh | sh
+
+      - name: Trigger redeploy
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret not set — add it under Settings → Secrets → Actions."
+            exit 1
+          fi
+          railway redeploy --service web --yes

--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { readHistoryAsync } from '../../../lib/signal-history';
+import { readHistoryAsync, computeLeaderboard } from '../../../lib/signal-history';
 import { getLeaderboard } from '../../../lib/leaderboard-cache';
+
+const VALID_STRATEGIES = new Set([
+  'classic', 'regime-aware', 'hmm-top3', 'vwap-ema-bb', 'full-risk',
+]);
 
 export async function GET(request: NextRequest) {
   try {
@@ -17,9 +21,16 @@ export async function GET(request: NextRequest) {
       : 'hitRate';
 
     const pairFilter = searchParams.get('pair')?.toUpperCase();
+    const rawStrategy = searchParams.get('strategyId');
+    const strategyFilter = rawStrategy && VALID_STRATEGIES.has(rawStrategy)
+      ? rawStrategy
+      : undefined;
 
-    // Serve from precomputed cache (resolves outcomes + computes on miss)
-    const data = await getLeaderboard(period, sortBy);
+    // Strategy-filtered variant recomputes from history; the unfiltered path
+    // still uses the precomputed cache.
+    const data = strategyFilter
+      ? computeLeaderboard(await readHistoryAsync(), period, sortBy, strategyFilter)
+      : await getLeaderboard(period, sortBy);
 
     if (pairFilter) {
       const asset = data.assets.find(a => a.pair === pairFilter);

--- a/apps/web/app/api/strategy-breakdown/route.ts
+++ b/apps/web/app/api/strategy-breakdown/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getStrategyBreakdown } from '../../../lib/leaderboard-cache';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const rawPeriod = searchParams.get('period') ?? 'all';
+    const period: '7d' | '30d' | 'all' =
+      rawPeriod === '7d' ? '7d' : rawPeriod === '30d' ? '30d' : 'all';
+
+    const rows = await getStrategyBreakdown(period);
+
+    return NextResponse.json(
+      { period, rows, generatedAt: new Date().toISOString() },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
+          'Access-Control-Allow-Origin': '*',
+        },
+      },
+    );
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -60,6 +60,25 @@ interface LeaderboardData {
   };
 }
 
+interface StrategyBreakdownRow {
+  strategyId: string;
+  totalSignals: number;
+  resolvedSignals: number;
+  hitRate4h: number;
+  hitRate24h: number;
+  avgConfidence: number;
+  avgPnl: number;
+}
+
+const STRATEGY_LABELS: Record<string, string> = {
+  'hmm-top3': 'HMM Top-3',
+  'classic': 'Classic',
+  'regime-aware': 'Regime Aware',
+  'vwap-ema-bb': 'VWAP + EMA + BB',
+  'full-risk': 'Full Risk Pipeline',
+  'unknown': 'Unknown',
+};
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 function formatPrice(price: number): string {
@@ -111,14 +130,16 @@ export function TrackRecordClient() {
   const [stats, setStats] = useState<HistoryStats | null>(null);
   const [records, setRecords] = useState<HistoryRecord[]>([]);
   const [leaderboard, setLeaderboard] = useState<LeaderboardData | null>(null);
+  const [strategyBreakdown, setStrategyBreakdown] = useState<StrategyBreakdownRow[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async (p: Period) => {
     setLoading(true);
     try {
-      const [historyRes, leaderboardRes] = await Promise.allSettled([
+      const [historyRes, leaderboardRes, breakdownRes] = await Promise.allSettled([
         fetch('/api/signals/history?limit=50&sort=resolved-first'),
         fetch(`/api/leaderboard?period=${p}`),
+        fetch(`/api/strategy-breakdown?period=${p}`),
       ]);
 
       if (historyRes.status === 'fulfilled' && historyRes.value.ok) {
@@ -130,6 +151,11 @@ export function TrackRecordClient() {
       if (leaderboardRes.status === 'fulfilled' && leaderboardRes.value.ok) {
         const data = await leaderboardRes.value.json();
         setLeaderboard(data);
+      }
+
+      if (breakdownRes.status === 'fulfilled' && breakdownRes.value.ok) {
+        const data = await breakdownRes.value.json();
+        setStrategyBreakdown(Array.isArray(data.rows) ? data.rows : []);
       }
     } catch {
       // silently fail
@@ -222,6 +248,47 @@ export function TrackRecordClient() {
             <EquityCurve />
           </div>
         </section>
+
+        {/* Per-Strategy Breakdown */}
+        {strategyBreakdown.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xs uppercase tracking-wider text-[var(--text-secondary)] font-mono font-semibold mb-3">
+              Per-Strategy Performance
+            </h2>
+            <div className="glass-card rounded-2xl overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs font-mono">
+                  <thead>
+                    <tr className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)] border-b border-white/[0.06]">
+                      <th className="text-left px-4 py-3 font-semibold">Strategy</th>
+                      <th className="text-right px-4 py-3 font-semibold">Signals</th>
+                      <th className="text-right px-4 py-3 font-semibold">Resolved</th>
+                      <th className="text-left px-4 py-3 font-semibold w-40">Hit Rate 24h</th>
+                      <th className="text-right px-4 py-3 font-semibold">Avg Conf</th>
+                      <th className="text-right px-4 py-3 font-semibold">Avg P&amp;L</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {strategyBreakdown.map(row => (
+                      <tr key={row.strategyId} className="border-b border-white/[0.04] last:border-0 hover:bg-white/[0.02]">
+                        <td className="px-4 py-3 text-[var(--foreground)]">
+                          {STRATEGY_LABELS[row.strategyId] ?? row.strategyId}
+                        </td>
+                        <td className="text-right tabular-nums px-4 py-3">{row.totalSignals}</td>
+                        <td className="text-right tabular-nums px-4 py-3 text-[var(--text-secondary)]">{row.resolvedSignals}</td>
+                        <td className="px-4 py-3"><HitRateBar value={row.hitRate24h} /></td>
+                        <td className="text-right tabular-nums px-4 py-3 text-[var(--text-secondary)]">{row.avgConfidence}%</td>
+                        <td className={`text-right tabular-nums px-4 py-3 ${row.avgPnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                          {row.avgPnl >= 0 ? '+' : ''}{row.avgPnl.toFixed(2)}%
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Per-Symbol Breakdown */}
         <section className="mb-8">

--- a/apps/web/lib/leaderboard-cache.ts
+++ b/apps/web/lib/leaderboard-cache.ts
@@ -11,8 +11,10 @@
 import {
   readHistoryAsync,
   computeLeaderboard,
+  computeStrategyBreakdown,
   resolveRealOutcomes,
   type LeaderboardData,
+  type StrategyBreakdownRow,
 } from './signal-history';
 
 interface CachedSnapshot {
@@ -20,8 +22,14 @@ interface CachedSnapshot {
   expiresAt: number;
 }
 
+interface CachedBreakdown {
+  data: StrategyBreakdownRow[];
+  expiresAt: number;
+}
+
 const TTL_MS = 2 * 60 * 1000; // 2 minutes
 const cache = new Map<string, CachedSnapshot>();
+const breakdownCache = new Map<string, CachedBreakdown>();
 
 let refreshInFlight = false;
 
@@ -89,4 +97,17 @@ async function refreshAndGet(
 /** Invalidate all cached snapshots — call when new outcomes are recorded. */
 export function invalidateLeaderboardCache(): void {
   cache.clear();
+  breakdownCache.clear();
+}
+
+export async function getStrategyBreakdown(
+  period: '7d' | '30d' | 'all',
+): Promise<StrategyBreakdownRow[]> {
+  const cached = breakdownCache.get(period);
+  if (cached && Date.now() < cached.expiresAt) return cached.data;
+
+  const history = await readHistoryAsync();
+  const data = computeStrategyBreakdown(history, period);
+  breakdownCache.set(period, { data, expiresAt: Date.now() + TTL_MS });
+  return data;
 }

--- a/apps/web/lib/signal-history.ts
+++ b/apps/web/lib/signal-history.ts
@@ -76,6 +76,16 @@ export interface LeaderboardData {
   };
 }
 
+export interface StrategyBreakdownRow {
+  strategyId: string;
+  totalSignals: number;
+  resolvedSignals: number;
+  hitRate4h: number;
+  hitRate24h: number;
+  avgConfidence: number;
+  avgPnl: number;
+}
+
 // ── Helpers ──────────────────────────────────────────────────
 
 const isDbEnabled = () => !!process.env.DATABASE_URL;
@@ -607,13 +617,18 @@ export function computeLeaderboard(
   records: SignalHistoryRecord[],
   period: '7d' | '30d' | 'all',
   sortBy: 'hitRate' | 'totalSignals' | 'avgConfidence' = 'hitRate',
+  strategyId?: string,
 ): LeaderboardData {
   const cutoff =
     period === '7d' ? Date.now() - 7 * 86400000
     : period === '30d' ? Date.now() - 30 * 86400000
     : 0;
 
-  const filtered = records.filter(r => r.timestamp >= cutoff && !r.isSimulated);
+  const filtered = records.filter(
+    r => r.timestamp >= cutoff
+      && !r.isSimulated
+      && (strategyId ? r.strategyId === strategyId : true),
+  );
 
   const map = new Map<string, {
     total: number; hits4h: number; resolved4h: number;
@@ -698,3 +713,58 @@ export function computeLeaderboard(
     },
   };
 }
+
+export function computeStrategyBreakdown(
+  records: SignalHistoryRecord[],
+  period: '7d' | '30d' | 'all',
+): StrategyBreakdownRow[] {
+  const cutoff =
+    period === '7d' ? Date.now() - 7 * 86400000
+    : period === '30d' ? Date.now() - 30 * 86400000
+    : 0;
+
+  const filtered = records.filter(r => r.timestamp >= cutoff && !r.isSimulated);
+  const groups = new Map<string, {
+    total: number;
+    resolved4h: number; hits4h: number;
+    resolved24h: number; hits24h: number;
+    confSum: number;
+    pnlSum: number; pnlCount: number;
+  }>();
+
+  for (const r of filtered) {
+    const key = r.strategyId ?? 'unknown';
+    if (!groups.has(key)) {
+      groups.set(key, {
+        total: 0, resolved4h: 0, hits4h: 0, resolved24h: 0, hits24h: 0,
+        confSum: 0, pnlSum: 0, pnlCount: 0,
+      });
+    }
+    const g = groups.get(key)!;
+    g.total++;
+    g.confSum += r.confidence;
+    if (r.outcomes['4h'] !== null) {
+      g.resolved4h++;
+      if (r.outcomes['4h'].hit) g.hits4h++;
+    }
+    if (r.outcomes['24h'] !== null) {
+      g.resolved24h++;
+      if (r.outcomes['24h'].hit) g.hits24h++;
+      g.pnlSum += r.outcomes['24h'].pnlPct;
+      g.pnlCount++;
+    }
+  }
+
+  return Array.from(groups.entries())
+    .map(([strategyId, g]): StrategyBreakdownRow => ({
+      strategyId,
+      totalSignals: g.total,
+      resolvedSignals: g.resolved24h,
+      hitRate4h: g.resolved4h > 0 ? +((g.hits4h / g.resolved4h) * 100).toFixed(1) : 0,
+      hitRate24h: g.resolved24h > 0 ? +((g.hits24h / g.resolved24h) * 100).toFixed(1) : 0,
+      avgConfidence: g.total > 0 ? Math.round(g.confSum / g.total) : 0,
+      avgPnl: g.pnlCount > 0 ? +(g.pnlSum / g.pnlCount).toFixed(2) : 0,
+    }))
+    .sort((a, b) => b.totalSignals - a.totalSignals);
+}
+


### PR DESCRIPTION
## Summary

Two independent but related changes, both driven by the strategy-comparison audit
follow-up:

### 1. Per-strategy performance UI on /track-record

The audit added a `strategy_id` column to `signal_history` and backfilled 1440
historical rows to `hmm-top3`, but no page ever rendered those outcomes grouped
by strategy — so users couldn't actually *see* different presets compared, which
was the whole point of the audit.

- `computeStrategyBreakdown` in `signal-history.ts` aggregates per
  `strategy_id` (NULL → `unknown`).
- New `/api/strategy-breakdown?period=7d|30d|all` endpoint, 2 min TTL cache.
- `/api/leaderboard` grows an optional `?strategyId=` filter, whitelisted
  against the known preset set.
- `TrackRecordClient.tsx` fetches and renders a **Per-Strategy Performance**
  table above the existing per-symbol breakdown. Hidden when empty so it
  doesn't appear until real data lands.

### 2. Railway web auto-deploy workflow

Root cause of the audit fix going un-deployed: Railway's GitHub integration was
only firing for the `ws-server` service. The `web` service (tradeclaw.win) was
silently stuck on stale code for ~10 hours, which is why every new cron run kept
writing `strategy_id=NULL` despite the fix being in main.

- New `.github/workflows/deploy-web.yml` installs Railway CLI and runs
  `railway redeploy --service web` on every main push that touches
  `apps/web/**`, `packages/**`, `scripts/**`, `Dockerfile`, or package
  manifests. Path filter avoids redeploys on doc-only changes.
- Requires `RAILWAY_TOKEN` repo secret (Railway → Account → Tokens,
  then GitHub → Settings → Secrets → Actions).
- Has a `workflow_dispatch` trigger so you can also fire it manually
  from the Actions tab.

## Deployment notes

1. **Add `RAILWAY_TOKEN` secret before merging** — otherwise the workflow
   errors out with a clear message but still completes cleanly.
2. First post-merge push to main will auto-redeploy the web service and the
   per-strategy card will light up with the backfilled data.

## Test plan

- [x] `apps/web` typecheck: clean
- [x] `@tradeclaw/strategies` unit tests: 28/28 pass
- [x] `npm run build`: green
- [x] Manual: historical backfill applied (1440 rows → `hmm-top3`)
- [ ] Verify `/api/strategy-breakdown?period=all` returns hmm-top3 row
      once web service redeploys
- [ ] Manual: /track-record displays the Per-Strategy Performance section
      with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)