### PR TITLE
feat: user profile in navbar + member/admin link split

### DIFF
--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { PageNavBar } from '../../components/PageNavBar';
+
+/**
+ * Admin shell — every page under /admin gets the same top navbar so operators
+ * have one consistent surface (Pro Grants, Social Queue, Executions, "Back to
+ * App") and a clear visual cue that they are in admin mode.
+ *
+ * The /admin/login page is the one exception: it intentionally has no chrome
+ * because the user has no session yet. Routing-wise it still inherits this
+ * layout, but PageNavBar's UserMenu correctly renders the "Sign in" CTA when
+ * there's no session, which is exactly what we want.
+ *
+ * Auth gating itself lives in `requireAdmin()` inside each admin page.tsx
+ * (a server-side check). This layout only adds chrome.
+ */
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageNavBar />
+      {children}
+    </>
+  );
+}

--- a/apps/web/app/api/alert-channels/__tests__/route.test.ts
+++ b/apps/web/app/api/alert-channels/__tests__/route.test.ts
@@ -44,6 +44,9 @@ function fakeUser(overrides: Partial<{ telegramUserId: bigint | null }> = {}) {
     tier: 'free' as const,
     tierExpiresAt: null,
     telegramUserId: null,
+    displayName: null,
+    avatarUrl: null,
+    authProvider: null,
     ...overrides,
   };
 }

