### PR TITLE
fix(security): close 29 findings from 2026-05-06 review (7 CRIT / 9 HIGH / 9 MED / 4 LOW)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -84,6 +84,13 @@ RESEND_FROM_EMAIL=TradeClaw <signals@tradeclaw.win>
 TELEGRAM_BOT_TOKEN=...
 NEXT_PUBLIC_TELEGRAM_BOT_USERNAME=tradeclawbot
 
+# Required for inbound /api/telegram webhook auth. Pass the same value to
+# Telegram via setWebhook { secret_token: "..." }; Telegram echoes it back
+# as the X-Telegram-Bot-Api-Secret-Token request header. The route compares
+# constant-time and rejects unauthenticated POSTs (401).
+# Generate with: openssl rand -hex 32
+TELEGRAM_WEBHOOK_SECRET=
+
 # Channel / group IDs (use negative numbers for groups, e.g. -1001234567890)
 TELEGRAM_FREE_CHANNEL_ID=-100...
 

--- a/apps/web/app/api/alert-channels/route.ts
+++ b/apps/web/app/api/alert-channels/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/alert-rules-db';
 import { getUserById } from '@/lib/db';
 import { readSessionFromRequest } from '@/lib/user-session';
+import { isSafeOutboundUrl } from '@/lib/safe-outbound-url';
 
 /**
  * Per-user "preferred platform" channel configuration.
@@ -50,6 +51,18 @@ export async function POST(req: NextRequest) {
   const parsed = UpsertSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  // SSRF gate at write time: Discord and generic webhook configs supply a
+  // server-fetched URL. Reject anything that targets internal/private
+  // addresses or non-HTTPS schemes BEFORE persisting.
+  const cfg = parsed.data.config;
+  const urlField = parsed.data.channel === 'discord' ? cfg.webhookUrl : parsed.data.channel === 'webhook' ? cfg.url : null;
+  if (urlField && !isSafeOutboundUrl(urlField)) {
+    return NextResponse.json(
+      { error: 'unsafe_outbound_url' },
+      { status: 400 },
+    );
   }
 
   const config = await upsertChannelConfig(

--- a/apps/web/app/api/alert-rules/dispatch/route.ts
+++ b/apps/web/app/api/alert-rules/dispatch/route.ts
@@ -2,14 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAllEnabledRules, getChannelConfigsForUser, signalMatchesRule } from '@/lib/alert-rules-db';
 import { sendToChannel, type ChannelName, type AlertSignal } from '@/lib/alert-channels';
 import { recordBroadcastResult } from '@/lib/observability';
-
-const CRON_SECRET = process.env.CRON_SECRET;
+import { requireCronAuth } from '@/lib/cron-auth';
 
 export async function POST(req: NextRequest) {
-  const auth = req.headers.get('authorization');
-  if (CRON_SECRET && auth !== `Bearer ${CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(req);
+  if (denied) return denied;
 
   const body = await req.json();
   const { signal } = body as { signal: AlertSignal & { [key: string]: unknown } };

--- a/apps/web/app/api/auth/google/callback/route.ts
+++ b/apps/web/app/api/auth/google/callback/route.ts
@@ -8,6 +8,7 @@ import {
 import {
   OAUTH_STATE_COOKIE,
   decodeState,
+  safeNext,
 } from '../../../../../lib/oauth-state';
 
 export const dynamic = 'force-dynamic';
@@ -108,15 +109,21 @@ export async function GET(request: NextRequest) {
   const hasCheckoutPayload =
     !!state.priceId || (state.tier === 'pro' && (state.interval === 'monthly' || state.interval === 'annual'));
 
+  // Re-apply safeNext on every read of state.next. The /start route
+  // sanitized at write time, but a leaked or attacker-crafted state blob
+  // could carry a `//evil.com/` value that would otherwise resolve to a
+  // different origin via scheme-relative URL parsing.
+  const safeStateNext = safeNext(state.next);
+
   let target: URL;
   if (hasCheckoutPayload) {
     target = new URL('/signin', appOrigin(request));
     if (state.priceId) target.searchParams.set('priceId', state.priceId);
     if (state.tier) target.searchParams.set('tier', state.tier);
     if (state.interval) target.searchParams.set('interval', state.interval);
-    if (state.next) target.searchParams.set('next', state.next);
-  } else if (state.next) {
-    target = new URL(state.next, appOrigin(request));
+    if (safeStateNext) target.searchParams.set('next', safeStateNext);
+  } else if (safeStateNext) {
+    target = new URL(safeStateNext, appOrigin(request));
   } else {
     target = new URL('/dashboard', appOrigin(request));
   }

--- a/apps/web/app/api/auth/google/start/route.ts
+++ b/apps/web/app/api/auth/google/start/route.ts
@@ -3,18 +3,13 @@ import {
   OAUTH_STATE_COOKIE,
   encodeState,
   newNonce,
+  safeNext,
   stateCookieOptions,
 } from '../../../../../lib/oauth-state';
 
 export const dynamic = 'force-dynamic';
 
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
-
-function safeNext(value: string | null): string | undefined {
-  if (!value) return undefined;
-  if (!value.startsWith('/') || value.startsWith('//')) return undefined;
-  return value;
-}
 
 function getRedirectUri(request: NextRequest): string {
   const base =

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { timingSafeEqual } from 'node:crypto';
+import { secureCookieDefault } from '../../../../lib/cookie-flags';
 
 const COOKIE_NAME = 'tc_admin';
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
@@ -31,7 +32,7 @@ export async function POST(request: NextRequest) {
     const response = NextResponse.json({ ok: true });
     response.cookies.set(COOKIE_NAME, adminSecret, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: secureCookieDefault(),
       // Strict — the admin cookie value IS the secret. Lax let cross-site
       // GET navigations carry it; with Strict the cookie only attaches to
       // same-site requests, which suits a top-level admin UI.

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,7 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
 
 const COOKIE_NAME = 'tc_admin';
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+function safeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,7 +24,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { secret } = body as { secret?: string };
 
-    if (!secret || secret !== adminSecret) {
+    if (!secret || !safeStringEqual(secret, adminSecret)) {
       return NextResponse.json({ error: 'Invalid secret' }, { status: 401 });
     }
 
@@ -24,7 +32,10 @@ export async function POST(request: NextRequest) {
     response.cookies.set(COOKIE_NAME, adminSecret, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
+      // Strict — the admin cookie value IS the secret. Lax let cross-site
+      // GET navigations carry it; with Strict the cookie only attaches to
+      // same-site requests, which suits a top-level admin UI.
+      sameSite: 'strict',
       path: '/',
       maxAge: MAX_AGE,
     });

--- a/apps/web/app/api/auth/magic-link/start/route.ts
+++ b/apps/web/app/api/auth/magic-link/start/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { issueMagicLink } from '../../../../../lib/magic-link';
+import { countRecentMagicLinkEmails, issueMagicLink } from '../../../../../lib/magic-link';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const recentByEmail = new Map<string, number>();
+const RATE_LIMIT_WINDOW_SECONDS = 60;
 
 export async function POST(req: NextRequest) {
   const { email } = (await req.json().catch(() => ({}))) as { email?: string };
@@ -13,19 +12,23 @@ export async function POST(req: NextRequest) {
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
     return NextResponse.json({ error: 'Invalid email' }, { status: 400 });
   }
-  const last = recentByEmail.get(normalized) ?? 0;
-  if (Date.now() - last < RATE_LIMIT_WINDOW_MS) {
+
+  // DB-backed rate limit: in-process Map was useless on serverless cold
+  // starts and let an attacker enumerate emails / pollute the token table.
+  // Check BEFORE issuing — never write to the DB on a rate-limited request.
+  // Silent 200 so we don't double as an account-existence oracle.
+  const recent = await countRecentMagicLinkEmails(normalized, RATE_LIMIT_WINDOW_SECONDS);
+  if (recent > 0) {
     return NextResponse.json({ ok: true }, { status: 200 });
   }
 
   const apiKey = process.env.RESEND_API_KEY;
   const from = process.env.RESEND_FROM_EMAIL;
   if (!apiKey || !from) {
-    const { raw } = await issueMagicLink(normalized);
-    if (process.env.NODE_ENV !== 'production') {
-      console.info('[magic-link dev] no Resend env — link:', `/api/auth/magic-link/verify?token=${raw}`);
-    }
-    recentByEmail.set(normalized, Date.now());
+    // No email transport configured → still issue a token (so /verify works
+    // for an operator pulling it out of the DB) but DO NOT log it. Tokens
+    // in dev logs end up in shared CI buffers and ship to log aggregators.
+    await issueMagicLink(normalized);
     return NextResponse.json({ ok: true });
   }
 
@@ -53,6 +56,5 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'email_send_failed' }, { status: 502 });
   }
 
-  recentByEmail.set(normalized, Date.now());
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/app/api/cron/execute/route.ts
+++ b/apps/web/app/api/cron/execute/route.ts
@@ -1,19 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runExecutorTick } from '../../../../lib/execution/executor';
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 50;
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return process.env.NODE_ENV !== 'production';
-  return request.headers.get('authorization') === `Bearer ${secret}`;
-}
-
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
   const t0 = Date.now();
   try {
     const r = await runExecutorTick();

--- a/apps/web/app/api/cron/manage-positions/route.ts
+++ b/apps/web/app/api/cron/manage-positions/route.ts
@@ -1,19 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runPositionManagerTick } from '../../../../lib/execution/position-manager';
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 50;
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return process.env.NODE_ENV !== 'production';
-  return request.headers.get('authorization') === `Bearer ${secret}`;
-}
-
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
   const t0 = Date.now();
   try {
     const r = await runPositionManagerTick();

--- a/apps/web/app/api/cron/position-monitor/route.ts
+++ b/apps/web/app/api/cron/position-monitor/route.ts
@@ -16,15 +16,7 @@ import {
   getProGroupId,
   getProSignalsTopicId,
 } from '../../../../lib/telegram-channels';
-
-// ── Auth guard ────────────────────────────────────────────────
-
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return true;
-  const header = request.headers.get('authorization');
-  return header === `Bearer ${secret}`;
-}
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 // ── Price fetching ───────────────────────────────────────────
 
@@ -137,9 +129,8 @@ function shouldClose(
 // ── Route handler ────────────────────────────────────────────
 
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   try {
     const positions = await getAllOpenPositionsForSweep();

--- a/apps/web/app/api/cron/signals/route.ts
+++ b/apps/web/app/api/cron/signals/route.ts
@@ -18,21 +18,11 @@ import { isWinningCell, getWinningCellsMode } from '../../../../lib/winning-cell
 import { runRiskPipeline } from '../../../../lib/risk-pipeline';
 import { fetchRegimeMap } from '../../../../lib/regime-filter';
 import { recordSignalRun } from '../../../../lib/signal-run-log';
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
 const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
-
-// ── Auth guard ────────────────────────────────────────────────
-
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) {
-    return process.env.NODE_ENV !== 'production';
-  }
-  const header = request.headers.get('authorization');
-  return header === `Bearer ${secret}`;
-}
 
 // ── Record logic ──────────────────────────────────────────────
 
@@ -210,9 +200,8 @@ async function handleTelegramCallback(request: NextRequest): Promise<Response> {
 // ── Route handler ─────────────────────────────────────────────
 
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   const runStartedAt = new Date();
   try {
@@ -314,9 +303,8 @@ export async function GET(request: NextRequest): Promise<Response> {
 }
 
 export async function POST(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   // If body has signalId + messageId, it's a telegram posted callback
   const contentType = request.headers.get('content-type') ?? '';

--- a/apps/web/app/api/cron/sync/route.ts
+++ b/apps/web/app/api/cron/sync/route.ts
@@ -1,13 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-// ── Auth guard ────────────────────────────────────────────────
-
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return true;
-  const header = request.headers.get('authorization');
-  return header === `Bearer ${secret}`;
-}
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 // ── Schedule helpers ──────────────────────────────────────────
 
@@ -52,9 +44,8 @@ async function callInternal(
 // ── Route handler ─────────────────────────────────────────────
 
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   const results: Record<string, unknown> = {};
   const hour = currentHourUTC();

--- a/apps/web/app/api/cron/telegram/route.ts
+++ b/apps/web/app/api/cron/telegram/route.ts
@@ -3,20 +3,15 @@ import { broadcastTopSignals } from '../../../../lib/telegram-broadcast';
 import { query, execute } from '../../../../lib/db-pool';
 import { FREE_SYMBOLS } from '../../../../lib/tier';
 import { getBotToken, getFreeChannelId } from '../../../../lib/telegram-channels';
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 // ---------------------------------------------------------------------------
 // GET /api/cron/telegram — Vercel Cron handler (every 4 hours)
 // ---------------------------------------------------------------------------
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  // Auth guard — Vercel cron sends CRON_SECRET as bearer token
-  const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const header = request.headers.get('authorization');
-    if (header !== `Bearer ${secret}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   try {
     // Resolved through lib/telegram-channels so the legacy var names

--- a/apps/web/app/api/cron/trial-reminders/route.ts
+++ b/apps/web/app/api/cron/trial-reminders/route.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../lib/db';
 import { sendTrialEndingEmail } from '../../../../lib/transactional-email';
 import { getStripe } from '../../../../lib/stripe';
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,12 +18,6 @@ export const dynamic = 'force-dynamic';
 // trial_reminder_sent_at IS NULL, it stays idempotent.
 const REMIND_FROM_HOURS = 12;
 const REMIND_TO_HOURS = 30;
-
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return true;
-  return request.headers.get('authorization') === `Bearer ${secret}`;
-}
 
 interface ReminderSummary {
   checked: number;
@@ -119,9 +114,8 @@ async function runReminderSweep(): Promise<ReminderSummary> {
 }
 
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
   try {
     const summary = await runReminderSweep();
     return NextResponse.json({ ...summary, timestamp: new Date().toISOString() });

--- a/apps/web/app/api/cron/universe/route.ts
+++ b/apps/web/app/api/cron/universe/route.ts
@@ -1,19 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runUniverseScreen } from '../../../../lib/execution/universe-runner';
+import { requireCronAuth } from '../../../../lib/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return process.env.NODE_ENV !== 'production';
-  return request.headers.get('authorization') === `Bearer ${secret}`;
-}
-
 export async function GET(request: NextRequest): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   const t0 = Date.now();
   try {

--- a/apps/web/app/api/earningsedge/webhook/route.ts
+++ b/apps/web/app/api/earningsedge/webhook/route.ts
@@ -1,39 +1,65 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { handleWebhookEvent } from '@/lib/earningsedge/stripe';
+import { verifyEEWebhookSignature, parseEEEvent } from '@/lib/earningsedge/stripe';
 import { upsertUser, getUserByStripeCustomer, updateUserTier } from '@/lib/earningsedge/db';
+import { tryClaimStripeEvent } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
+  const payload = await request.text();
+  const signature = request.headers.get('stripe-signature');
+
+  if (!signature) {
+    return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+  }
+
+  // Step 1: signature verification. Throws on bad signature OR when the
+  // EE-specific webhook secret is unset (no fallback to the main secret —
+  // that would let main-product events replay against EE).
+  let event;
   try {
-    const payload = await request.text();
-    const signature = request.headers.get('stripe-signature');
-
-    if (!signature) {
-      return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+    event = verifyEEWebhookSignature(payload, signature);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'verify_failed';
+    if (message.includes('not configured')) {
+      return NextResponse.json({ error: 'ee_webhook_not_configured' }, { status: 503 });
     }
+    return NextResponse.json({ error: 'invalid_signature' }, { status: 400 });
+  }
 
-    const event = await handleWebhookEvent(payload, signature);
+  // Step 2: idempotency. Stripe replays events on retry; without this gate
+  // upsertUser/updateUserTier would re-fire on every redelivery. Namespace
+  // the event id with `ee:` so the shared processed_stripe_events table
+  // doesn't collide with TradeClaw-main event IDs across separate Stripe
+  // accounts.
+  const claimed = await tryClaimStripeEvent(`ee:${event.id}`, event.type);
+  if (!claimed) {
+    return NextResponse.json({ received: true, duplicate: true });
+  }
 
-    if (event.type === 'checkout.session.completed' && event.email) {
-      // Upsert user with new tier
+  // Step 3: parse + side effects. Errors here surface as 500 so Stripe
+  // retries; the idempotency table will let the retry through.
+  try {
+    const parsed = await parseEEEvent(event);
+
+    if (parsed.type === 'checkout.session.completed' && parsed.email) {
       try {
         await upsertUser({
-          email: event.email,
-          tier: (event.tier as 'basic' | 'pro') || 'basic',
-          stripe_customer_id: event.customerId,
-          stripe_subscription_id: event.subscriptionId,
+          email: parsed.email,
+          tier: (parsed.tier as 'basic' | 'pro') || 'basic',
+          stripe_customer_id: parsed.customerId,
+          stripe_subscription_id: parsed.subscriptionId,
         });
       } catch {
-        // DB might not be configured — log and continue
         console.error('[earningsedge] Failed to upsert user after checkout');
       }
     }
 
-    if (event.type === 'customer.subscription.deleted' && event.customerId) {
+    if (parsed.type === 'customer.subscription.deleted' && parsed.customerId) {
       try {
-        // Look up user by Stripe customer ID, then downgrade to free
-        const existing = await getUserByStripeCustomer(event.customerId);
+        const existing = await getUserByStripeCustomer(parsed.customerId);
         if (existing) {
-          await updateUserTier(existing.email, 'free', event.customerId);
+          await updateUserTier(existing.email, 'free', parsed.customerId);
         }
       } catch {
         console.error('[earningsedge] Failed to downgrade user after subscription deletion');
@@ -42,7 +68,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ received: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Webhook failed';
-    return NextResponse.json({ error: message }, { status: 400 });
+    console.error('[earningsedge] handler error:', err);
+    return NextResponse.json({ error: 'handler_error' }, { status: 500 });
   }
 }

--- a/apps/web/app/api/telegram/broadcast/route.ts
+++ b/apps/web/app/api/telegram/broadcast/route.ts
@@ -4,6 +4,19 @@ import {
   readBroadcastState,
 } from '../../../../lib/telegram-broadcast';
 import { getBotToken, getFreeChannelId } from '../../../../lib/telegram-channels';
+import { requireCronAuth } from '../../../../lib/cron-auth';
+import { assertAdminApi } from '../../../../lib/admin-gate';
+
+// Accept either an admin browser session or a Vercel-cron Bearer token.
+// Pre-fix this route was wide open and any internet caller could trigger
+// a broadcast or read the channel-id prefix from GET.
+async function authorize(request: NextRequest): Promise<NextResponse | null> {
+  const adminDenied = await assertAdminApi(request);
+  if (!adminDenied) return null;
+  const cronDenied = requireCronAuth(request);
+  if (!cronDenied) return null;
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}
 
 // ---------------------------------------------------------------------------
 // POST /api/telegram/broadcast — trigger a channel broadcast
@@ -11,6 +24,9 @@ import { getBotToken, getFreeChannelId } from '../../../../lib/telegram-channels
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = await authorize(request);
+  if (denied) return denied;
+
   let body: { channelId?: string; botToken?: string } = {};
   try {
     body = (await request.json()) as typeof body;
@@ -48,7 +64,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 // GET /api/telegram/broadcast — broadcast status
 // ---------------------------------------------------------------------------
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = await authorize(request);
+  if (denied) return denied;
+
   try {
     const state = readBroadcastState();
     const channelId = getFreeChannelId();

--- a/apps/web/app/api/telegram/link-token/__tests__/route.test.ts
+++ b/apps/web/app/api/telegram/link-token/__tests__/route.test.ts
@@ -30,24 +30,28 @@ describe('POST /api/telegram/link-token', () => {
     expect(res.status).toBe(401);
   });
 
-  it('issues a verifiable token tied to the session userId', async () => {
+  it('issues a verifiable deep link tied to the session userId', async () => {
     mockedRead.mockReturnValueOnce({ userId: 'user-abc', issuedAt: Date.now() });
 
     const res = await POST(new NextRequest('http://localhost/api/telegram/link-token', { method: 'POST' }));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(typeof body.token).toBe('string');
     expect(body.deepLink).toMatch(/^https:\/\/t\.me\/[^/]+\?start=/);
     expect(body.expiresInSeconds).toBeGreaterThan(0);
+    // Token is no longer surfaced in the body — it lives only in the deep
+    // link query string. This prevents the response body from becoming a
+    // one-time credential that gets cached in dev tools / network logs.
+    expect(body.token).toBeUndefined();
 
-    const verified = verifyTelegramLinkToken(body.token);
+    // Extract the token from the deep link to verify it still binds to the
+    // session userId (the bot route is what consumes it).
+    const tokenInLink = decodeURIComponent(new URL(body.deepLink).searchParams.get('start') ?? '');
+    const verified = verifyTelegramLinkToken(tokenInLink);
     expect(verified?.userId).toBe('user-abc');
   });
 
   it('does not accept a body-supplied userId', async () => {
-    // Even if a malicious caller supplies userId in the request body, the
-    // route must rely solely on the signed session cookie.
     mockedRead.mockReturnValueOnce({ userId: 'real-user', issuedAt: Date.now() });
 
     const res = await POST(
@@ -58,7 +62,8 @@ describe('POST /api/telegram/link-token', () => {
     );
     const body = await res.json();
 
-    const verified = verifyTelegramLinkToken(body.token);
+    const tokenInLink = decodeURIComponent(new URL(body.deepLink).searchParams.get('start') ?? '');
+    const verified = verifyTelegramLinkToken(tokenInLink);
     expect(verified?.userId).toBe('real-user');
   });
 });

--- a/apps/web/app/api/telegram/link-token/route.ts
+++ b/apps/web/app/api/telegram/link-token/route.ts
@@ -22,8 +22,12 @@ export async function POST(request: NextRequest) {
   const token = createTelegramLinkToken(session.userId);
   const deepLink = `https://t.me/${BOT_USERNAME}?start=${encodeURIComponent(token)}`;
 
+  // Only return the deep link. Returning the raw token alongside it was
+  // redundant and turned the response body into a one-time credential —
+  // every fetch to this endpoint, every browser dev-tools open, every
+  // network log captured the bearer-equivalent. The link itself is the
+  // only thing the UI needs to render or copy to clipboard.
   return NextResponse.json({
-    token,
     deepLink,
     expiresInSeconds: TELEGRAM_LINK_TOKEN_TTL_SECONDS,
   });

--- a/apps/web/app/api/telegram/route.ts
+++ b/apps/web/app/api/telegram/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { linkTelegramUser, getUserById } from '../../../lib/db';
 import { sendInvite } from '../../../lib/telegram';
 import { verifyTelegramLinkToken } from '../../../lib/telegram-link-token';
+import { verifyTelegramWebhook } from '../../../lib/telegram-webhook-auth';
 
 interface TelegramConfig {
   botToken: string;
@@ -172,8 +173,13 @@ export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as Record<string, unknown>;
 
-    // Mode 1: Telegram bot webhook update
+    // Mode 1: Telegram bot webhook update — must carry the
+    // X-Telegram-Bot-Api-Secret-Token header that Telegram echoes back from
+    // setWebhook. Without this check anyone on the public internet can POST
+    // a forged update_id and trigger /start link flows or future commands.
     if ('update_id' in body) {
+      const denied = verifyTelegramWebhook(request);
+      if (denied) return denied;
       await handleBotUpdate(body as unknown as TelegramUpdate);
       return NextResponse.json({ ok: true });
     }

--- a/apps/web/app/api/v1/signals/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/signals/__tests__/route.test.ts
@@ -162,7 +162,7 @@ describe('GET /api/v1/signals — tier gating', () => {
     expect(ids).toContain('nvda');
   });
 
-  it('response carries Vary: Cookie, Authorization so shared edge cache does not poison tiers', async () => {
+  it('free tier: public CDN cache, no tier header leak, Vary: Cookie + Authorization', async () => {
     mockedGetTier.mockResolvedValueOnce('free');
     mockedReadLiveSignals.mockResolvedValueOnce({
       signals: [makeSignal()],
@@ -172,7 +172,23 @@ describe('GET /api/v1/signals — tier gating', () => {
 
     const res = await GET(makeReq());
     expect(res.headers.get('Vary')).toBe('Cookie, Authorization');
-    expect(res.headers.get('X-TradeClaw-Tier')).toBe('free');
+    // X-TradeClaw-Tier was a CORS-readable cross-origin tier oracle. Stripped.
+    expect(res.headers.get('X-TradeClaw-Tier')).toBeNull();
+    expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=60');
+  });
+
+  it('paid tier: private no-store, no tier header leak', async () => {
+    mockedGetTier.mockResolvedValueOnce('pro');
+    mockedReadLiveSignals.mockResolvedValueOnce({
+      signals: [makeSignal()],
+      isStale: false,
+      generatedAt: new Date().toISOString(),
+    });
+
+    const res = await GET(makeReq());
+    expect(res.headers.get('X-TradeClaw-Tier')).toBeNull();
+    expect(res.headers.get('Vary')).toBe('Cookie, Authorization');
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
   it('returns 503 on upstream failure instead of masking as 200 + empty list', async () => {

--- a/apps/web/app/api/v1/signals/route.ts
+++ b/apps/web/app/api/v1/signals/route.ts
@@ -71,10 +71,14 @@ export async function GET(req: NextRequest) {
   // so a Pro browser hitting the same edge cache as a free caller doesn't
   // poison either side.
   const tier = await getTierFromRequest(req);
+  // Free / unauthenticated callers can be CDN-cached for 60s; authenticated
+  // callers must NOT be cached (Vary: Cookie is unreliable on some edges
+  // and X-TradeClaw-Tier was previously CORS-readable, leaking tier
+  // cross-origin). Drop the tier header entirely; tier still travels in
+  // the JSON body but only same-origin code reads it.
   const headers: Record<string, string> = {
-    "Cache-Control": "public, s-maxage=60",
+    "Cache-Control": tier === 'free' ? "public, s-maxage=60" : "private, no-store",
     "X-TradeClaw-Version": "v1",
-    "X-TradeClaw-Tier": tier,
     // Vary on Cookie AND Authorization so shared CDN cache does not poison
     // tiers across cookie-auth (browser) and bearer-token (SDK) callers.
     Vary: "Cookie, Authorization",

--- a/apps/web/app/api/webhooks/tradingview/route.ts
+++ b/apps/web/app/api/webhooks/tradingview/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
 import { execute } from '@/lib/db-pool';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
+
+function safeSecretEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 /**
  * Strategy IDs that may flow in via the TradingView webhook pipe. Used as an
@@ -83,7 +91,7 @@ export async function POST(req: NextRequest) {
   if (!expected) {
     return NextResponse.json({ error: 'not_configured' }, { status: 503 });
   }
-  if (!secret || secret !== expected) {
+  if (!secret || !safeSecretEqual(secret, expected)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/apps/web/app/api/webhooks/tradingview/route.ts
+++ b/apps/web/app/api/webhooks/tradingview/route.ts
@@ -131,10 +131,13 @@ export async function POST(req: NextRequest) {
       ],
     );
   } catch (err) {
-    return NextResponse.json(
-      { error: 'db_error', message: err instanceof Error ? err.message : 'unknown' },
-      { status: 500 },
-    );
+    // Server-side log retains the full error for debugging; the response
+    // body must not echo it back. Postgres error messages routinely include
+    // schema details (table names, column names, constraint identifiers)
+    // that are useful to an attacker and have no business in an API
+    // response.
+    console.error('[tv-webhook] db_error:', err);
+    return NextResponse.json({ error: 'db_error' }, { status: 500 });
   }
 
   return NextResponse.json({ ok: true });

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,7 +1,15 @@
 import type { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
+import { timingSafeEqual } from 'node:crypto';
 import { readSessionFromCookies } from '../../lib/user-session';
+
+function safeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const session = await readSessionFromCookies();
@@ -9,9 +17,10 @@ export default async function DashboardLayout({ children }: { children: ReactNod
 
   const cookieStore = await cookies();
   const adminSecret = process.env.ADMIN_SECRET;
-  const hasAdminCookie =
-    !!adminSecret && cookieStore.get('tc_admin')?.value === adminSecret;
-  if (hasAdminCookie) return <>{children}</>;
+  const cookieValue = cookieStore.get('tc_admin')?.value;
+  if (adminSecret && cookieValue && safeStringEqual(cookieValue, adminSecret)) {
+    return <>{children}</>;
+  }
 
   redirect('/signin?next=%2Fdashboard');
 }

--- a/apps/web/lib/__tests__/cron-auth.test.ts
+++ b/apps/web/lib/__tests__/cron-auth.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server';
+import { requireCronAuth } from '../cron-auth';
+
+function buildRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/cron/test', { headers });
+}
+
+describe('requireCronAuth', () => {
+  const ORIGINAL = process.env.CRON_SECRET;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = ORIGINAL;
+    }
+  });
+
+  it('returns 503 when CRON_SECRET is unset (fail closed)', async () => {
+    delete process.env.CRON_SECRET;
+    const res = requireCronAuth(buildRequest({ authorization: 'Bearer anything' }));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(503);
+    const body = await res!.json();
+    expect(body.error).toBe('cron_not_configured');
+  });
+
+  it('returns 401 when authorization header is missing', () => {
+    process.env.CRON_SECRET = 'a-secret-value-for-testing-12345';
+    const res = requireCronAuth(buildRequest());
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('returns 401 when bearer secret is wrong', () => {
+    process.env.CRON_SECRET = 'a-secret-value-for-testing-12345';
+    const res = requireCronAuth(buildRequest({ authorization: 'Bearer wrong-value' }));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('returns 401 when bearer length matches but content differs', () => {
+    process.env.CRON_SECRET = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const res = requireCronAuth(
+      buildRequest({ authorization: 'Bearer bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('returns null (passes) when bearer secret matches', () => {
+    process.env.CRON_SECRET = 'a-secret-value-for-testing-12345';
+    const res = requireCronAuth(
+      buildRequest({ authorization: 'Bearer a-secret-value-for-testing-12345' }),
+    );
+    expect(res).toBeNull();
+  });
+
+  it('returns 401 when authorization scheme is not Bearer', () => {
+    process.env.CRON_SECRET = 'a-secret-value-for-testing-12345';
+    const res = requireCronAuth(
+      buildRequest({ authorization: 'Basic a-secret-value-for-testing-12345' }),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('does not throw on differing-length headers (no buffer compare crash)', () => {
+    process.env.CRON_SECRET = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    expect(() =>
+      requireCronAuth(buildRequest({ authorization: 'Bearer short' })),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/lib/__tests__/db-pool.test.ts
+++ b/apps/web/lib/__tests__/db-pool.test.ts
@@ -1,0 +1,86 @@
+/**
+ * withClient contract tests — verifies session-scoped state (advisory locks)
+ * can survive across calls on a single held connection.
+ *
+ * The previous executor.ts pattern called `pg_try_advisory_lock` through
+ * query() and `pg_advisory_unlock` through query() again. Each query() call
+ * checks out a fresh pool client, runs one statement, and releases. Session
+ * locks held on the first client leaked to idleTimeoutMillis. withClient
+ * pins one client for the callback's lifetime so lock+work+unlock share a
+ * session.
+ */
+
+jest.mock('pg', () => ({ Pool: jest.fn() }));
+
+import type { PoolClient } from 'pg';
+
+function makeFakeClient(): { client: PoolClient; release: jest.Mock; query: jest.Mock } {
+  const release = jest.fn();
+  const query = jest.fn().mockResolvedValue({ rows: [] });
+  const client = { query, release } as unknown as PoolClient;
+  return { client, release, query };
+}
+
+async function loadWithMockedPool(connect: jest.Mock): Promise<typeof import('../db-pool')> {
+  // Re-grab Pool *after* resetModules so the mock matches the freshly
+  // re-imported module graph that db-pool will see.
+  const pg = await import('pg');
+  (pg.Pool as unknown as jest.Mock).mockImplementation(() => ({ connect }));
+  return await import('../db-pool');
+}
+
+describe('withClient', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.DATABASE_URL = 'postgresql://localhost/test';
+  });
+
+  it('connects a client, passes it to the callback, releases it once on success', async () => {
+    const { client, release } = makeFakeClient();
+    const connect = jest.fn().mockResolvedValue(client);
+    const { withClient } = await loadWithMockedPool(connect);
+
+    const result = await withClient(async (c) => {
+      expect(c).toBe(client);
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client even when the callback throws', async () => {
+    const { client, release } = makeFakeClient();
+    const connect = jest.fn().mockResolvedValue(client);
+    const { withClient } = await loadWithMockedPool(connect);
+
+    await expect(
+      withClient(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs lock acquire and unlock on the SAME client (session-scoped invariant)', async () => {
+    // Hand out a distinct client object on each connect() so the test would
+    // fail if withClient checked out a fresh client mid-callback. Tracks the
+    // previous H6 fail-mode where pg_try_advisory_lock and pg_advisory_unlock
+    // landed on different sessions.
+    const c1 = makeFakeClient();
+    const c2 = makeFakeClient();
+    const connect = jest.fn().mockResolvedValueOnce(c1.client).mockResolvedValueOnce(c2.client);
+    const { withClient } = await loadWithMockedPool(connect);
+
+    await withClient(async (lockClient) => {
+      await lockClient.query('SELECT pg_try_advisory_lock($1)', [42]);
+      await lockClient.query('SELECT pg_advisory_unlock($1)', [42]);
+    });
+
+    expect(c1.query).toHaveBeenCalledTimes(2);
+    expect(c2.query).toHaveBeenCalledTimes(0);
+    expect(c1.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/__tests__/magic-link.test.ts
+++ b/apps/web/lib/__tests__/magic-link.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { hashToken, generateRawToken, isExpired, MAGIC_LINK_TTL_MS } from '../magic-link';
 
 describe('magic-link primitives', () => {
@@ -7,15 +6,91 @@ describe('magic-link primitives', () => {
     expect(t).toMatch(/^[A-Za-z0-9_-]{40,}$/);
     expect(t.length).toBeGreaterThanOrEqual(40);
   });
+
   it('hashToken is deterministic and 64 hex chars', () => {
     expect(hashToken('abc')).toBe(hashToken('abc'));
     expect(hashToken('abc')).toMatch(/^[0-9a-f]{64}$/);
     expect(hashToken('abc')).not.toBe(hashToken('abd'));
   });
+
   it('isExpired flips past TTL', () => {
     const past = new Date(Date.now() - MAGIC_LINK_TTL_MS - 1000);
-    const now = new Date();
+    const future = new Date(Date.now() + MAGIC_LINK_TTL_MS);
     expect(isExpired(past)).toBe(true);
-    expect(isExpired(now)).toBe(false);
+    expect(isExpired(future)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Race-safe consume: the second simultaneous click must not return ok:true.
+// Mocks the underlying query function so we can simulate the race.
+// ---------------------------------------------------------------------------
+
+jest.mock('../db-pool', () => ({
+  query: jest.fn(),
+  execute: jest.fn(),
+}));
+
+import { query } from '../db-pool';
+import { consumeMagicLink, countRecentMagicLinkEmails } from '../magic-link';
+
+const mockedQuery = query as jest.MockedFunction<typeof query>;
+
+describe('consumeMagicLink (single-shot UPDATE...RETURNING)', () => {
+  beforeEach(() => mockedQuery.mockReset());
+
+  it('returns ok with email when row was claimed', async () => {
+    mockedQuery.mockResolvedValueOnce([
+      {
+        email: 'user@example.com',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+    ]);
+    const result = await consumeMagicLink('raw-token-value');
+    expect(result.ok).toBe(true);
+    expect(result.email).toBe('user@example.com');
+  });
+
+  it('returns consumed when no row was claimed (race loser)', async () => {
+    // Empty rows array == nothing matched UPDATE WHERE consumed_at IS NULL
+    mockedQuery.mockResolvedValueOnce([]);
+    const result = await consumeMagicLink('raw-token-value');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('consumed');
+  });
+
+  it('returns expired when claimed row already past TTL', async () => {
+    mockedQuery.mockResolvedValueOnce([
+      {
+        email: 'user@example.com',
+        expires_at: new Date(Date.now() - 60_000).toISOString(),
+      },
+    ]);
+    const result = await consumeMagicLink('raw-token-value');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('expired');
+  });
+});
+
+describe('countRecentMagicLinkEmails', () => {
+  beforeEach(() => mockedQuery.mockReset());
+
+  it('returns the count from the DB row', async () => {
+    mockedQuery.mockResolvedValueOnce([{ count: '3' }]);
+    const n = await countRecentMagicLinkEmails('user@example.com', 60);
+    expect(n).toBe(3);
+  });
+
+  it('returns 0 when DB returns no rows', async () => {
+    mockedQuery.mockResolvedValueOnce([]);
+    const n = await countRecentMagicLinkEmails('user@example.com', 60);
+    expect(n).toBe(0);
+  });
+
+  it('lowercases and trims the email before query', async () => {
+    mockedQuery.mockResolvedValueOnce([{ count: '0' }]);
+    await countRecentMagicLinkEmails('  USER@Example.com  ', 60);
+    const callArgs = mockedQuery.mock.calls[0][1] as unknown[];
+    expect(callArgs[0]).toBe('user@example.com');
   });
 });

--- a/apps/web/lib/__tests__/safe-outbound-url.test.ts
+++ b/apps/web/lib/__tests__/safe-outbound-url.test.ts
@@ -1,0 +1,58 @@
+import {
+  checkSafeOutboundUrl,
+  isSafeOutboundUrl,
+  assertSafeOutboundUrl,
+} from '../safe-outbound-url';
+
+describe('safe-outbound-url', () => {
+  it.each([
+    'https://discord.com/api/webhooks/123/abc',
+    'https://hooks.slack.com/services/T1/B2/abc',
+    'https://example.com:8443/path',
+    'https://api.tradeclaw.win/v1/whatever',
+  ])('accepts %s', (url) => {
+    expect(isSafeOutboundUrl(url)).toBe(true);
+    expect(() => assertSafeOutboundUrl(url)).not.toThrow();
+  });
+
+  it.each([
+    ['http://example.com', 'protocol'],
+    ['ftp://example.com/x', 'protocol'],
+    ['file:///etc/passwd', 'protocol'],
+    ['javascript:alert(1)', 'protocol'],
+    ['data:text/html,<script>', 'protocol'],
+  ])('rejects non-HTTPS %s', (url, expectedReason) => {
+    const err = checkSafeOutboundUrl(url);
+    expect(err?.reason).toBe(expectedReason);
+  });
+
+  it.each([
+    'https://localhost/',
+    'https://127.0.0.1/',
+    'https://10.0.0.5/',
+    'https://172.16.0.1/',
+    'https://172.31.255.255/',
+    'https://192.168.1.1/',
+    'https://169.254.169.254/latest/meta-data/', // AWS IMDS
+    'https://0.0.0.0/',
+    'https://metadata.google.internal/computeMetadata/v1/',
+    'https://metadata.azure.com/instance',
+    'https://service.local/x',
+    'https://kube-api.internal/',
+    'https://[::1]/',
+    'https://[fe80::1]/',
+    'https://[fc00::1]/',
+  ])('rejects internal target %s', (url) => {
+    expect(isSafeOutboundUrl(url)).toBe(false);
+  });
+
+  it('rejects unparseable input', () => {
+    const err = checkSafeOutboundUrl('not a url');
+    expect(err?.reason).toBe('parse');
+  });
+
+  it('assertSafeOutboundUrl throws with reason in message', () => {
+    expect(() => assertSafeOutboundUrl('http://example.com')).toThrow(/unsafe_outbound_url:protocol/);
+    expect(() => assertSafeOutboundUrl('https://10.0.0.1')).toThrow(/unsafe_outbound_url:ip_private/);
+  });
+});

--- a/apps/web/lib/__tests__/telegram-webhook-auth.test.ts
+++ b/apps/web/lib/__tests__/telegram-webhook-auth.test.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server';
+import { verifyTelegramWebhook } from '../telegram-webhook-auth';
+
+function buildRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/telegram', { method: 'POST', headers });
+}
+
+describe('verifyTelegramWebhook', () => {
+  const ORIGINAL = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.TELEGRAM_WEBHOOK_SECRET;
+    } else {
+      process.env.TELEGRAM_WEBHOOK_SECRET = ORIGINAL;
+    }
+  });
+
+  it('returns 503 when TELEGRAM_WEBHOOK_SECRET is unset', async () => {
+    delete process.env.TELEGRAM_WEBHOOK_SECRET;
+    const res = verifyTelegramWebhook(buildRequest());
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(503);
+  });
+
+  it('returns 401 when secret-token header is missing', () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'tg-webhook-secret-12345';
+    const res = verifyTelegramWebhook(buildRequest());
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('returns 401 when secret-token header is wrong', () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'tg-webhook-secret-12345';
+    const res = verifyTelegramWebhook(
+      buildRequest({ 'x-telegram-bot-api-secret-token': 'nope' }),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('returns null when secret-token header matches', () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'tg-webhook-secret-12345';
+    const res = verifyTelegramWebhook(
+      buildRequest({ 'x-telegram-bot-api-secret-token': 'tg-webhook-secret-12345' }),
+    );
+    expect(res).toBeNull();
+  });
+});

--- a/apps/web/lib/admin-emails.ts
+++ b/apps/web/lib/admin-emails.ts
@@ -15,12 +15,22 @@ const DEFAULT_ADMIN_EMAILS = ['naimkatiman@gmail.com'];
 const DEFAULT_PRO_EMAILS = ['naimkatiman92@gmail.com'];
 
 function parseList(raw: string | undefined, fallback: string[]): Set<string> {
-  if (!raw) return new Set(fallback.map((e) => e.toLowerCase()));
-  const parsed = raw
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    // Production never inherits a hardcoded fallback. The previous behavior
+    // silently granted admin/Pro to a static address on any deploy that
+    // forgot to set the env var — including forks, staging clones, and
+    // misconfigured production. Fail closed (empty set ⇒ access denied).
+    if (process.env.NODE_ENV === 'production') return new Set();
+    return new Set(fallback.map((e) => e.toLowerCase()));
+  }
+  const parsed = trimmed
     .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
-  return new Set(parsed.length > 0 ? parsed : fallback.map((e) => e.toLowerCase()));
+  if (parsed.length > 0) return new Set(parsed);
+  if (process.env.NODE_ENV === 'production') return new Set();
+  return new Set(fallback.map((e) => e.toLowerCase()));
 }
 
 export function getAdminEmails(): Set<string> {

--- a/apps/web/lib/admin-gate.ts
+++ b/apps/web/lib/admin-gate.ts
@@ -1,9 +1,18 @@
 import 'server-only';
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
-import { readSessionFromCookies } from './user-session';
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
+import { readSessionFromCookies, readSessionFromRequest } from './user-session';
 import { getUserById } from './db';
 import { isAdminEmail } from './admin-emails';
+
+function safeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 /**
  * Server-component guard for admin pages. Allows either:
@@ -26,9 +35,39 @@ export async function requireAdmin(): Promise<{ via: 'email' | 'secret'; email?:
 
   const cookieStore = await cookies();
   const adminSecret = process.env.ADMIN_SECRET;
-  if (adminSecret && cookieStore.get('tc_admin')?.value === adminSecret) {
+  const cookieValue = cookieStore.get('tc_admin')?.value;
+  if (adminSecret && cookieValue && safeStringEqual(cookieValue, adminSecret)) {
     return { via: 'secret' };
   }
 
   redirect('/admin/login');
+}
+
+/**
+ * API-route variant of `requireAdmin`: returns 401 instead of redirecting.
+ * Accepts the same two grants (Google-OAuth admin email or `tc_admin`
+ * cookie matching `ADMIN_SECRET`). Use from POST/GET handlers that the
+ * admin browser hits directly.
+ */
+export async function assertAdminApi(request: Request): Promise<NextResponse | null> {
+  const session = readSessionFromRequest(request);
+  if (session?.userId) {
+    const user = await getUserById(session.userId);
+    if (user?.email && isAdminEmail(user.email)) return null;
+  }
+
+  const cookieHeader = request.headers.get('cookie') ?? '';
+  const adminSecret = process.env.ADMIN_SECRET;
+  if (adminSecret) {
+    const match = cookieHeader
+      .split(';')
+      .map((c) => c.trim())
+      .find((c) => c.startsWith('tc_admin='));
+    if (match) {
+      const value = decodeURIComponent(match.slice('tc_admin='.length));
+      if (safeStringEqual(value, adminSecret)) return null;
+    }
+  }
+
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 }

--- a/apps/web/lib/alert-channels.ts
+++ b/apps/web/lib/alert-channels.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { isSafeOutboundUrl } from './safe-outbound-url';
 
 /**
  * Per-user "preferred platform" senders.
@@ -126,6 +127,9 @@ export async function sendDiscordWebhook(
 ): Promise<boolean> {
   const url = config.webhookUrl;
   if (!url) return false;
+  // SSRF gate: even though /api/alert-channels validates at write time, the
+  // DB row may pre-date that gate, so re-check before every send.
+  if (!isSafeOutboundUrl(url)) return false;
   try {
     const res = await fetch(url, {
       method: 'POST',
@@ -145,6 +149,7 @@ export async function sendGenericWebhook(
 ): Promise<boolean> {
   const url = config.url;
   if (!url) return false;
+  if (!isSafeOutboundUrl(url)) return false;
   try {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/apps/web/lib/cookie-flags.ts
+++ b/apps/web/lib/cookie-flags.ts
@@ -1,0 +1,15 @@
+import 'server-only';
+
+/**
+ * Default `Secure` flag for auth cookies. Previous code keyed this on
+ * `NODE_ENV === 'production'`, which meant any non-production deploy
+ * (preview, staging, custom NODE_ENV) sent session cookies over plain
+ * HTTP. Default to true; allow opt-out via `INSECURE_COOKIES=1` for
+ * local dev over HTTP (and even then only when NODE_ENV !== 'production').
+ */
+export function secureCookieDefault(): boolean {
+  if (process.env.INSECURE_COOKIES === '1' && process.env.NODE_ENV !== 'production') {
+    return false;
+  }
+  return true;
+}

--- a/apps/web/lib/cron-auth.ts
+++ b/apps/web/lib/cron-auth.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
+
+const BEARER_PREFIX = 'Bearer ';
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export function requireCronAuth(request: NextRequest): NextResponse | null {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'cron_not_configured' }, { status: 503 });
+  }
+  const header = request.headers.get('authorization') ?? '';
+  if (!header.startsWith(BEARER_PREFIX)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const supplied = header.slice(BEARER_PREFIX.length);
+  if (!safeEqual(supplied, secret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return null;
+}

--- a/apps/web/lib/db-pool.ts
+++ b/apps/web/lib/db-pool.ts
@@ -2,7 +2,7 @@
  * Centralized PostgreSQL connection pool for TradeClaw.
  * Reads DATABASE_URL from environment (Railway PostgreSQL).
  */
-import { Pool } from 'pg';
+import { Pool, type PoolClient } from 'pg';
 
 let pool: Pool | null = null;
 
@@ -48,4 +48,22 @@ export async function queryOne<T = Record<string, unknown>>(
 
 export async function execute(sql: string, params?: unknown[]): Promise<void> {
   await query(sql, params);
+}
+
+/**
+ * Run `cb` with a single dedicated pool client held for its entire lifetime.
+ * Required for session-scoped state — `pg_try_advisory_lock` and friends
+ * are session-bound, so acquiring on one client and releasing on another
+ * (which is what `query()` does on each call) leaks the lock until the
+ * underlying session is recycled by `idleTimeoutMillis`.
+ *
+ * The client is released back to the pool on both success and failure.
+ */
+export async function withClient<T>(cb: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await getPool().connect();
+  try {
+    return await cb(client);
+  } finally {
+    client.release();
+  }
 }

--- a/apps/web/lib/earningsedge/stripe.ts
+++ b/apps/web/lib/earningsedge/stripe.ts
@@ -66,23 +66,57 @@ export async function createCheckoutSession(
   return session.url!;
 }
 
-export async function handleWebhookEvent(
-  payload: string,
-  signature: string,
-): Promise<{ type: string; customerId?: string; subscriptionId?: string; tier?: string; email?: string }> {
+/**
+ * Verify a Stripe webhook signature against the EE-specific secret.
+ *
+ * Previous behavior fell back to STRIPE_WEBHOOK_SECRET when
+ * EE_STRIPE_WEBHOOK_SECRET was unset. That let a TradeClaw-main event
+ * delivered to the EE endpoint pass signature verification, with all the
+ * cross-product replay risk that implies. Fail closed: if EE-specific
+ * secret is unset, the EE webhook returns 503.
+ */
+export function verifyEEWebhookSignature(payload: string, signature: string): Stripe.Event {
   const stripe = getEEStripe();
-  const webhookSecret = process.env.EE_STRIPE_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET;
-  if (!webhookSecret) throw new Error('Webhook secret not configured');
+  const webhookSecret = process.env.EE_STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    throw new Error('EE_STRIPE_WEBHOOK_SECRET not configured');
+  }
+  return stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+}
 
-  const event = stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+/**
+ * Strict price-id → EE tier map. Throws on an unknown price rather than
+ * silently defaulting to 'basic' — the main TradeClaw webhook throws on
+ * unknown price IDs and EE should match. A misconfigured env var must not
+ * silently downgrade a paying user.
+ */
+function resolveEETierFromPriceId(priceId: string | undefined): 'basic' | 'pro' {
+  if (priceId && priceId === EE_PRICES.pro_monthly) return 'pro';
+  if (priceId && priceId === EE_PRICES.basic_monthly) return 'basic';
+  throw new Error(`unknown_or_unconfigured_ee_price_id:${priceId ?? 'null'}`);
+}
 
+export interface ParsedEEEvent {
+  id: string;
+  type: string;
+  customerId?: string;
+  subscriptionId?: string;
+  tier?: string;
+  email?: string;
+}
+
+export async function parseEEEvent(event: Stripe.Event): Promise<ParsedEEEvent> {
+  const stripe = getEEStripe();
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session;
-    if (session.metadata?.product !== 'earningsedge') return { type: event.type };
+    if (session.metadata?.product !== 'earningsedge') {
+      return { id: event.id, type: event.type };
+    }
     const subscription = await stripe.subscriptions.retrieve(session.subscription as string);
     const priceId = subscription.items.data[0]?.price.id;
-    const tier = priceId === EE_PRICES.pro_monthly ? 'pro' : 'basic';
+    const tier = resolveEETierFromPriceId(priceId);
     return {
+      id: event.id,
       type: event.type,
       customerId: session.customer as string,
       subscriptionId: session.subscription as string,
@@ -94,11 +128,21 @@ export async function handleWebhookEvent(
   if (event.type === 'customer.subscription.deleted') {
     const subscription = event.data.object as Stripe.Subscription;
     return {
+      id: event.id,
       type: event.type,
       customerId: subscription.customer as string,
       subscriptionId: subscription.id,
     };
   }
 
-  return { type: event.type };
+  return { id: event.id, type: event.type };
+}
+
+/** @deprecated retained for backwards compatibility — prefer the split helpers. */
+export async function handleWebhookEvent(
+  payload: string,
+  signature: string,
+): Promise<ParsedEEEvent> {
+  const event = verifyEEWebhookSignature(payload, signature);
+  return parseEEEvent(event);
 }

--- a/apps/web/lib/execution/binance-futures.ts
+++ b/apps/web/lib/execution/binance-futures.ts
@@ -355,7 +355,12 @@ export async function getOrderByClientId(
 function ensureWriteAllowed(action: string, payload: Record<string, unknown>): boolean {
   const mode = getMode();
   if (mode === 'disabled') {
-    console.log(`[binance] DRY-RUN (${action}) — EXECUTION_MODE=disabled —`, JSON.stringify(payload));
+    // Only emit non-sensitive fields — symbol is enough for traceability.
+    // Quantities, prices, sides, and full order params should not land in
+    // shared log aggregators.
+    const safe: Record<string, unknown> = {};
+    if (typeof payload.symbol === 'string') safe.symbol = payload.symbol;
+    console.log(`[binance] DRY-RUN (${action}) — EXECUTION_MODE=disabled —`, JSON.stringify(safe));
     return false;
   }
   return true;

--- a/apps/web/lib/execution/executor.ts
+++ b/apps/web/lib/execution/executor.ts
@@ -34,8 +34,14 @@ import { computeATR, computeSize, extractFilters, type SymbolFilters } from './s
 import { notifyEntryFilled } from './telegram';
 import { getTodayUniverse } from './universe-runner';
 
+// Trading firewall — the executor pulls signals only where strategy_id =
+// 'hmm-top3'. TradingView webhook strategies (tv-zaky-classic etc.) land in
+// the separate `premium_signals` table and are NEVER read here. Do not
+// loosen this filter without an explicit risk review — it is the gate that
+// keeps third-party webhook input out of live order placement.
 const STRATEGY_ID = 'hmm-top3';
 const SIGNAL_LOOKBACK_MINUTES = 5;
+const ADVISORY_LOCK_KEY = 'tradeclaw:executor:hmm-top3';
 const H1_KLINE_LIMIT = 100;        // enough for EMA50 + slope + ADX(14) warmup
 const BROKER = 'binance-futures';
 const TP1_FRACTION = 0.5;          // half qty at TP1, runner = the rest
@@ -55,6 +61,7 @@ interface ExecutorTickResult {
   filtered: number;
   errors: number;
   halted?: string;
+  skipped?: 'locked';
 }
 
 interface PendingSignal {
@@ -76,6 +83,26 @@ export async function runExecutorTick(): Promise<ExecutorTickResult> {
     return result;
   }
 
+  // PG advisory lock — prevents two overlapping cron firings from both
+  // hitting placeOrder for the same signal between the SQL pull and the
+  // executions row insert. Lock is session-scoped and auto-released when
+  // the connection returns to the pool.
+  const lockAcquired = await tryAcquireExecutorLock();
+  if (!lockAcquired) {
+    return { ...result, skipped: 'locked' };
+  }
+
+  try {
+    return await runExecutorTickLocked(mode, result);
+  } finally {
+    await releaseExecutorLock();
+  }
+}
+
+async function runExecutorTickLocked(
+  mode: ReturnType<typeof currentMode>,
+  result: ExecutorTickResult,
+): Promise<ExecutorTickResult> {
   // 1. Pull pending signals
   const signals = await fetchPendingSignals();
   result.processed = signals.length;
@@ -314,6 +341,35 @@ export async function runExecutorTick(): Promise<ExecutorTickResult> {
 
   console.log(`[pilot/executor] tick: ${JSON.stringify(result)}`);
   return result;
+}
+
+// ─── Concurrency helpers ──────────────────────────────────────────────
+
+async function tryAcquireExecutorLock(): Promise<boolean> {
+  try {
+    const rows = await query<{ acquired: boolean }>(
+      `SELECT pg_try_advisory_lock(hashtext($1)::bigint) AS acquired`,
+      [ADVISORY_LOCK_KEY],
+    );
+    return rows[0]?.acquired === true;
+  } catch (err) {
+    // If the lock query fails (e.g. DB unreachable) skip the tick rather
+    // than running unprotected. Better to miss a tick than to risk a
+    // double-fill bracket race during a DB blip.
+    console.error('[pilot/executor] advisory lock acquire failed:', getMsg(err));
+    return false;
+  }
+}
+
+async function releaseExecutorLock(): Promise<void> {
+  try {
+    await query(
+      `SELECT pg_advisory_unlock(hashtext($1)::bigint)`,
+      [ADVISORY_LOCK_KEY],
+    );
+  } catch (err) {
+    console.error('[pilot/executor] advisory lock release failed:', getMsg(err));
+  }
 }
 
 // ─── Data helpers ──────────────────────────────────────────────────────

--- a/apps/web/lib/execution/executor.ts
+++ b/apps/web/lib/execution/executor.ts
@@ -11,7 +11,8 @@
  * the SQL pull already excludes signals with an executions row.
  */
 
-import { execute, query } from '../db-pool';
+import type { PoolClient } from 'pg';
+import { execute, query, withClient } from '../db-pool';
 import { BINANCE_SYMBOLS } from '../../app/lib/ohlcv';
 import {
   cancelOrder,
@@ -85,18 +86,22 @@ export async function runExecutorTick(): Promise<ExecutorTickResult> {
 
   // PG advisory lock — prevents two overlapping cron firings from both
   // hitting placeOrder for the same signal between the SQL pull and the
-  // executions row insert. Lock is session-scoped and auto-released when
-  // the connection returns to the pool.
-  const lockAcquired = await tryAcquireExecutorLock();
-  if (!lockAcquired) {
-    return { ...result, skipped: 'locked' };
-  }
-
-  try {
-    return await runExecutorTickLocked(mode, result);
-  } finally {
-    await releaseExecutorLock();
-  }
+  // executions row insert. Held on a dedicated session via withClient so
+  // acquire and release run on the same connection; without this, releasing
+  // through query() picks an arbitrary pool client and the lock leaks until
+  // the original session idle-times out (idleTimeoutMillis=30s). Inner work
+  // continues to use the pool freely — the held client is only the lock owner.
+  return withClient(async (lockClient) => {
+    const lockAcquired = await tryAcquireExecutorLock(lockClient);
+    if (!lockAcquired) {
+      return { ...result, skipped: 'locked' };
+    }
+    try {
+      return await runExecutorTickLocked(mode, result);
+    } finally {
+      await releaseExecutorLock(lockClient);
+    }
+  });
 }
 
 async function runExecutorTickLocked(
@@ -345,13 +350,13 @@ async function runExecutorTickLocked(
 
 // ─── Concurrency helpers ──────────────────────────────────────────────
 
-async function tryAcquireExecutorLock(): Promise<boolean> {
+async function tryAcquireExecutorLock(client: PoolClient): Promise<boolean> {
   try {
-    const rows = await query<{ acquired: boolean }>(
+    const r = await client.query<{ acquired: boolean }>(
       `SELECT pg_try_advisory_lock(hashtext($1)::bigint) AS acquired`,
       [ADVISORY_LOCK_KEY],
     );
-    return rows[0]?.acquired === true;
+    return r.rows[0]?.acquired === true;
   } catch (err) {
     // If the lock query fails (e.g. DB unreachable) skip the tick rather
     // than running unprotected. Better to miss a tick than to risk a
@@ -361,9 +366,9 @@ async function tryAcquireExecutorLock(): Promise<boolean> {
   }
 }
 
-async function releaseExecutorLock(): Promise<void> {
+async function releaseExecutorLock(client: PoolClient): Promise<void> {
   try {
-    await query(
+    await client.query(
       `SELECT pg_advisory_unlock(hashtext($1)::bigint)`,
       [ADVISORY_LOCK_KEY],
     );

--- a/apps/web/lib/execution/risk-rails.test.ts
+++ b/apps/web/lib/execution/risk-rails.test.ts
@@ -1,0 +1,77 @@
+jest.mock('./binance-futures', () => ({
+  getRealizedPnlSince: jest.fn(),
+}));
+
+import { getRealizedPnlSince } from './binance-futures';
+import { checkLossKillSwitch } from './risk-rails';
+
+const mockedIncome = getRealizedPnlSince as jest.MockedFunction<typeof getRealizedPnlSince>;
+
+const account = (totalWalletBalance: number) => ({ totalWalletBalance });
+
+describe('checkLossKillSwitch', () => {
+  beforeEach(() => {
+    mockedIncome.mockReset();
+    delete process.env.EXEC_DAILY_LOSS_PCT;
+    delete process.env.EXEC_WEEKLY_LOSS_PCT;
+  });
+
+  it('halts immediately when wallet equity is zero', async () => {
+    // No income query needed — short-circuit before the network call.
+    const verdict = await checkLossKillSwitch(account(0));
+    expect(verdict.halted).toBe(true);
+    expect(verdict.reason).toMatch(/zero_equity_kill/);
+    expect(mockedIncome).not.toHaveBeenCalled();
+  });
+
+  it('halts when wallet equity is negative', async () => {
+    const verdict = await checkLossKillSwitch(account(-1));
+    expect(verdict.halted).toBe(true);
+    expect(verdict.reason).toMatch(/zero_equity_kill/);
+  });
+
+  it('halts when daily loss exceeds threshold', async () => {
+    process.env.EXEC_DAILY_LOSS_PCT = '5';
+    const now = Date.now();
+    mockedIncome.mockResolvedValueOnce([
+      { time: now - 60_000, income: '-60', symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL' },
+    ]);
+    // -60 / 1000 = 6% > 5% threshold
+    const verdict = await checkLossKillSwitch(account(1000));
+    expect(verdict.halted).toBe(true);
+    expect(verdict.reason).toMatch(/daily_loss_kill/);
+  });
+
+  it('does not halt when daily loss is below threshold', async () => {
+    process.env.EXEC_DAILY_LOSS_PCT = '5';
+    const now = Date.now();
+    mockedIncome.mockResolvedValueOnce([
+      { time: now - 60_000, income: '-30', symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL' },
+    ]);
+    // -30 / 1000 = 3% < 5% threshold
+    const verdict = await checkLossKillSwitch(account(1000));
+    expect(verdict.halted).toBe(false);
+  });
+
+  it('halts when weekly loss exceeds threshold even if daily is fine', async () => {
+    process.env.EXEC_DAILY_LOSS_PCT = '5';
+    process.env.EXEC_WEEKLY_LOSS_PCT = '12';
+    const now = Date.now();
+    const fiveDaysAgo = now - 5 * 24 * 60 * 60 * 1000;
+    mockedIncome.mockResolvedValueOnce([
+      { time: fiveDaysAgo, income: '-150', symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL' },
+    ]);
+    // -150 / 1000 = 15% > 12% weekly threshold; 0% daily.
+    const verdict = await checkLossKillSwitch(account(1000));
+    expect(verdict.halted).toBe(true);
+    expect(verdict.reason).toMatch(/weekly_loss_kill/);
+  });
+
+  it('does not halt on positive realized PnL', async () => {
+    mockedIncome.mockResolvedValueOnce([
+      { time: Date.now() - 60_000, income: '50', symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL' },
+    ]);
+    const verdict = await checkLossKillSwitch(account(1000));
+    expect(verdict.halted).toBe(false);
+  });
+});

--- a/apps/web/lib/execution/risk-rails.ts
+++ b/apps/web/lib/execution/risk-rails.ts
@@ -75,7 +75,21 @@ export async function checkLossKillSwitch(
   const equityUsd = account.totalWalletBalance;
 
   if (equityUsd <= 0) {
-    return { halted: false };
+    // Drawdown without settled USDT (or a brand-new account with zero
+    // wallet) is exactly the situation we want to halt on, not skip.
+    // Previous behavior was halted:false, which let new entries through
+    // at the worst possible moment.
+    return {
+      halted: true,
+      reason: `zero_equity_kill: totalWalletBalance=${equityUsd}`,
+      detail: {
+        realizedPnlDaily: 0,
+        realizedPnlWeekly: 0,
+        equityUsd,
+        dailyPct,
+        weeklyPct,
+      },
+    };
   }
 
   const now = Date.now();

--- a/apps/web/lib/magic-link.ts
+++ b/apps/web/lib/magic-link.ts
@@ -27,25 +27,55 @@ export async function issueMagicLink(email: string): Promise<{ raw: string }> {
   return { raw };
 }
 
+/**
+ * Count rows already issued for `email` within the last `windowSeconds`.
+ * Used as the persistent rate-limit gate — the prior in-process Map was
+ * useless on serverless cold starts, allowing unbounded enumeration.
+ */
+export async function countRecentMagicLinkEmails(
+  email: string,
+  windowSeconds: number,
+): Promise<number> {
+  const rows = await query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+       FROM magic_link_tokens
+      WHERE email = $1
+        AND created_at > NOW() - MAKE_INTERVAL(secs => $2)`,
+    [email.toLowerCase().trim(), windowSeconds],
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
 export interface ConsumeResult {
   ok: boolean;
   email?: string;
   reason?: 'not_found' | 'expired' | 'consumed';
 }
 
+/**
+ * Race-safe single-shot consume: the UPDATE only matches when the row is
+ * still unconsumed. The previous SELECT-then-UPDATE could let two parallel
+ * verifies both observe `consumed_at = NULL` and both return ok:true.
+ */
 export async function consumeMagicLink(raw: string): Promise<ConsumeResult> {
   const tokenHash = hashToken(raw);
-  const rows = await query<{ email: string; expires_at: string; consumed_at: string | null }>(
-    `SELECT email, expires_at, consumed_at FROM magic_link_tokens WHERE token_hash = $1`,
+  const rows = await query<{ email: string; expires_at: string }>(
+    `UPDATE magic_link_tokens
+        SET consumed_at = NOW()
+      WHERE token_hash = $1
+        AND consumed_at IS NULL
+      RETURNING email, expires_at`,
     [tokenHash],
   );
-  if (rows.length === 0) return { ok: false, reason: 'not_found' };
+  if (rows.length === 0) {
+    // Either no such token or another caller already claimed it. We can't
+    // tell which without a second query and the UX outcome is the same;
+    // surface as 'consumed' so the verify route returns a generic error.
+    return { ok: false, reason: 'consumed' };
+  }
   const row = rows[0];
-  if (row.consumed_at) return { ok: false, reason: 'consumed' };
-  if (isExpired(new Date(row.expires_at))) return { ok: false, reason: 'expired' };
-  await query(
-    `UPDATE magic_link_tokens SET consumed_at = NOW() WHERE token_hash = $1 AND consumed_at IS NULL`,
-    [tokenHash],
-  );
+  if (isExpired(new Date(row.expires_at))) {
+    return { ok: false, reason: 'expired' };
+  }
   return { ok: true, email: row.email };
 }

--- a/apps/web/lib/oauth-state.ts
+++ b/apps/web/lib/oauth-state.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { secureCookieDefault } from './cookie-flags';
 
 export const OAUTH_STATE_COOKIE = 'tc_oauth_state';
 export const OAUTH_STATE_MAX_AGE_SECONDS = 60 * 10; // 10 minutes
@@ -74,9 +75,21 @@ export function decodeState(token: string): OAuthStatePayload | null {
 export function stateCookieOptions() {
   return {
     httpOnly: true as const,
-    secure: process.env.NODE_ENV === 'production',
+    secure: secureCookieDefault(),
     sameSite: 'lax' as const,
     path: '/',
     maxAge: OAUTH_STATE_MAX_AGE_SECONDS,
   };
+}
+
+/**
+ * Sanitize a `next` URL parameter — accept only same-origin paths starting
+ * with `/` and reject `//` (which would coerce to a different origin via
+ * scheme-relative URL resolution). Also exported from the OAuth start
+ * route; callback re-applies it before redirecting.
+ */
+export function safeNext(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  if (!value.startsWith('/') || value.startsWith('//')) return undefined;
+  return value;
 }

--- a/apps/web/lib/safe-outbound-url.ts
+++ b/apps/web/lib/safe-outbound-url.ts
@@ -1,0 +1,101 @@
+import 'server-only';
+
+/**
+ * Validate that a user-supplied URL is safe to fetch from the server.
+ *
+ * Mitigates SSRF: Discord webhook URL and the generic webhook URL come from
+ * untrusted user config. Without this gate, an attacker could store
+ * `http://169.254.169.254/latest/meta-data/iam/security-credentials/...`
+ * (AWS IMDS) or any internal service URL and the server would dutifully
+ * GET/POST it, returning the response or its side effects to the attacker.
+ *
+ * Rules:
+ *   - Only HTTPS (no http://, no file:, no ftp:, no data:, etc.)
+ *   - Reject hostnames that are loopback / private / link-local
+ *   - Reject explicit IPv4 literals in private/reserved ranges
+ *   - Reject explicit IPv6 literals (::1, fc00::/7, fe80::/10)
+ *   - Reject known cloud-metadata hosts
+ *
+ * NOT mitigated here: DNS rebinding (an attacker DNS-resolved-allowed host
+ * can flip to 169.254.169.254 between this check and the fetch). For
+ * defense-in-depth, callers should additionally enforce a per-call timeout
+ * and reject redirects to internal addresses.
+ */
+
+const BLOCKED_HOSTS = new Set([
+  'localhost',
+  'metadata.google.internal',
+  'metadata.azure.com',
+  'metadata.azure.internal',
+  'kubernetes.default.svc',
+  'kubernetes.default.svc.cluster.local',
+]);
+
+function isPrivateIPv4(host: string): boolean {
+  const parts = host.split('.');
+  if (parts.length !== 4) return false;
+  const nums = parts.map((p) => Number(p));
+  if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = nums;
+  if (a === 10) return true;                       // 10.0.0.0/8
+  if (a === 127) return true;                      // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true;         // 169.254.0.0/16 link-local + AWS IMDS
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true;         // 192.168.0.0/16
+  if (a === 0) return true;                        // 0.0.0.0/8
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 carrier-grade NAT
+  if (a >= 224) return true;                       // 224.0.0.0/4 multicast + reserved
+  return false;
+}
+
+function isPrivateIPv6(host: string): boolean {
+  const lower = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (lower === '::1' || lower === '::') return true;
+  if (lower.startsWith('fe80:')) return true; // link-local
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // unique-local fc00::/7
+  // ::ffff:127.0.0.1 etc — reject IPv4-mapped IPv6 to private addresses
+  const v4Mapped = lower.match(/^::ffff:([0-9.]+)$/);
+  if (v4Mapped) return isPrivateIPv4(v4Mapped[1]);
+  return false;
+}
+
+export interface SafeUrlError {
+  reason: 'parse' | 'protocol' | 'host_empty' | 'host_blocked' | 'ip_private';
+  detail?: string;
+}
+
+export function checkSafeOutboundUrl(raw: string): SafeUrlError | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { reason: 'parse' };
+  }
+  if (parsed.protocol !== 'https:') {
+    return { reason: 'protocol', detail: parsed.protocol };
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!host) return { reason: 'host_empty' };
+  if (BLOCKED_HOSTS.has(host)) return { reason: 'host_blocked', detail: host };
+
+  if (isPrivateIPv4(host)) return { reason: 'ip_private', detail: host };
+  if (host.includes(':')) {
+    if (isPrivateIPv6(host)) return { reason: 'ip_private', detail: host };
+  }
+  // Non-hostname suffix wildcards we never want to allow
+  if (host.endsWith('.local') || host.endsWith('.internal')) {
+    return { reason: 'host_blocked', detail: host };
+  }
+  return null;
+}
+
+export function isSafeOutboundUrl(raw: string): boolean {
+  return checkSafeOutboundUrl(raw) === null;
+}
+
+export function assertSafeOutboundUrl(raw: string): void {
+  const err = checkSafeOutboundUrl(raw);
+  if (err) {
+    throw new Error(`unsafe_outbound_url:${err.reason}${err.detail ? `:${err.detail}` : ''}`);
+  }
+}

--- a/apps/web/lib/telegram-webhook-auth.ts
+++ b/apps/web/lib/telegram-webhook-auth.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
+
+const HEADER = 'x-telegram-bot-api-secret-token';
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export function verifyTelegramWebhook(request: NextRequest): NextResponse | null {
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'telegram_webhook_not_configured' }, { status: 503 });
+  }
+  const header = request.headers.get(HEADER) ?? '';
+  if (!safeEqual(header, secret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return null;
+}

--- a/apps/web/lib/user-session.ts
+++ b/apps/web/lib/user-session.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { secureCookieDefault } from './cookie-flags';
 
 /**
  * Lightweight HMAC-signed session cookie for the user auth flow.
@@ -85,7 +86,7 @@ export interface SessionCookieOptions {
 export function sessionCookieOptions(): SessionCookieOptions {
   return {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: secureCookieDefault(),
     sameSite: 'lax',
     path: '/',
     maxAge: USER_SESSION_MAX_AGE_SECONDS,

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,5 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// Edge-runtime safe constant-time string compare. `node:crypto.timingSafeEqual`
+// is not available on Vercel Edge — fall back to an XOR loop. The length
+// branch is fine here since the admin secret length is server-configured
+// and not attacker-influenced.
+function safeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
 // ---------------------------------------------------------------------------
 // 1. Rate-limit store (in-memory, per-IP, resets every 60 s)
 // ---------------------------------------------------------------------------
@@ -222,7 +235,9 @@ export function middleware(request: NextRequest) {
       // Check httpOnly cookie (for browser sessions)
       const cookieToken = request.cookies.get("tc_admin")?.value ?? null;
 
-      if (bearerToken !== adminSecret && cookieToken !== adminSecret) {
+      const bearerOk = bearerToken !== null && safeStringEqual(bearerToken, adminSecret);
+      const cookieOk = cookieToken !== null && safeStringEqual(cookieToken, adminSecret);
+      if (!bearerOk && !cookieOk) {
         // If it's a browser request (Accept: text/html), redirect to login
         const accept = request.headers.get("accept") ?? "";
         if (accept.includes("text/html")) {

--- a/docs/plans/2026-05-06-security-fixes.md
+++ b/docs/plans/2026-05-06-security-fixes.md
@@ -1,0 +1,74 @@
+# 2026-05-06 — Security Fix Sprint
+
+Source: `/security-review` + `/security-scan` run on `main` at `f7f8aaf` (2026-05-06).
+Total findings: 7 CRITICAL · 9 HIGH · 9 MEDIUM · 4 LOW.
+
+Branch: `fix/security-2026-05-06` (worktree `../tradeclaw-security`).
+
+## Commit plan (each ≤15 files)
+
+### Commit 1 — Cron auth + Telegram/TV gating
+Fixes: C1, C2, C3, C4, C5, C6, H3, H4, H8.
+
+Changes:
+- New `apps/web/lib/cron-auth.ts` — `requireCronAuth(request)` returns `Response | null`.
+  Behavior: if `CRON_SECRET` unset → 503 (`{ error: 'cron_not_configured' }`). Compares Bearer with `crypto.timingSafeEqual`. Length-mismatch returns 401 without timing leak.
+- Apply `requireCronAuth` to: `cron/execute`, `cron/manage-positions`, `cron/position-monitor`, `cron/sync`, `cron/signals`, `cron/telegram`, `cron/universe`, `alert-rules/dispatch`. Removes 7 copies of the broken `isAuthorized` (C1–C3, H4, H8).
+- New `apps/web/lib/telegram-webhook-auth.ts` — `verifyTelegramWebhookSecret(request)`.
+  Reads `TELEGRAM_WEBHOOK_SECRET`, requires `X-Telegram-Bot-Api-Secret-Token` header, timing-safe compare. Applied at `app/api/telegram/route.ts` POST before `update_id` dispatch (C5).
+- `app/api/telegram/broadcast/route.ts` — POST and GET both require admin OR cron-secret (C4).
+- `app/api/webhooks/tradingview/route.ts:86` — replace `secret !== expected` with `timingSafeEqual` (C6).
+- `.env.example` — add `TELEGRAM_WEBHOOK_SECRET`.
+- Tests:
+  - `apps/web/lib/__tests__/cron-auth.test.ts` (RED first).
+  - `apps/web/lib/__tests__/telegram-webhook-auth.test.ts`.
+  - Extend `apps/web/app/api/telegram/broadcast/__tests__/route.test.ts` (new).
+
+### Commit 2 — Auth hardening
+Fixes: C7, H1, H2, M3, L1, L3.
+
+Changes:
+- `apps/web/lib/admin-emails.ts` — remove `DEFAULT_ADMIN_EMAILS` and `DEFAULT_PRO_EMAILS` fallback when `NODE_ENV === 'production'`. Throw at module load if env missing in prod (H1).
+- `apps/web/lib/admin-gate.ts:29` — replace `===` with `crypto.timingSafeEqual` (H3). Verify `tc_admin` cookie issue path sets `Secure; HttpOnly; SameSite=Strict` (L3).
+- `apps/web/app/api/auth/magic-link/start/route.ts` — replace in-process `Map` with DB-backed rate limit (`magic_link_rate_limits` table). Set rate-limit row BEFORE issuing token (C7, H2). Drop `console.info(token)` even in dev (L1).
+- `apps/web/lib/magic-link.ts:38-49` — collapse SELECT+UPDATE into single `UPDATE … WHERE consumed_at IS NULL RETURNING email, expires_at` (M3).
+- New migration: `apps/web/migrations/023_magic_link_rate_limits.sql`.
+- Tests: extend `lib/__tests__/magic-link.test.ts` for race + new `magic-link/start/__tests__/route.test.ts`.
+
+### Commit 3 — Execution kill-switch + lock + log
+Fixes: H5, H6, M6, M9, L4.
+
+Changes:
+- `apps/web/lib/execution/risk-rails.ts:77-79` — `equityUsd <= 0 → halted: true` with reason `zero_equity` (H5).
+- `apps/web/lib/execution/executor.ts` — wrap tick in PG advisory lock (`pg_try_advisory_lock(hashtext('tradeclaw:executor'))`); skip with `{ skipped: 'locked' }` if not acquired (H6).
+- `apps/web/lib/execution/binance-futures.ts:358` — DRY-RUN log redacts to `{ symbol, side, action }` only (M6).
+- `docs/plans/2026-05-06-security-fixes.md` (this doc) — append "Trading firewall" section pointing at `executor.ts:36` `strategy_id = 'hmm-top3'` filter (M9).
+- New tests: `lib/execution/__tests__/risk-rails.test.ts` covering halt path (L4 + H5).
+
+### Commit 4 — SSRF + tier leak + EE webhook
+Fixes: H7, H9, M4, M5, L2.
+
+Changes:
+- `apps/web/lib/alert-channels.ts` — new `assertSafeOutboundUrl(u)` helper (HTTPS-only; reject localhost, RFC-1918, link-local, multicast, AWS IMDS, IPv6-private). Called from Discord (line 127) and generic webhook (line 154) before `fetch`. Same gate at the upsert path in `app/api/alert-channels/route.ts` POST.
+- `apps/web/app/api/v1/signals/route.ts` — drop `X-TradeClaw-Tier` header (H9). Switch authenticated paths to `Cache-Control: private, no-store`; keep public path on `s-maxage=60`.
+- `apps/web/lib/earningsedge/stripe.ts:74` — drop `|| process.env.STRIPE_WEBHOOK_SECRET` fallback; throw when `EE_STRIPE_WEBHOOK_SECRET` unset (M4).
+- `apps/web/lib/earningsedge/stripe.ts:84` — explicit `pro` ↔ `basic` price-id map; throw on unknown (L2).
+- `apps/web/app/api/earningsedge/webhook/route.ts` — call `tryClaimStripeEvent` before tier mutation (M5).
+- Tests: `lib/__tests__/alert-channels.test.ts` extends with SSRF cases.
+
+### Commit 5 — OAuth + session
+Fixes: M1, M2.
+
+Changes:
+- `apps/web/app/api/auth/google/callback/route.ts:119` — re-run `safeNext()` before constructing redirect URL (M1).
+- `apps/web/lib/user-session.ts:87` — default `secure: true`; allow `process.env.ALLOW_INSECURE_COOKIE === '1'` only as a local-dev escape hatch (M2).
+
+### Commit 6 — Error scrub + link-token body
+Fixes: M7, M8.
+
+Changes:
+- `apps/web/app/api/webhooks/tradingview/route.ts:127` — log full err server-side, return `{ error: 'db_error' }` only (M8).
+- `apps/web/app/api/telegram/link-token/route.ts:24-28` — drop `token` from response body, keep only `deepLink` and `expiresInSeconds` (M7). Update `__tests__/route.test.ts`.
+
+## Out of scope
+- Harness `/security-scan` — denied by sandbox (npx auto-install + scope outside project). User to grant `Bash(npx -y ecc-agentshield:*)` permission and re-run.

--- a/docs/plans/2026-05-06-security-fixes.md
+++ b/docs/plans/2026-05-06-security-fixes.md
@@ -70,5 +70,22 @@ Changes:
 - `apps/web/app/api/webhooks/tradingview/route.ts:127` — log full err server-side, return `{ error: 'db_error' }` only (M8).
 - `apps/web/app/api/telegram/link-token/route.ts:24-28` — drop `token` from response body, keep only `deepLink` and `expiresInSeconds` (M7). Update `__tests__/route.test.ts`.
 
+## Trading firewall (M9)
+
+The live executor at [apps/web/lib/execution/executor.ts] reads only signals
+where `strategy_id = 'hmm-top3'` (constant `STRATEGY_ID` at the top of the
+file, applied via the SQL filter at the `fetchPendingSignals` query).
+TradingView webhook strategies (`tv-zaky-classic`, `tv-hafiz-synergy`,
+`tv-impulse-hunter`) land in the **separate** `premium_signals` table via
+[apps/web/app/api/webhooks/tradingview/route.ts] and are never read by the
+executor.
+
+This is the firewall that keeps third-party webhook input out of live
+order placement. Do not loosen the `STRATEGY_ID` filter, do not add a
+`UNION` over `premium_signals`, and do not introduce a "signal source
+abstraction" that lets a TV alert flow into the executor without an
+explicit risk review. The block comment above `STRATEGY_ID` enforces the
+same warning at the source-code level.
+
 ## Out of scope
 - Harness `/security-scan` — denied by sandbox (npx auto-install + scope outside project). User to grant `Bash(npx -y ecc-agentshield:*)` permission and re-run.


### PR DESCRIPTION
Closes all 29 findings from the 2026-05-06 `/security-review` run on `main` at f7f8aaf.

**Scope:** auth (magic-link, OAuth, admin gates), payments (EarningsEdge webhook), live execution (Binance Futures kill-switch + lock), inbound webhooks (TradingView, Telegram), cron auth, SSRF, response-leak hygiene.

Plan doc: [`docs/plans/2026-05-06-security-fixes.md`](docs/plans/2026-05-06-security-fixes.md).

## Per-commit findings table

| Commit | Findings closed |
|---|---|
| `fix(security): close cron + telegram + tradingview auth gates` | C1 C2 C3 C4 C5 C6 H3 H4 H8 |
| `fix(auth): harden magic-link, admin gates, and tc_admin compares` | C7 H1 H2 M3 L1 L3 |
| `fix(execution): kill-switch fail-closed, advisory lock, log scrub` | H5 H6 M6 M9 L4 |
| `fix(security): SSRF allowlist, v1 tier-leak, earningsedge webhook` | H7 H9 M4 M5 L2 |
| `fix(auth): re-validate OAuth state.next, default-secure cookies` | M1 M2 |
| `fix(security): scrub TV webhook 500 body, drop link-token from response` | M7 M8 |

**Totals:** 7 CRITICAL + 9 HIGH + 9 MEDIUM + 4 LOW = 29/29.

## CRITICAL findings — what was fixed

| # | Issue | Fix |
|---|---|---|
| C1 | position-monitor cron open even on prod when CRON_SECRET unset | New lib/cron-auth.ts returns 503 when secret missing |
| C2 | 3 cron routes open in non-prod when CRON_SECRET unset | Same helper, applied to all |
| C3 | cron/sync falls open when CRON_SECRET unset | Same helper |
| C4 | /api/telegram/broadcast zero auth on GET+POST | Admin OR cron-secret via new assertAdminApi |
| C5 | /api/telegram no X-Telegram-Bot-Api-Secret-Token check | New lib/telegram-webhook-auth.ts |
| C6 | TradingView secret !== plain compare | crypto.timingSafeEqual |
| C7 | Magic-link writes DB token before in-process Map check | DB-backed rate-limit query, fires before issue |

## HIGH findings — what was fixed

| # | Issue | Fix |
|---|---|---|
| H1 | Hardcoded admin/Pro fallback emails | parseList returns empty Set in production |
| H2 | In-process rate-limit Map useless on serverless | DB-backed countRecentMagicLinkEmails |
| H3 | tc_admin cookie === compare (4 sites) | timingSafeEqual Node + XOR-loop in Edge middleware |
| H4 | Cron === Bearer compare (timing leak) | timingSafeEqual in requireCronAuth |
| H5 | Risk-rails kill switch fails OPEN at zero equity | equityUsd <= 0 → halted: true, reason zero_equity_kill |
| H6 | No advisory lock on overlapping executor ticks | pg_try_advisory_lock(hashtext(...)::bigint) |
| H7 | SSRF via user-supplied Discord/webhook URLs | New lib/safe-outbound-url.ts (HTTPS-only, blocks RFC-1918, IMDS, link-local, IPv6 ULA, metadata hosts) — write time + send time |
| H8 | alert-rules/dispatch open when CRON_SECRET unset | requireCronAuth |
| H9 | v1/signals X-TradeClaw-Tier CORS-readable | Header dropped; paid tier switched to Cache-Control private no-store |

## MEDIUM + LOW

M1 OAuth callback re-runs safeNext() · M2 secureCookieDefault() defaults true (opt-out via INSECURE_COOKIES=1) · M3 magic-link consume = single UPDATE...RETURNING · M4 EarningsEdge webhook secret no longer falls back to main · M5 EarningsEdge gets tryClaimStripeEvent idempotency (namespaced ee:) · M6 binance DRY-RUN log redacts to {symbol, action} · M7 link-token route drops token field from response body · M8 TV webhook 500 returns generic db_error only · M9 trading firewall (STRATEGY_ID = 'hmm-top3') documented in code + plan doc · L1 magic-link dev console.info dropped · L2 EarningsEdge price-id strict map (throws on unknown) · L3 tc_admin cookie raised to SameSite=strict · L4 risk-rails.test.ts covers the kill-switch halt path (the test that would have caught H5)

## Operator follow-up before deploy (BLOCKING)

- [ ] Set CRON_SECRET in production env (cron routes now 503 without it).
- [ ] Set TELEGRAM_WEBHOOK_SECRET and re-call Telegram setWebhook with the same value.
- [ ] Set EE_STRIPE_WEBHOOK_SECRET (no longer falls back to main STRIPE_WEBHOOK_SECRET).
- [ ] Set ADMIN_EMAILS and PRO_EMAILS in production (no more hardcoded fallbacks — empty env = no admin/Pro grants).
- [ ] Verify migration 022 (magic_link_tokens) is applied — used by the new rate-limit query.

## Test plan

- [x] New unit tests for cron-auth (8), telegram-webhook-auth (5), safe-outbound-url (26), risk-rails (6), magic-link race + rate-limit (9), v1/signals tier-header (2).
- [x] tsc --noEmit exit 0 across apps/web.
- [x] All pre-existing unit tests still pass (563/589 — the 26 skipped + 5 failing pre-date this branch and import from vitest which isn't installed).
- [ ] Deploy to a preview env with the env vars above set, smoke-test:
  - [ ] curl /api/cron/execute without bearer → 401
  - [ ] curl /api/cron/execute with wrong bearer → 401
  - [ ] curl /api/cron/execute with right bearer → 200
  - [ ] curl -X POST /api/telegram/broadcast without auth → 401
  - [ ] curl -X POST /api/telegram with update_id body, no secret-token header → 401
  - [ ] Magic-link /start rate limit fires on 2nd call within 60s
  - [ ] /api/v1/signals response no longer carries X-TradeClaw-Tier
  - [ ] Sign in via Google → cookie has Secure flag (preview env)
  - [ ] Pro user can still trigger admin broadcast button on /telegram

## Out of scope (deferred)

- Harness /security-scan was denied by sandbox (npx auto-install + scope outside project). Run after npm install -g ecc-agentshield if you want the ~/.claude config audit.
- 5 pre-existing test files import from vitest (not installed) — unrelated to security; would land as a separate test-infra cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)