--- a/apps/web/app/api/auth/github/callback/route.ts
+++ b/apps/web/app/api/auth/github/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { upsertUserProfile } from '../../../../../lib/db';
+import { safeAvatarUrl } from '../../../../../lib/avatar-url';
 import {
   USER_SESSION_COOKIE,
   createSessionToken,
@@ -124,10 +125,7 @@ export async function GET(request: NextRequest) {
     const rawName = (userJson.name ?? '').trim();
     const rawLogin = (userJson.login ?? '').trim();
     displayName = rawName || rawLogin || null;
-    avatarUrl =
-      typeof userJson.avatar_url === 'string' && userJson.avatar_url.startsWith('https://')
-        ? userJson.avatar_url
-        : null;
+    avatarUrl = safeAvatarUrl(userJson.avatar_url);
   } catch {
     return errorRedirect(request, 'oauth_network_error');
   }

--- a/apps/web/app/api/auth/github/callback/route.ts
+++ b/apps/web/app/api/auth/github/callback/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { upsertUserByEmail } from '../../../../../lib/db';
+import { upsertUserProfile } from '../../../../../lib/db';
 import {
   USER_SESSION_COOKIE,
   createSessionToken,
@@ -68,6 +68,8 @@ export async function GET(request: NextRequest) {
   }
 
   let email: string | null = null;
+  let displayName: string | null = null;
+  let avatarUrl: string | null = null;
   try {
     const tokenRes = await fetch(GITHUB_TOKEN_URL, {
       method: 'POST',
@@ -100,6 +102,9 @@ export async function GET(request: NextRequest) {
     if (!userRes.ok) return errorRedirect(request, 'userinfo_failed');
     const userJson = (await userRes.json()) as {
       email?: string | null;
+      name?: string | null;
+      login?: string | null;
+      avatar_url?: string | null;
     };
 
     const emailsRes = await fetch(GITHUB_EMAILS_URL, { headers: ghHeaders });
@@ -113,13 +118,28 @@ export async function GET(request: NextRequest) {
     }
 
     if (!email) return errorRedirect(request, 'email_unverified');
+
+    // GitHub `name` is optional; `login` (handle) is always present and
+    // is a fine fallback for the navbar greeting.
+    const rawName = (userJson.name ?? '').trim();
+    const rawLogin = (userJson.login ?? '').trim();
+    displayName = rawName || rawLogin || null;
+    avatarUrl =
+      typeof userJson.avatar_url === 'string' && userJson.avatar_url.startsWith('https://')
+        ? userJson.avatar_url
+        : null;
   } catch {
     return errorRedirect(request, 'oauth_network_error');
   }
 
   let userId: string;
   try {
-    const user = await upsertUserByEmail(email);
+    const user = await upsertUserProfile({
+      email,
+      displayName,
+      avatarUrl,
+      authProvider: 'github',
+    });
     userId = user.id;
   } catch {
     return errorRedirect(request, 'user_upsert_failed');

--- a/apps/web/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/google/callback/__tests__/route.test.ts
@@ -104,6 +104,9 @@ describe('GET /api/auth/google/callback', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const fetchMock = setFetch([
@@ -166,6 +169,9 @@ describe('GET /api/auth/google/callback', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     setFetch([
       { ok: true, json: async () => ({ access_token: 'gat_xyz' }) },
@@ -204,6 +210,9 @@ describe('GET /api/auth/google/callback', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     setFetch([
       { ok: true, json: async () => ({ access_token: 'gat_xyz' }) },

--- a/apps/web/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/google/callback/__tests__/route.test.ts
@@ -352,6 +352,51 @@ describe('GET /api/auth/google/callback', () => {
     expect(new URL(res.headers.get('location')!).searchParams.get('error')).toBe('google_access_denied');
   });
 
+  it('drops a non-allowlisted https avatar host (defends against hot-link of attacker domain)', async () => {
+    mockedDecodeState.mockReturnValue({
+      nonce: 'a'.repeat(32),
+      issuedAt: Date.now(),
+    });
+    mockedUpsertUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'naim@example.com',
+      stripeCustomerId: null,
+      tier: 'free',
+      tierExpiresAt: null,
+      telegramUserId: null,
+      displayName: 'Naim',
+      avatarUrl: null,
+      authProvider: 'google',
+    });
+    setFetch([
+      { ok: true, json: async () => ({ access_token: 'gat_xyz' }) },
+      {
+        ok: true,
+        json: async () => ({
+          email: 'naim@example.com',
+          email_verified: true,
+          name: 'Naim',
+          // Valid https but not on the avatar host allowlist — must be dropped.
+          picture: 'https://attacker.example.com/track.png',
+        }),
+      },
+    ]);
+
+    await GET(
+      makeRequest({
+        url: 'http://localhost:3000/api/auth/google/callback?code=auth_code&state=fake_state',
+        cookies: { tc_oauth_state: 'a'.repeat(32) },
+      }),
+    );
+
+    expect(mockedUpsertUser).toHaveBeenCalledWith({
+      email: 'naim@example.com',
+      displayName: 'Naim',
+      avatarUrl: null,
+      authProvider: 'google',
+    });
+  });
+
   it('drops a non-https picture URL and a missing name; persists nulls instead', async () => {
     mockedDecodeState.mockReturnValue({
       nonce: 'a'.repeat(32),

--- a/apps/web/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/google/callback/__tests__/route.test.ts
@@ -8,12 +8,17 @@
 import { NextRequest } from 'next/server';
 
 jest.mock('../../../../../../lib/db', () => ({
-  upsertUserByEmail: jest.fn(),
+  upsertUserProfile: jest.fn(),
 }));
 
 jest.mock('../../../../../../lib/oauth-state', () => ({
   OAUTH_STATE_COOKIE: 'tc_oauth_state',
   decodeState: jest.fn(),
+  // Pass-through: the route re-applies safeNext to state.next at read time.
+  // Real implementation is in lib/oauth-state.ts; the unit test only needs a
+  // stable identity function so the redirect-target logic exercises both
+  // branches deterministically.
+  safeNext: jest.fn((next: string | undefined | null) => next ?? null),
 }));
 
 jest.mock('../../../../../../lib/user-session', () => ({
@@ -28,12 +33,12 @@ jest.mock('../../../../../../lib/user-session', () => ({
   }),
 }));
 
-import { upsertUserByEmail } from '../../../../../../lib/db';
+import { upsertUserProfile } from '../../../../../../lib/db';
 import { decodeState } from '../../../../../../lib/oauth-state';
 import { createSessionToken } from '../../../../../../lib/user-session';
 import { GET } from '../route';
 
-const mockedUpsertUser = upsertUserByEmail as jest.MockedFunction<typeof upsertUserByEmail>;
+const mockedUpsertUser = upsertUserProfile as jest.MockedFunction<typeof upsertUserProfile>;
 const mockedDecodeState = decodeState as jest.MockedFunction<typeof decodeState>;
 const mockedCreateToken = createSessionToken as jest.MockedFunction<typeof createSessionToken>;
 
@@ -111,7 +116,15 @@ describe('GET /api/auth/google/callback', () => {
 
     const fetchMock = setFetch([
       { ok: true, json: async () => ({ access_token: 'gat_xyz' }) },
-      { ok: true, json: async () => ({ email: 'naim@example.com', email_verified: true }) },
+      {
+        ok: true,
+        json: async () => ({
+          email: 'naim@example.com',
+          email_verified: true,
+          name: 'Naim Katiman',
+          picture: 'https://lh3.googleusercontent.com/a/abc=s96-c',
+        }),
+      },
     ]);
 
     const res = await GET(
@@ -139,8 +152,13 @@ describe('GET /api/auth/google/callback', () => {
     expect(userinfoCall[0]).toBe('https://openidconnect.googleapis.com/v1/userinfo');
     expect(userinfoCall[1].headers.authorization).toBe('Bearer gat_xyz');
 
-    // User row written
-    expect(mockedUpsertUser).toHaveBeenCalledWith('naim@example.com');
+    // User row written with full profile
+    expect(mockedUpsertUser).toHaveBeenCalledWith({
+      email: 'naim@example.com',
+      displayName: 'Naim Katiman',
+      avatarUrl: 'https://lh3.googleusercontent.com/a/abc=s96-c',
+      authProvider: 'google',
+    });
     expect(mockedCreateToken).toHaveBeenCalledWith('user-1');
 
     // Session cookie set, state cookie deleted
@@ -332,5 +350,52 @@ describe('GET /api/auth/google/callback', () => {
 
     expect(res.status).toBe(302);
     expect(new URL(res.headers.get('location')!).searchParams.get('error')).toBe('google_access_denied');
+  });
+
+  it('drops a non-https picture URL and a missing name; persists nulls instead', async () => {
+    mockedDecodeState.mockReturnValue({
+      nonce: 'a'.repeat(32),
+      issuedAt: Date.now(),
+    });
+    mockedUpsertUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'naim@example.com',
+      stripeCustomerId: null,
+      tier: 'free',
+      tierExpiresAt: null,
+      telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: 'google',
+    });
+    setFetch([
+      { ok: true, json: async () => ({ access_token: 'gat_xyz' }) },
+      {
+        ok: true,
+        json: async () => ({
+          email: 'naim@example.com',
+          email_verified: true,
+          // attacker-controlled javascript: URL must NOT survive
+          picture: 'javascript:alert(1)',
+          // empty name → null, not empty string
+          name: '',
+        }),
+      },
+    ]);
+
+    const res = await GET(
+      makeRequest({
+        url: 'http://localhost:3000/api/auth/google/callback?code=auth_code&state=fake_state',
+        cookies: { tc_oauth_state: 'a'.repeat(32) },
+      }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(mockedUpsertUser).toHaveBeenCalledWith({
+      email: 'naim@example.com',
+      displayName: null,
+      avatarUrl: null,
+      authProvider: 'google',
+    });
   });
 });

--- a/apps/web/app/api/auth/google/callback/route.ts
+++ b/apps/web/app/api/auth/google/callback/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { upsertUserByEmail } from '../../../../../lib/db';
+import { upsertUserProfile } from '../../../../../lib/db';
 import {
   USER_SESSION_COOKIE,
   createSessionToken,
@@ -62,6 +62,8 @@ export async function GET(request: NextRequest) {
   }
 
   let email: string | null = null;
+  let displayName: string | null = null;
+  let avatarUrl: string | null = null;
   try {
     const tokenRes = await fetch(GOOGLE_TOKEN_URL, {
       method: 'POST',
@@ -85,18 +87,27 @@ export async function GET(request: NextRequest) {
     const userJson = (await userRes.json()) as {
       email?: string;
       email_verified?: boolean;
+      name?: string;
+      picture?: string;
     };
     if (!userJson.email || userJson.email_verified === false) {
       return errorRedirect(request, 'email_unverified');
     }
     email = userJson.email;
+    displayName = typeof userJson.name === 'string' && userJson.name.trim() ? userJson.name.trim() : null;
+    avatarUrl = typeof userJson.picture === 'string' && userJson.picture.startsWith('https://') ? userJson.picture : null;
   } catch {
     return errorRedirect(request, 'oauth_network_error');
   }
 
   let userId: string;
   try {
-    const user = await upsertUserByEmail(email);
+    const user = await upsertUserProfile({
+      email,
+      displayName,
+      avatarUrl,
+      authProvider: 'google',
+    });
     userId = user.id;
   } catch {
     return errorRedirect(request, 'user_upsert_failed');

--- a/apps/web/app/api/auth/google/callback/route.ts
+++ b/apps/web/app/api/auth/google/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { upsertUserProfile } from '../../../../../lib/db';
+import { safeAvatarUrl } from '../../../../../lib/avatar-url';
 import {
   USER_SESSION_COOKIE,
   createSessionToken,
@@ -95,7 +96,7 @@ export async function GET(request: NextRequest) {
     }
     email = userJson.email;
     displayName = typeof userJson.name === 'string' && userJson.name.trim() ? userJson.name.trim() : null;
-    avatarUrl = typeof userJson.picture === 'string' && userJson.picture.startsWith('https://') ? userJson.picture : null;
+    avatarUrl = safeAvatarUrl(userJson.picture);
   } catch {
     return errorRedirect(request, 'oauth_network_error');
   }

--- a/apps/web/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/app/api/auth/magic-link/verify/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { consumeMagicLink } from '../../../../../lib/magic-link';
+// TODO(magic-link): swap to upsertUserProfile once magic-link supports a
+// display name on the verify form. Until then magic-link users get
+// displayName/avatarUrl/authProvider all null, which the navbar handles
+// (initials fallback, no provider chip).
 import { upsertUserByEmail } from '../../../../../lib/db';
 import { createSessionToken, sessionCookieOptions, USER_SESSION_COOKIE } from '../../../../../lib/user-session';
 

--- a/apps/web/app/api/auth/session/route.ts
+++ b/apps/web/app/api/auth/session/route.ts
@@ -42,6 +42,9 @@ export async function GET(request: NextRequest) {
       subscriptionStatus: sub?.status ?? null,
       currentPeriodEnd: sub?.currentPeriodEnd.toISOString() ?? null,
       trialEnd: sub?.trialEnd?.toISOString() ?? null,
+      displayName: user.displayName,
+      avatarUrl: user.avatarUrl,
+      authProvider: user.authProvider,
     },
   });
 }

--- a/apps/web/app/api/stripe/checkout/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/checkout/__tests__/route.test.ts
@@ -95,6 +95,9 @@ describe('POST /api/stripe/checkout', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const sessionsCreate = jest.fn().mockResolvedValue({
@@ -138,6 +141,9 @@ describe('POST /api/stripe/checkout', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const sessionsCreate = jest.fn().mockResolvedValue({
@@ -168,6 +174,9 @@ describe('POST /api/stripe/checkout', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const sessionsCreate = jest.fn().mockRejectedValue(new Error('Stripe down'));

--- a/apps/web/app/api/stripe/portal/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/portal/__tests__/route.test.ts
@@ -56,6 +56,9 @@ describe('POST /api/stripe/portal', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const res = await POST(makeRequest());
@@ -72,6 +75,9 @@ describe('POST /api/stripe/portal', () => {
       tier: 'pro',
       tierExpiresAt: new Date(Date.now() + 30 * 86400 * 1000),
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const portalCreate = jest.fn().mockResolvedValue({
@@ -103,6 +109,9 @@ describe('POST /api/stripe/portal', () => {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const portalCreate = jest.fn().mockRejectedValue(new Error('Stripe down'));

--- a/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
@@ -236,6 +236,9 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
 
     const res = await POST(makeRequest());
@@ -300,6 +303,9 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     mockedSendDunning.mockResolvedValueOnce({ ok: false, reason: 'provider_error' });
 

--- a/apps/web/app/api/telegram/invite-status/__tests__/route.test.ts
+++ b/apps/web/app/api/telegram/invite-status/__tests__/route.test.ts
@@ -48,6 +48,9 @@ describe('GET /api/telegram/invite-status', () => {
       tier: 'free',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     mockedGetSub.mockResolvedValueOnce(null);
 
@@ -72,6 +75,9 @@ describe('GET /api/telegram/invite-status', () => {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: BigInt(42),
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     mockedGetSub.mockResolvedValueOnce({
       id: 'sub-1',
@@ -118,6 +124,9 @@ describe('GET /api/telegram/invite-status', () => {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: BigInt(42),
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     mockedGetSub.mockResolvedValueOnce(null);
     mockedGetInvite.mockResolvedValueOnce({
@@ -144,6 +153,9 @@ describe('GET /api/telegram/invite-status', () => {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: BigInt(42),
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
     });
     mockedGetSub.mockResolvedValueOnce(null);
     mockedGetInvite.mockResolvedValueOnce(null);

--- a/apps/web/app/api/telegram/resend-invite/__tests__/route.test.ts
+++ b/apps/web/app/api/telegram/resend-invite/__tests__/route.test.ts
@@ -40,6 +40,9 @@ function arrangeProUserWithLinkedTelegram() {
     tier: 'pro',
     tierExpiresAt: null,
     telegramUserId: BigInt(99999),
+    displayName: null,
+    avatarUrl: null,
+    authProvider: null,
   });
   mockedGetSub.mockResolvedValueOnce({
     id: 'sub-row-1',

--- a/apps/web/app/components/navbar.tsx
+++ b/apps/web/app/components/navbar.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { Play, Thermometer, ChevronDown, Activity, ShoppingBag, Briefcase, FlaskConical, BarChart2, Server, Star, Rocket, Mail, Heart, HandHeart, Cloud, MessageSquare, User, Database, BookOpen } from 'lucide-react';
 import { ThemeToggle } from './theme-toggle';
 import { TradeClawLogo } from '../../components/tradeclaw-logo';
-import { TierBadge } from '../../components/TierBadge';
+import { UserMenu } from '../../components/UserMenu';
 import type { LucideIcon } from 'lucide-react';
 
 interface NavLink {
@@ -181,7 +181,7 @@ export function Navbar() {
 
           {/* CTA */}
           <div className="flex items-center gap-2 shrink-0">
-            <TierBadge />
+            <UserMenu size="compact" />
             <Link
               href="/dashboard"
               className="hidden sm:flex items-center gap-1.5 text-xs font-medium text-emerald-400 hover:text-emerald-300 transition-colors duration-300"

--- a/apps/web/components/PageNavBar.tsx
+++ b/apps/web/components/PageNavBar.tsx
@@ -15,6 +15,10 @@ import {
   Wrench,
   Layers,
   Crosshair,
+  KeyRound,
+  Megaphone,
+  Activity,
+  ShieldCheck,
 } from 'lucide-react';
 import { TradeClawLogo } from './tradeclaw-logo';
 import { UserMenu } from './UserMenu';
@@ -31,7 +35,18 @@ interface DropdownGroup {
   links: NavLink[];
 }
 
-const PRIMARY_LINKS: { href: string; label: string }[] = [
+// ---------------------------------------------------------------------------
+// Link sets — picked at render time by `selectNav(pathname)`.
+//
+// MEMBER  → in-app links (default; covers /dashboard and every signed-in surface).
+// ADMIN   → /admin/* operator surface. Trading links are hidden so admins
+//           don't context-switch into the trader UI by accident; "Back to App"
+//           takes them to /dashboard.
+// ---------------------------------------------------------------------------
+
+interface PrimaryLink { href: string; label: string }
+
+const MEMBER_PRIMARY: PrimaryLink[] = [
   { href: '/dashboard', label: 'Signals' },
   { href: '/screener', label: 'Screener' },
   { href: '/backtest', label: 'Backtest' },
@@ -39,7 +54,7 @@ const PRIMARY_LINKS: { href: string; label: string }[] = [
   { href: '/track-record', label: 'Track Record' },
 ];
 
-const MORE_GROUPS: DropdownGroup[] = [
+const MEMBER_MORE: DropdownGroup[] = [
   {
     label: 'Trading Tools',
     links: [
@@ -73,15 +88,60 @@ const MORE_GROUPS: DropdownGroup[] = [
   },
 ];
 
-const ALL_MORE_HREFS = MORE_GROUPS.flatMap((g) => g.links.map((l) => l.href));
+const ADMIN_PRIMARY: PrimaryLink[] = [
+  { href: '/admin', label: 'Overview' },
+  { href: '/admin/pro-grants', label: 'Pro Grants' },
+  { href: '/admin/social-queue', label: 'Social Queue' },
+  { href: '/admin/executions', label: 'Executions' },
+  { href: '/dashboard', label: '↩ App' },
+];
+
+const ADMIN_MORE: DropdownGroup[] = [
+  {
+    label: 'Operations',
+    links: [
+      { href: '/admin/pro-grants', label: 'Pro Grants', icon: KeyRound },
+      { href: '/admin/social-queue', label: 'Social Queue', icon: Megaphone },
+      { href: '/admin/executions', label: 'Executions', icon: Activity },
+    ],
+  },
+  {
+    label: 'Surfaces',
+    links: [
+      { href: '/track-record', label: 'Public Track Record', icon: ShieldCheck },
+      { href: '/dashboard', label: 'User Dashboard', icon: BarChart2 },
+    ],
+  },
+];
+
+interface NavSet {
+  primary: PrimaryLink[];
+  more: DropdownGroup[];
+  /** Discriminator used in component logic (e.g. accent colors for admin). */
+  variant: 'member' | 'admin';
+}
+
+function selectNav(pathname: string): NavSet {
+  if (pathname === '/admin' || pathname.startsWith('/admin/')) {
+    return { primary: ADMIN_PRIMARY, more: ADMIN_MORE, variant: 'admin' };
+  }
+  return { primary: MEMBER_PRIMARY, more: MEMBER_MORE, variant: 'member' };
+}
 
 export function PageNavBar() {
   const pathname = usePathname();
   const [moreOpen, setMoreOpen] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
 
-  const isActive = (href: string) => pathname === href || pathname.startsWith(href + '/');
-  const moreHasActive = ALL_MORE_HREFS.some(isActive);
+  const navSet = selectNav(pathname ?? '/');
+  const { primary: PRIMARY_LINKS, more: MORE_GROUPS, variant } = navSet;
+  const allMoreHrefs = MORE_GROUPS.flatMap((g) => g.links.map((l) => l.href));
+
+  // /admin/x must NOT highlight /admin overview just because pathname starts
+  // with '/admin'. Use exact-match for the overview entry.
+  const isActive = (href: string) =>
+    href === '/admin' ? pathname === '/admin' : pathname === href || pathname.startsWith(href + '/');
+  const moreHasActive = allMoreHrefs.some(isActive);
 
   // Close dropdown on click outside
   useEffect(() => {
@@ -109,7 +169,14 @@ export function PageNavBar() {
     }`;
 
   return (
-    <nav className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--background)]/90 backdrop-blur-xl">
+    <nav
+      className={`sticky top-0 z-50 border-b backdrop-blur-xl ${
+        variant === 'admin'
+          ? 'border-amber-500/20 bg-amber-950/20'
+          : 'border-[var(--border)] bg-[var(--background)]/90'
+      }`}
+      aria-label={variant === 'admin' ? 'Admin navigation' : 'Member navigation'}
+    >
       <div className="max-w-7xl mx-auto px-4 h-14 flex items-center gap-4">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-1.5 shrink-0">
@@ -117,6 +184,11 @@ export function PageNavBar() {
           <span className="text-sm font-semibold">
             Trade<span className="text-emerald-400">Claw</span>
           </span>
+          {variant === 'admin' && (
+            <span className="ml-1 text-[9px] uppercase tracking-widest font-bold text-amber-400 bg-amber-500/10 border border-amber-500/30 px-1.5 py-0.5 rounded">
+              Admin
+            </span>
+          )}
         </Link>
 
         {/* Desktop: Primary links + More dropdown */}

--- a/apps/web/components/PageNavBar.tsx
+++ b/apps/web/components/PageNavBar.tsx
@@ -17,6 +17,7 @@ import {
   Crosshair,
 } from 'lucide-react';
 import { TradeClawLogo } from './tradeclaw-logo';
+import { UserMenu } from './UserMenu';
 import type { LucideIcon } from 'lucide-react';
 
 interface NavLink {
@@ -119,7 +120,7 @@ export function PageNavBar() {
         </Link>
 
         {/* Desktop: Primary links + More dropdown */}
-        <div className="hidden md:flex items-center gap-1 ml-auto">
+        <div className="hidden md:flex items-center gap-1 ml-auto mr-2">
           {PRIMARY_LINKS.map((page) => (
             <Link
               key={page.href}
@@ -188,7 +189,10 @@ export function PageNavBar() {
           </div>
         </div>
 
-        {/* Mobile: just the logo is shown — mobile-nav.tsx handles bottom navigation */}
+        {/* Identity affordance — visible on all breakpoints. */}
+        <div className="ml-auto md:ml-0 flex items-center">
+          <UserMenu />
+        </div>
       </div>
     </nav>
   );

--- a/apps/web/components/UserMenu.tsx
+++ b/apps/web/components/UserMenu.tsx
@@ -95,7 +95,10 @@ export function UserMenu({ size = 'default' }: UserMenuProps) {
     try {
       await fetch('/api/auth/session', { method: 'DELETE' });
     } finally {
-      // Hard navigation so server components re-resolve the cleared cookie.
+      // Hard navigation forces server components to re-resolve the cleared
+      // cookie. Awaiting the DELETE first means the Set-Cookie header has
+      // landed before this redirect; `finally` runs even on network failure
+      // so the user is never stranded on a "signed-in" UI after clicking.
       window.location.href = '/';
     }
   }

--- a/apps/web/components/UserMenu.tsx
+++ b/apps/web/components/UserMenu.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { ChevronDown, LogOut, CreditCard, ShieldCheck, User } from 'lucide-react';
+import { useUserSession, type ClientSession } from '../lib/hooks/use-user-tier';
+
+interface UserMenuProps {
+  /**
+   * Visual density. `compact` matches the rounded-pill marketing navbar;
+   * `default` matches the in-app sticky navbar.
+   */
+  size?: 'compact' | 'default';
+}
+
+function tierPillClasses(tier: ClientSession['tier']): string {
+  if (tier === 'free') {
+    return 'bg-zinc-800/80 text-zinc-300 border border-zinc-700/50';
+  }
+  return 'bg-emerald-500/15 text-emerald-400 border border-emerald-500/30';
+}
+
+function initialsOf(session: ClientSession): string {
+  const source = (session.displayName ?? session.email ?? '').trim();
+  if (!source) return '?';
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+  return source.slice(0, 2).toUpperCase();
+}
+
+function AvatarImage({ session }: { session: ClientSession }) {
+  const [errored, setErrored] = useState(false);
+  if (!session.avatarUrl || errored) {
+    return (
+      <span className="grid h-7 w-7 place-items-center rounded-full bg-emerald-500/15 text-[10px] font-semibold text-emerald-400 border border-emerald-500/20">
+        {initialsOf(session)}
+      </span>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- avatar URL is on a third-party CDN, Next/Image would require allow-listing every provider
+    <img
+      src={session.avatarUrl}
+      alt=""
+      width={28}
+      height={28}
+      referrerPolicy="no-referrer"
+      onError={() => setErrored(true)}
+      className="h-7 w-7 rounded-full object-cover border border-white/10"
+    />
+  );
+}
+
+/**
+ * Identity affordance for the navbar.
+ *
+ *  - Anonymous → renders a "Sign in" link to /signin.
+ *  - Authenticated → avatar + tier pill + dropdown (Profile, Billing, Sign out).
+ *
+ * Used by both the marketing navbar and the in-app PageNavBar so the same
+ * "I'm logged in as X" cue follows the user across surfaces.
+ */
+export function UserMenu({ size = 'default' }: UserMenuProps) {
+  const { status, session } = useUserSession();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  if (status === 'loading') {
+    // Reserve space — avoids layout shift when the session resolves.
+    return <span className="h-7 w-7 rounded-full bg-white/5 animate-pulse" aria-hidden="true" />;
+  }
+
+  if (status === 'anonymous' || !session) {
+    const cls =
+      size === 'compact'
+        ? 'rounded-full bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-400 hover:bg-emerald-500/25 border border-emerald-500/30 transition-colors'
+        : 'rounded-lg bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-400 hover:bg-emerald-500/25 border border-emerald-500/30 transition-colors';
+    return (
+      <Link href="/signin" className={cls} data-testid="user-menu-signin">
+        Sign in
+      </Link>
+    );
+  }
+
+  async function signOut() {
+    try {
+      await fetch('/api/auth/session', { method: 'DELETE' });
+    } finally {
+      // Hard navigation so server components re-resolve the cleared cookie.
+      window.location.href = '/';
+    }
+  }
+
+  const tierLabel = session.tier.toUpperCase();
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="user-menu-trigger"
+        className="flex items-center gap-2 rounded-full pl-1 pr-2 py-1 hover:bg-white/5 transition-colors"
+      >
+        <AvatarImage session={session} />
+        <span
+          className={`hidden sm:inline-flex text-[10px] px-2 py-0.5 rounded-full font-semibold uppercase tracking-wider ${tierPillClasses(
+            session.tier,
+          )}`}
+        >
+          {tierLabel}
+        </span>
+        <ChevronDown className={`w-3 h-3 text-zinc-400 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute top-full right-0 mt-2 w-60 rounded-xl border border-[var(--border)] bg-[var(--bg-card)]/95 backdrop-blur-2xl shadow-2xl shadow-black/40 p-1.5 z-50"
+        >
+          <div className="px-3 py-2 border-b border-white/[0.06] mb-1">
+            <p className="text-xs font-semibold text-white truncate">
+              {session.displayName ?? session.email}
+            </p>
+            <p className="text-[11px] text-zinc-500 truncate">{session.email}</p>
+            {session.authProvider && (
+              <p className="text-[10px] text-zinc-600 mt-0.5 uppercase tracking-wider">
+                via {session.authProvider}
+              </p>
+            )}
+          </div>
+
+          <Link
+            href="/settings"
+            onClick={() => setOpen(false)}
+            role="menuitem"
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs text-zinc-300 hover:bg-white/5 hover:text-white"
+          >
+            <User className="w-3.5 h-3.5" />
+            Profile & Settings
+          </Link>
+          <Link
+            href={session.tier === 'free' ? '/pricing?from=usermenu' : '/dashboard/billing'}
+            onClick={() => setOpen(false)}
+            role="menuitem"
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs text-zinc-300 hover:bg-white/5 hover:text-white"
+          >
+            <CreditCard className="w-3.5 h-3.5" />
+            {session.tier === 'free' ? 'Upgrade to Pro' : 'Billing'}
+          </Link>
+          {session.isAdmin && (
+            <Link
+              href="/admin"
+              onClick={() => setOpen(false)}
+              role="menuitem"
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs text-emerald-400 hover:bg-emerald-500/10"
+            >
+              <ShieldCheck className="w-3.5 h-3.5" />
+              Admin Dashboard
+            </Link>
+          )}
+          <button
+            type="button"
+            onClick={signOut}
+            role="menuitem"
+            data-testid="user-menu-signout"
+            className="w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs text-zinc-300 hover:bg-white/5 hover:text-white"
+          >
+            <LogOut className="w-3.5 h-3.5" />
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/avatar-url.ts
+++ b/apps/web/lib/avatar-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Allowlist for OAuth-provided avatar URLs.
+ *
+ * Only Google's `lh*.googleusercontent.com` and GitHub's
+ * `avatars.githubusercontent.com` host avatars on https. Anything else
+ * coming back from the IdP — a redirect, a custom-domain CDN, a
+ * hand-rolled URL — gets dropped to null at signin time so the navbar
+ * never hot-links an attacker-controlled domain. Cheaper than tightening
+ * the application-wide CSP for one feature.
+ */
+const ALLOWED_AVATAR_HOSTS = [
+  'lh3.googleusercontent.com',
+  'lh4.googleusercontent.com',
+  'lh5.googleusercontent.com',
+  'lh6.googleusercontent.com',
+  'avatars.githubusercontent.com',
+];
+
+export function safeAvatarUrl(input: unknown): string | null {
+  if (typeof input !== 'string' || !input) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!ALLOWED_AVATAR_HOSTS.includes(parsed.hostname)) return null;
+  return parsed.toString();
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -33,7 +33,7 @@ export interface UserRecord {
   telegramUserId: bigint | null;
   displayName: string | null;
   avatarUrl: string | null;
-  authProvider: 'google' | 'github' | 'email' | null;
+  authProvider: 'google' | 'github' | null;
 }
 
 export interface SubscriptionRecord {
@@ -90,7 +90,7 @@ function toUserRecord(row: UserRow): UserRecord {
     displayName: row.name,
     avatarUrl: row.avatar_url,
     authProvider:
-      row.auth_provider === 'google' || row.auth_provider === 'github' || row.auth_provider === 'email'
+      row.auth_provider === 'google' || row.auth_provider === 'github'
         ? row.auth_provider
         : null,
   };
@@ -196,14 +196,18 @@ export interface UserProfileInput {
    * we never overwrite an existing auth_provider so the UI doesn't flip
    * between Google and GitHub when the same email signs in via both.
    */
-  authProvider: 'google' | 'github' | 'email';
+  authProvider: 'google' | 'github';
 }
 
 /**
  * Find-or-create a user by email and refresh their profile fields. Display
- * name and avatar are overwritten on every call (so a user who changes their
- * Google photo gets the new one on next sign-in); auth_provider is set only
- * when the row is first created.
+ * name and avatar mirror what the provider returned on this sign-in — so a
+ * user who changes their Google photo gets the new one (and a user who
+ * removes it gets a null, which the UserMenu falls back to initials for).
+ *
+ * `auth_provider` is set only when the row is first created; subsequent
+ * sign-ins via a different provider don't overwrite it (avoids confusing
+ * "via google" / "via github" flips when the same email signs in via both).
  */
 export async function upsertUserProfile(input: UserProfileInput): Promise<UserRecord> {
   const normalized = input.email.trim().toLowerCase();
@@ -211,8 +215,8 @@ export async function upsertUserProfile(input: UserProfileInput): Promise<UserRe
     `INSERT INTO users (email, name, avatar_url, auth_provider)
      VALUES ($1, $2, $3, $4)
      ON CONFLICT (email) DO UPDATE SET
-       name       = COALESCE(EXCLUDED.name, users.name),
-       avatar_url = COALESCE(EXCLUDED.avatar_url, users.avatar_url),
+       name       = EXCLUDED.name,
+       avatar_url = EXCLUDED.avatar_url,
        updated_at = NOW()
      RETURNING ${USER_COLUMNS}`,
     [normalized, input.displayName, input.avatarUrl, input.authProvider],

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -31,6 +31,9 @@ export interface UserRecord {
   tier: 'free' | 'pro' | 'elite' | 'custom';
   tierExpiresAt: Date | null;
   telegramUserId: bigint | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  authProvider: 'google' | 'github' | 'email' | null;
 }
 
 export interface SubscriptionRecord {
@@ -71,6 +74,9 @@ interface UserRow {
   tier: string;
   tier_expires_at: string | null;
   telegram_user_id: string | null;
+  name: string | null;
+  avatar_url: string | null;
+  auth_provider: string | null;
 }
 
 function toUserRecord(row: UserRow): UserRecord {
@@ -81,8 +87,17 @@ function toUserRecord(row: UserRow): UserRecord {
     tier: row.tier as UserRecord['tier'],
     tierExpiresAt: row.tier_expires_at ? new Date(row.tier_expires_at) : null,
     telegramUserId: row.telegram_user_id ? BigInt(row.telegram_user_id) : null,
+    displayName: row.name,
+    avatarUrl: row.avatar_url,
+    authProvider:
+      row.auth_provider === 'google' || row.auth_provider === 'github' || row.auth_provider === 'email'
+        ? row.auth_provider
+        : null,
   };
 }
+
+const USER_COLUMNS = `id, email, stripe_customer_id, tier, tier_expires_at,
+  telegram_user_id, name, avatar_url, auth_provider`;
 
 interface SubscriptionRow {
   id: string;
@@ -135,11 +150,13 @@ export async function getUserById(userId: string): Promise<UserRecord | null> {
       tier: 'pro',
       tierExpiresAt: null,
       telegramUserId: null,
+      displayName: 'E2E Pro User',
+      avatarUrl: null,
+      authProvider: null,
     };
   }
   const row = await queryOne<UserRow>(
-    `SELECT id, email, stripe_customer_id, tier, tier_expires_at, telegram_user_id
-     FROM users WHERE id = $1`,
+    `SELECT ${USER_COLUMNS} FROM users WHERE id = $1`,
     [userId],
   );
   return row ? toUserRecord(row) : null;
@@ -147,8 +164,7 @@ export async function getUserById(userId: string): Promise<UserRecord | null> {
 
 export async function getUserByEmail(email: string): Promise<UserRecord | null> {
   const row = await queryOne<UserRow>(
-    `SELECT id, email, stripe_customer_id, tier, tier_expires_at, telegram_user_id
-     FROM users WHERE email = $1`,
+    `SELECT ${USER_COLUMNS} FROM users WHERE email = $1`,
     [email.toLowerCase()],
   );
   return row ? toUserRecord(row) : null;
@@ -164,10 +180,44 @@ export async function upsertUserByEmail(email: string): Promise<UserRecord> {
     `INSERT INTO users (email)
      VALUES ($1)
      ON CONFLICT (email) DO UPDATE SET updated_at = NOW()
-     RETURNING id, email, stripe_customer_id, tier, tier_expires_at, telegram_user_id`,
+     RETURNING ${USER_COLUMNS}`,
     [normalized],
   );
   if (!row) throw new Error('upsertUserByEmail: insert returned no row');
+  return toUserRecord(row);
+}
+
+export interface UserProfileInput {
+  email: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  /**
+   * Provider used for THIS sign-in. Only persisted on the first row insert —
+   * we never overwrite an existing auth_provider so the UI doesn't flip
+   * between Google and GitHub when the same email signs in via both.
+   */
+  authProvider: 'google' | 'github' | 'email';
+}
+
+/**
+ * Find-or-create a user by email and refresh their profile fields. Display
+ * name and avatar are overwritten on every call (so a user who changes their
+ * Google photo gets the new one on next sign-in); auth_provider is set only
+ * when the row is first created.
+ */
+export async function upsertUserProfile(input: UserProfileInput): Promise<UserRecord> {
+  const normalized = input.email.trim().toLowerCase();
+  const row = await queryOne<UserRow>(
+    `INSERT INTO users (email, name, avatar_url, auth_provider)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (email) DO UPDATE SET
+       name       = COALESCE(EXCLUDED.name, users.name),
+       avatar_url = COALESCE(EXCLUDED.avatar_url, users.avatar_url),
+       updated_at = NOW()
+     RETURNING ${USER_COLUMNS}`,
+    [normalized, input.displayName, input.avatarUrl, input.authProvider],
+  );
+  if (!row) throw new Error('upsertUserProfile: insert returned no row');
   return toUserRecord(row);
 }
 
@@ -175,8 +225,7 @@ export async function getUserByStripeCustomerId(
   stripeCustomerId: string,
 ): Promise<UserRecord | null> {
   const row = await queryOne<UserRow>(
-    `SELECT id, email, stripe_customer_id, tier, tier_expires_at, telegram_user_id
-     FROM users WHERE stripe_customer_id = $1`,
+    `SELECT ${USER_COLUMNS} FROM users WHERE stripe_customer_id = $1`,
     [stripeCustomerId],
   );
   return row ? toUserRecord(row) : null;
@@ -217,8 +266,7 @@ export async function getUserByTelegramId(
   telegramUserId: bigint,
 ): Promise<UserRecord | null> {
   const row = await queryOne<UserRow>(
-    `SELECT id, email, stripe_customer_id, tier, tier_expires_at, telegram_user_id
-     FROM users WHERE telegram_user_id = $1`,
+    `SELECT ${USER_COLUMNS} FROM users WHERE telegram_user_id = $1`,
     [telegramUserId.toString()],
   );
   return row ? toUserRecord(row) : null;

--- a/apps/web/lib/hooks/use-user-tier.ts
+++ b/apps/web/lib/hooks/use-user-tier.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 export type ClientTier = 'free' | 'pro' | 'elite' | 'custom';
 export type ClientSubscriptionStatus = 'active' | 'past_due' | 'canceled' | 'trialing' | null;
+export type ClientAuthProvider = 'google' | 'github' | 'email' | null;
 
 export interface ClientSession {
   userId: string;
@@ -25,6 +26,12 @@ export interface ClientSession {
    * future. Null for non-trial subs.
    */
   trialEnd: string | null;
+  /** Display name from Google's `name` or GitHub's `name`/`login`. Null for legacy email-only rows. */
+  displayName: string | null;
+  /** Profile image from Google `picture` or GitHub `avatar_url`. Always https. */
+  avatarUrl: string | null;
+  /** Provider used for the row's first-ever sign-in. Never updated thereafter. */
+  authProvider: ClientAuthProvider;
 }
 
 interface SessionResponse {

--- a/apps/web/lib/hooks/use-user-tier.ts
+++ b/apps/web/lib/hooks/use-user-tier.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 export type ClientTier = 'free' | 'pro' | 'elite' | 'custom';
 export type ClientSubscriptionStatus = 'active' | 'past_due' | 'canceled' | 'trialing' | null;
-export type ClientAuthProvider = 'google' | 'github' | 'email' | null;
+export type ClientAuthProvider = 'google' | 'github' | null;
 
 export interface ClientSession {
   userId: string;

--- a/apps/web/migrations/027_user_profile.sql
+++ b/apps/web/migrations/027_user_profile.sql
@@ -1,0 +1,21 @@
+-- User profile fields captured from OAuth providers.
+--
+-- The users.name column already exists (migration 001_monetization.sql) and
+-- is reused for display name. This migration adds:
+--
+--   * avatar_url     — profile image URL from Google's `picture` field or
+--                      GitHub's `avatar_url` field. Captured at sign-in and
+--                      refreshed on every successful OAuth callback.
+--   * auth_provider  — 'google' | 'github'. Recorded once on first sign-in
+--                      so we can render the correct provider chip in the UI
+--                      and never overwrite it (avoids confusing flips when a
+--                      user later signs in via a different provider that
+--                      resolves to the same email).
+--
+-- All additions are nullable; no backfill is required. Existing rows keep
+-- working — the navbar falls back to a User icon + email when fields are null.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS avatar_url    TEXT NULL,
+  ADD COLUMN IF NOT EXISTS auth_provider VARCHAR(16) NULL
+    CHECK (auth_provider IS NULL OR auth_provider IN ('google', 'github', 'email'));

--- a/apps/web/migrations/027_user_profile.sql
+++ b/apps/web/migrations/027_user_profile.sql
@@ -18,4 +18,4 @@
 ALTER TABLE users
   ADD COLUMN IF NOT EXISTS avatar_url    TEXT NULL,
   ADD COLUMN IF NOT EXISTS auth_provider VARCHAR(16) NULL
-    CHECK (auth_provider IS NULL OR auth_provider IN ('google', 'github', 'email'));
+    CHECK (auth_provider IS NULL OR auth_provider IN ('google', 'github'));

--- a/docs/plans/2026-05-07-user-profile-and-nav-split.md
+++ b/docs/plans/2026-05-07-user-profile-and-nav-split.md
@@ -1,0 +1,58 @@
+# 2026-05-07 — User profile in navbar + member/admin separation
+
+## Goal
+
+Two outcomes:
+1. Logged-in users see their Google/GitHub identity (avatar + display name) in the top bar so the "am I signed in?" question is answered at a glance.
+2. The in-app navbar adapts its center link-set to the current section (public marketing, member app, admin) so each audience sees only their own surface.
+
+## Approved scope
+
+- DB schema additions: `users.avatar_url`, `users.auth_provider`. The `users.name` column already exists from migration `001_monetization.sql` and will be reused for display name.
+- OAuth callbacks (`/api/auth/google/callback`, `/api/auth/github/callback`) capture `name`, picture/avatar URL, and provider, and persist on every successful sign-in (so a user who changes their photo upstream gets a refresh on their next sign-in).
+- `/api/auth/session` returns `displayName`, `avatarUrl`, `authProvider` alongside the existing tier fields.
+- New `UserMenu` component (avatar with fallback, tier pill, dropdown: Profile/Billing/Sign out). Anonymous renders a `Sign in` button.
+- `PageNavBar` (the in-app sticky navbar at the top of the dashboard / screener / backtest / etc.) becomes pathname-aware: a `MEMBER_LINKS` set when on member routes, an `ADMIN_LINKS` set when on `/admin/*`, default = current `PRIMARY_LINKS`. UserMenu placed at the right.
+- Marketing `Navbar` (the rounded-pill one on `/`) gets the same `UserMenu` next to its existing "Star on GitHub" CTA so identity carries across pages.
+- `app/admin/layout.tsx` (new) wraps `/admin/*` so the admin navbar variant renders consistently on every admin page.
+
+## Out of scope (deferred)
+
+- Custom avatar upload / library integration (Gravatar fallback). User-supplied photos can be added later.
+- Migrating away from email-as-primary-key to OAuth `provider+sub` identifiers. Today's email-merge behavior is preserved.
+- Changing the marketing navbar's visual design; only the right-side CTA group gains a UserMenu.
+- Reorganising the admin tile grid; today's tile layout stays.
+
+## Member route list (confirmed)
+
+`/dashboard`, `/screener`, `/backtest`, `/leaderboard`, `/track-record`, `/strategy-builder`, `/multi-timeframe`, `/paper-trading`, `/commentary`, `/journal`, `/glossary`, `/notifications`, `/alerts`, `/api-keys`, `/api-usage`, `/portfolio`, `/settings`.
+
+Track Record stays accessible to anonymous visitors as well — it's a marketing/proof page — so it appears in both public and member nav.
+
+## Admin route list
+
+`/admin`, `/admin/pro-grants`, `/admin/social-queue`, `/admin/executions` plus external links (Stripe, Railway).
+
+## Build sequence (one commit per layer)
+
+| # | Layer | Files | Verification |
+|---|---|---|---|
+| 1 | Migration + db.ts | `apps/web/migrations/027_user_profile.sql` (new), `apps/web/lib/db.ts` (extend `UserRecord`/`UserRow`, add `upsertUserProfile`) | `npm run build` in `apps/web`. New SQL is idempotent (`IF NOT EXISTS`). |
+| 2 | OAuth callbacks | `apps/web/app/api/auth/google/callback/route.ts`, `apps/web/app/api/auth/github/callback/route.ts` | Type-check. Manual local sign-in optional. |
+| 3 | Session API + hook | `apps/web/app/api/auth/session/route.ts`, `apps/web/lib/hooks/use-user-tier.ts` (extend `ClientSession`) | Type-check. |
+| 4 | UserMenu component | new `apps/web/components/UserMenu.tsx`, replace `TierBadge` slot in `apps/web/app/components/navbar.tsx`, add to `apps/web/components/PageNavBar.tsx` right side | Visual smoke test. |
+| 5 | Pathname-aware nav | `apps/web/components/PageNavBar.tsx` (link-set switch), new `apps/web/app/admin/layout.tsx` | Type-check. Smoke test: `/dashboard` shows member links; `/admin` shows admin links; `/` shows marketing links. |
+
+## Risks
+
+- **OAuth provider field**: store as `'google' | 'github' | null`. We never overwrite once set — first provider wins (avoids confusing flips on cross-provider sign-in with same email).
+- **Avatar URLs are hot-linked**: rendered with `referrerpolicy="no-referrer"` and a `User` lucide fallback if the image errors out.
+- **Migration on shared prod**: idempotent `ADD COLUMN IF NOT EXISTS`, no backfill, no data risk.
+- **TierBadge consumers**: `TierBadge` is imported only in the marketing `navbar.tsx`. UserMenu absorbs its responsibility; the file stays exported in case other surfaces want a standalone tier pill.
+
+## Verification gate
+
+After all 5 commits:
+1. `npm run -s typecheck` (or `tsc --noEmit`) clean inside `apps/web`.
+2. `npm run -s lint --silent` clean for the changed files.
+3. Smoke matrix: anonymous on `/dashboard` (redirect to /signin) ✓; signed-in member on `/dashboard` (member links + UserMenu) ✓; admin on `/admin` (admin links + UserMenu) ✓.


### PR DESCRIPTION
## Summary
- OAuth signin (Google + GitHub) now captures display name, avatar URL, and provider; stored on every successful callback (avatar refreshes on next signin)
- New `UserMenu` component renders the avatar + tier pill + dropdown (Profile, Billing, Sign out, Admin entry when applicable) on both the marketing navbar and the in-app `PageNavBar`
- `PageNavBar` is now pathname-aware: `/admin/*` swaps to operator links (Pro Grants, Social Queue, Executions) and gains an amber accent + "Admin" pill so privileged surfaces are visually distinct
- New `app/admin/layout.tsx` wraps every admin page so admins see consistent chrome (previously the admin index had no navbar)

## Migration
`apps/web/migrations/027_user_profile.sql` — adds `users.avatar_url` (text) and `users.auth_provider` (varchar(16) with CHECK 'google'|'github'). Idempotent, additive, no backfill. Auto-applied by `docker-entrypoint.sh` on next Railway deploy.

## Security hardening (post-review)
- Avatar URLs filtered through a CDN allowlist (`lh3-6.googleusercontent.com`, `avatars.githubusercontent.com`) — defends against attacker-controlled hot-link domains stored in the DB
- `auth_provider` set on insert only; subsequent signins via different providers don't overwrite (avoids confusing UI flips)
- Sign-out awaits DELETE before hard reload so cookie clearing isn't racy

## Plan doc
[docs/plans/2026-05-07-user-profile-and-nav-split.md](docs/plans/2026-05-07-user-profile-and-nav-split.md)

## Test plan
- [x] TypeScript clean for changed files (only pre-existing errors remain — same on main)
- [x] Jest: 770 passed (main: 766) — added 2 new Google callback tests, fixed pre-existing missing-mock failure in oauth-state
- [ ] Post-deploy: anonymous on `/dashboard` redirects to `/signin` (existing gate)
- [ ] Post-deploy: signed-in member on `/dashboard` shows avatar + tier pill + dropdown
- [ ] Post-deploy: admin on `/admin` shows amber-accented navbar with admin links
- [ ] Post-deploy: clicking Sign out clears cookie and reloads to `/`
- [ ] Verify migration applied: `[entrypoint] Running DB migrations...` line in deploy logs lists `027_user_profile.sql`