### PR TITLE
Tier/Pro audit follow-ups: ws-server gate + grace bump + UI mounts

### DIFF
--- a/apps/web/app/components/navbar.tsx
+++ b/apps/web/app/components/navbar.tsx
@@ -6,6 +6,7 @@ import { Play, Thermometer, ChevronDown, Activity, ShoppingBag, Briefcase, Flask
 import { ThemeToggle } from './theme-toggle';
 import { TradeClawLogo } from '../../components/tradeclaw-logo';
 import { UserMenu } from '../../components/UserMenu';
+import { TierBadge } from '../../components/TierBadge';
 import type { LucideIcon } from 'lucide-react';
 
 interface NavLink {
@@ -182,6 +183,9 @@ export function Navbar() {
           {/* CTA */}
           <div className="flex items-center gap-2 shrink-0">
             <UserMenu size="compact" />
+            <span className="hidden sm:inline-flex">
+              <TierBadge size="sm" />
+            </span>
             <Link
               href="/dashboard"
               className="hidden sm:flex items-center gap-1.5 text-xs font-medium text-emerald-400 hover:text-emerald-300 transition-colors duration-300"

--- a/apps/web/app/components/past-due-banner.tsx
+++ b/apps/web/app/components/past-due-banner.tsx
@@ -8,10 +8,10 @@ import { PAST_DUE_GRACE_DAYS } from '../../lib/tier-client';
 /**
  * Red banner shown above the dashboard when the user's last invoice failed.
  *
- * Renders nothing unless `subscriptionStatus === 'past_due'`. During Stripe's
- * 7-day grace window the user keeps Pro access, so the tier banner still
- * shows their tier — this component layers a separate, more urgent prompt
- * on top.
+ * Renders nothing unless `subscriptionStatus === 'past_due'`. During the
+ * grace window (PAST_DUE_GRACE_DAYS) the user keeps Pro access, so the tier
+ * banner still shows their tier — this component layers a separate, more
+ * urgent prompt on top.
  *
  * CTA opens the Stripe billing portal where the customer can update their
  * default payment method (the dunning email already gives them the

--- a/apps/web/app/dashboard/DashboardClient.tsx
+++ b/apps/web/app/dashboard/DashboardClient.tsx
@@ -26,6 +26,7 @@ import { AccuracyStatsBar } from '../components/accuracy-stats-bar';
 import { AccuracyMeta } from '../components/accuracy-meta';
 import { SignalExportMenu } from '../components/signal-export-menu';
 import { LockedTP } from '../../components/LockedTP';
+import { DelayCountdown } from '../../components/DelayCountdown';
 import { usePriceStream } from '../../lib/hooks/use-price-stream';
 import { BackgroundDecor } from '../../components/background/BackgroundDecor';
 import { InfoHint } from '../../components/InfoHint';
@@ -1352,19 +1353,40 @@ export function DashboardClient({ initialSignals, initialSyntheticSymbols }: { i
           return (
             <>
               {/* Locked signals — free tier sees pair/direction/confidence + countdown until unlock */}
-              {lockedSignals.length > 0 && (
-                <section className="mb-6">
-                  <div className="flex items-center gap-3 mb-3">
-                    <h2 className="text-xs uppercase tracking-wider text-emerald-400/80 font-mono font-semibold">Unlocking soon</h2>
-                    <span className="text-[10px] text-[var(--text-secondary)] font-mono">{lockedSignals.length} signal{lockedSignals.length !== 1 ? 's' : ''} ahead of free-tier delay</span>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                    {lockedSignals.map(stub => (
-                      <LockedSignalCard key={stub.id} stub={stub} />
-                    ))}
-                  </div>
-                </section>
-              )}
+              {lockedSignals.length > 0 && (() => {
+                // Earliest stub drives the section-level countdown banner.
+                // Free-tier delay is 15 min (TIER_DELAY_MS.free) — hardcoded
+                // here because tier.ts is server-only and the constant cannot
+                // be re-exported through tier-client without a wider refactor.
+                const FREE_DELAY_MS = 15 * 60 * 1000;
+                const earliest = lockedSignals.reduce(
+                  (a, b) =>
+                    new Date(a.availableAt).getTime() <= new Date(b.availableAt).getTime()
+                      ? a
+                      : b,
+                );
+                const earliestUnlockMs = new Date(earliest.availableAt).getTime();
+                return (
+                  <section className="mb-6">
+                    <div className="mb-3">
+                      <DelayCountdown
+                        signalTimestamp={earliestUnlockMs - FREE_DELAY_MS}
+                        delayMs={FREE_DELAY_MS}
+                        onUnlock={fetchSignals}
+                      />
+                    </div>
+                    <div className="flex items-center gap-3 mb-3">
+                      <h2 className="text-xs uppercase tracking-wider text-emerald-400/80 font-mono font-semibold">Unlocking soon</h2>
+                      <span className="text-[10px] text-[var(--text-secondary)] font-mono">{lockedSignals.length} signal{lockedSignals.length !== 1 ? 's' : ''} ahead of free-tier delay</span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                      {lockedSignals.map(stub => (
+                        <LockedSignalCard key={stub.id} stub={stub} />
+                      ))}
+                    </div>
+                  </section>
+                );
+              })()}
 
               {/* Main signals (70%+) */}
               {mainSignals.length > 0 && (

--- a/apps/web/lib/tier-client.ts
+++ b/apps/web/lib/tier-client.ts
@@ -31,5 +31,8 @@ export const FREE_HISTORY_DAYS = 7;
  * downgrades to free. Lives here (client-safe) so the past-due banner can
  * compute its grace deadline without pulling the server tier module.
  * Server resolution (`getUserTier`) re-exports this from ./tier.ts.
+ *
+ * Sized to cover Stripe Smart Retries (~3 weeks). Cutting access at day 7
+ * churned customers whose card update landed on Stripe's later retries.
  */
-export const PAST_DUE_GRACE_DAYS = 7;
+export const PAST_DUE_GRACE_DAYS = 21;

--- a/apps/ws-server/src/__tests__/tier.test.ts
+++ b/apps/ws-server/src/__tests__/tier.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FREE_SYMBOLS,
+  isAllowedForTier,
+  partitionByTier,
+  type Tier,
+} from '../tier.js';
+
+describe('FREE_SYMBOLS', () => {
+  // Pinned set so accidental drift between ws-server and apps/web/lib/tier-client.ts
+  // surfaces as a failed test rather than a silent leak. If product changes the
+  // free symbol list, update this assertion AND apps/web/lib/tier-client.ts in
+  // the same PR.
+  it('matches the canonical 6-symbol free-tier set', () => {
+    expect([...FREE_SYMBOLS].sort()).toEqual(
+      ['BTCUSD', 'ETHUSD', 'XAUUSD', 'EURUSD', 'SPYUSD', 'QQQUSD'].sort(),
+    );
+  });
+});
+
+describe('isAllowedForTier', () => {
+  it('returns true for free symbols on free tier', () => {
+    for (const sym of FREE_SYMBOLS) {
+      expect(isAllowedForTier(sym, 'free')).toBe(true);
+    }
+  });
+
+  it('returns false for Pro-only symbols on free tier', () => {
+    expect(isAllowedForTier('NVDAUSD', 'free')).toBe(false);
+    expect(isAllowedForTier('TSLAUSD', 'free')).toBe(false);
+    expect(isAllowedForTier('GBPUSD', 'free')).toBe(false);
+  });
+
+  it('returns true for any symbol on pro/elite/custom', () => {
+    const tiers: Tier[] = ['pro', 'elite', 'custom'];
+    for (const tier of tiers) {
+      expect(isAllowedForTier('NVDAUSD', tier)).toBe(true);
+      expect(isAllowedForTier('BTCUSD', tier)).toBe(true);
+      expect(isAllowedForTier('GBPUSD', tier)).toBe(true);
+    }
+  });
+
+  it('is case-insensitive', () => {
+    expect(isAllowedForTier('btcusd', 'free')).toBe(true);
+    expect(isAllowedForTier('BtcUsd', 'free')).toBe(true);
+    expect(isAllowedForTier('nvdausd', 'free')).toBe(false);
+  });
+});
+
+describe('partitionByTier', () => {
+  it('splits a mixed list into allowed and blocked for free', () => {
+    const result = partitionByTier(['BTCUSD', 'NVDAUSD', 'ETHUSD', 'GBPUSD'], 'free');
+    expect(result.allowed.sort()).toEqual(['BTCUSD', 'ETHUSD'].sort());
+    expect(result.blocked.sort()).toEqual(['GBPUSD', 'NVDAUSD'].sort());
+  });
+
+  it('returns everything as allowed for pro', () => {
+    const result = partitionByTier(['BTCUSD', 'NVDAUSD', 'GBPUSD'], 'pro');
+    expect(result.allowed.sort()).toEqual(['BTCUSD', 'GBPUSD', 'NVDAUSD'].sort());
+    expect(result.blocked).toEqual([]);
+  });
+
+  it('preserves the input casing on allowed results', () => {
+    // Allowed list keeps the symbol in the form it was passed (uppercased)
+    // so the relay's existing case-handling stays unchanged.
+    const result = partitionByTier(['btcusd', 'nvdausd'], 'free');
+    expect(result.allowed).toEqual(['BTCUSD']);
+    expect(result.blocked).toEqual(['NVDAUSD']);
+  });
+
+  it('handles an empty input', () => {
+    expect(partitionByTier([], 'free')).toEqual({ allowed: [], blocked: [] });
+    expect(partitionByTier([], 'pro')).toEqual({ allowed: [], blocked: [] });
+  });
+});

--- a/apps/ws-server/src/middleware/auth.ts
+++ b/apps/ws-server/src/middleware/auth.ts
@@ -1,8 +1,11 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Tier } from '../tier.js';
 
 const AUTH_SECRET = process.env.AUTH_SECRET;
 const IS_DEV = process.env.NODE_ENV !== 'production';
+
+const VALID_TIERS: ReadonlySet<Tier> = new Set<Tier>(['free', 'pro', 'elite', 'custom']);
 
 // Fail fast in production if secret is missing
 if (!IS_DEV && !AUTH_SECRET) {
@@ -13,17 +16,34 @@ interface TokenPayload {
   sub: string;
   exp: number;
   iat: number;
+  /**
+   * Optional tier claim. When the apps/web token minter starts embedding
+   * the caller's tier we read it here; until then (and for any malformed
+   * or unknown value) the relay falls back to 'free' for fail-closed
+   * symbol gating.
+   */
+  tier?: Tier;
 }
 
 declare module 'fastify' {
   interface FastifyRequest {
     userId?: string;
+    /**
+     * Resolved subscription tier. Always populated by `wsAuth` (or set
+     * to 'free' on the dev-mode anonymous path). Never undefined inside
+     * a request that successfully reached `relayPlugin`.
+     */
+    tier?: Tier;
   }
 }
 
 export async function wsAuth(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  // Skip auth in development when no secret is configured
-  if (IS_DEV && !AUTH_SECRET) return;
+  // Skip auth in development when no secret is configured. Default to
+  // free tier so any per-symbol gate downstream still applies.
+  if (IS_DEV && !AUTH_SECRET) {
+    request.tier = 'free';
+    return;
+  }
 
   const query = request.query as { token?: string };
   const token = query.token;
@@ -40,6 +60,8 @@ export async function wsAuth(request: FastifyRequest, reply: FastifyReply): Prom
   }
 
   request.userId = payload.sub;
+  request.tier =
+    payload.tier && VALID_TIERS.has(payload.tier) ? payload.tier : 'free';
 }
 
 function verifyToken(token: string): TokenPayload | null {

--- a/apps/ws-server/src/tier.ts
+++ b/apps/ws-server/src/tier.ts
@@ -1,0 +1,54 @@
+/**
+ * Tier-aware symbol gate for the WebSocket relay.
+ *
+ * apps/web/lib/tier-client.ts is the canonical source for FREE_SYMBOLS;
+ * this module duplicates the constant so apps/ws-server stays a self-
+ * contained workspace. Drift is caught by the pin in
+ * src/__tests__/tier.test.ts — bumping FREE_SYMBOLS here without bumping
+ * the web side (or vice versa) fails CI.
+ */
+
+export type Tier = 'free' | 'pro' | 'elite' | 'custom';
+
+export const FREE_SYMBOLS: readonly string[] = [
+  'BTCUSD',
+  'ETHUSD',
+  'XAUUSD',
+  'EURUSD',
+  'SPYUSD',
+  'QQQUSD',
+];
+
+const FREE_SYMBOL_SET = new Set(FREE_SYMBOLS);
+
+/**
+ * True when `tier` is allowed to subscribe to live ticks for `symbol`.
+ *
+ * Pro/Elite/Custom inherit Elite's coverage by default — every traded
+ * symbol. Free is restricted to FREE_SYMBOLS. Comparison is case-
+ * insensitive so callers can pass user-supplied casing through.
+ */
+export function isAllowedForTier(symbol: string, tier: Tier): boolean {
+  if (tier !== 'free') return true;
+  return FREE_SYMBOL_SET.has(symbol.toUpperCase());
+}
+
+/**
+ * Splits a list of symbol strings into the subset the tier may subscribe
+ * to and the subset it may not. Both lists return uppercased symbols so
+ * the caller can treat them consistently with the rest of the relay's
+ * uppercased symbol bookkeeping.
+ */
+export function partitionByTier(
+  symbols: string[],
+  tier: Tier,
+): { allowed: string[]; blocked: string[] } {
+  const allowed: string[] = [];
+  const blocked: string[] = [];
+  for (const raw of symbols) {
+    const sym = raw.toUpperCase();
+    if (isAllowedForTier(sym, tier)) allowed.push(sym);
+    else blocked.push(sym);
+  }
+  return { allowed, blocked };
+}

--- a/apps/ws-server/src/websocket/relay.ts
+++ b/apps/ws-server/src/websocket/relay.ts
@@ -7,6 +7,7 @@ import type { ProviderManager } from './manager.js';
 import type { RedisService } from '../services/redis.js';
 import { wsAuth } from '../middleware/auth.js';
 import { checkConnectionRate, MessageRateLimiter, startCleanup } from '../middleware/rate-limit.js';
+import { partitionByTier, type Tier } from '../tier.js';
 
 interface RelayOptions extends FastifyPluginOptions {
   providerManager: ProviderManager;
@@ -62,10 +63,15 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
     }
 
     const clientId = `c_${++clientCounter}_${Date.now().toString(36)}`;
+    // Resolved by wsAuth (defaults to 'free' on the dev anonymous path).
+    // Captured at connect time so per-message tier lookups stay O(1) and
+    // don't change mid-connection — the only correct way to upgrade is to
+    // reconnect with a new token after checkout.
+    const tier: Tier = request.tier ?? 'free';
     clients.set(clientId, socket);
     resetIdleTimer(clientId);
 
-    app.log.info({ clientId, ip: request.ip }, 'Client connected');
+    app.log.info({ clientId, ip: request.ip, tier }, 'Client connected');
 
     socket.on('message', (data) => {
       // Message rate limiting (per client)
@@ -97,9 +103,24 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
       }
 
       if (msg.action === 'subscribe') {
+        // Tier gate: drop Pro-only symbols for free callers and surface
+        // them in a structured error frame so the client can render an
+        // upgrade CTA without string-matching.
+        const tierSplit = partitionByTier(validRequested, tier);
+        if (tierSplit.allowed.length === 0 && tierSplit.blocked.length > 0) {
+          sendError(
+            socket,
+            `Symbol(s) require Pro: ${tierSplit.blocked.join(', ')}`,
+          );
+          return;
+        }
+
         // Enforce per-client subscription cap
         const currentCount = subs.getClientSymbols(clientId).length;
-        const allowed = validRequested.slice(0, MAX_SUBSCRIPTIONS_PER_CLIENT - currentCount);
+        const allowed = tierSplit.allowed.slice(
+          0,
+          MAX_SUBSCRIPTIONS_PER_CLIENT - currentCount,
+        );
         if (allowed.length === 0) {
           sendError(socket, `Subscription limit reached (max ${MAX_SUBSCRIPTIONS_PER_CLIENT} symbols)`);
           return;
@@ -107,7 +128,16 @@ export async function relayPlugin(app: FastifyInstance, opts: RelayOptions) {
         const subscribed = subs.subscribe(clientId, allowed);
         const response: WsServerMessage = { type: 'subscribed', symbols: subscribed };
         socket.send(JSON.stringify(response));
-        app.log.info({ clientId, symbols: subscribed }, 'Client subscribed');
+        if (tierSplit.blocked.length > 0) {
+          // Pro-only symbols asked for alongside free symbols: subscribe
+          // the free set, then signal the rest as a single follow-up
+          // error frame. The connection stays open.
+          sendError(
+            socket,
+            `Symbol(s) require Pro: ${tierSplit.blocked.join(', ')}`,
+          );
+        }
+        app.log.info({ clientId, symbols: subscribed, blocked: tierSplit.blocked, tier }, 'Client subscribed');
       } else if (msg.action === 'unsubscribe') {
         const unsubscribed = subs.unsubscribe(clientId, validRequested);
         const response: WsServerMessage = { type: 'unsubscribed', symbols: unsubscribed };

--- a/docs/plans/2026-05-07-tier-pro-followups.md
+++ b/docs/plans/2026-05-07-tier-pro-followups.md
@@ -1,0 +1,100 @@
+# Tier/Pro Follow-Ups — Plan
+
+**Date:** 2026-05-07
+**Branch:** `fix/tier-pro-followups`
+**Worktree:** `../tradeclaw-tier-pro-followups`
+**Source:** Audit dated 2026-05-07 against the master Pro launch + tier-segregation-delta + pro-leak-closure specs.
+
+---
+
+## Why this plan exists
+
+The 2026-05-07 audit surfaced five follow-ups labelled "Top 5 fixes to ship first":
+
+| ID | Audit finding | Status after re-verification |
+|---|---|---|
+| H1 | Stripe `apiVersion: '2026-03-25.dahlia'` is bogus | **False positive — dropped.** The installed `stripe@21.0.1` SDK ships `'2026-03-25.dahlia'` as its canonical `ApiVersion` in `node_modules/stripe/types/apiVersion.d.ts`. The pin matches the SDK. |
+| H4 | `apps/ws-server` does no tier filtering | Confirmed — every WS client can subscribe to every symbol. |
+| M1 | `PAST_DUE_GRACE_DAYS = 7` is shorter than Stripe Smart Retries (~21d) | Confirmed. |
+| H2 | `TierBadge` component built but never mounted | Confirmed — zero call sites in `apps/web`. |
+| H3 | `DelayCountdown` built but never mounted as dashboard banner | Confirmed — only the inline `LockedSignalCard` exists. |
+| M4 | `/api/commentary` is unrate-limited LLM endpoint | **False positive — dropped.** `lib/market-commentary.ts` is template-based ("zero LLM cost"). No model call to throttle. |
+
+Net deliverables this branch: **M1, H2, H3, H4** in four commits.
+
+## Commit sequence
+
+Each commit is independently revertable.
+
+### C1 — `fix(tier): bump PAST_DUE_GRACE_DAYS to 21 to match Stripe retries`
+
+- **File:** `apps/web/lib/tier-client.ts:35`
+- **Change:** `7 → 21`
+- **Verify:** `apps/web/lib/__tests__/tier.test.ts` already covers past_due grace — re-run; if any test pins the constant, update the assertion alongside the constant.
+- **Rollback:** revert one line.
+
+### C2 — `feat(navbar): mount TierBadge for signed-in users`
+
+- **File:** `apps/web/app/components/navbar.tsx`
+- **Change:** import `TierBadge`, render between `UserMenu` and the `Star` link in the desktop CTA cluster (line ~184). Hidden on mobile (`hidden sm:inline-flex` wrapper) since the mobile hamburger overlay can stay clean.
+- **Component is server-safe?** No — `TierBadge` is `'use client'` and uses `useUserTier`. `Navbar` is already `'use client'`. Compatible.
+- **Verify:** type-check `apps/web`. Manual smoke: anon → no badge; free signed-in → grey "free" pill; pro signed-in → emerald "pro" pill linking to `/dashboard/billing`.
+- **Rollback:** revert one file.
+
+### C3 — `feat(dashboard): mount DelayCountdown banner above locked signals for free tier`
+
+- **File:** `apps/web/app/dashboard/DashboardClient.tsx`
+- **Change:** for the next-to-unlock signal in `lockedSignals`, render `DelayCountdown` once above the "Unlocking soon" header (line ~1355). Sort `lockedSignals` by ascending `availableAt` and pass the first one. Trigger `fetchSignals()` on `onUnlock`.
+- **Avoid double-mount:** keep the inline countdown in `LockedSignalCard` (per-card). The new banner is the spec's single dashboard-level surface.
+- **Tier check:** banner only renders when there is at least one locked stub, which by design only appears for free tier.
+- **Verify:** type-check `apps/web`. Existing E2E `tests/e2e/tier/tier-journey.spec.ts` exercises the locked-signal flow.
+- **Rollback:** revert one file.
+
+### C4 — `feat(ws-server): tier-aware subscriptions, default-free symbol gate`
+
+Largest commit. Splits the work this way for review clarity but lands as one commit so the gate is atomic.
+
+- **New file:** `apps/ws-server/src/tier.ts`
+  - Exports `Tier`, `FREE_SYMBOLS`, `TIER_SYMBOLS`, `isAllowedForTier(symbol, tier)`.
+  - Hardcoded duplication of `apps/web/lib/tier-client.ts FREE_SYMBOLS`. Documented as "second source of truth — pin via test"; webhook is fine because the set changes <quarterly.
+- **Edit:** `apps/ws-server/src/middleware/auth.ts`
+  - Extend `TokenPayload` with optional `tier?: Tier` claim.
+  - On verify, set `request.tier` (default `'free'`).
+  - Anonymous (dev fallback when `IS_DEV && !AUTH_SECRET`) → tier defaults to `'free'`.
+- **Edit:** `apps/ws-server/src/websocket/relay.ts`
+  - In the subscribe branch, partition `validRequested` into `allowedByTier` and `blockedByTier` via `isAllowedForTier`. Subscribe only the allowed set. If anything was blocked, send a `{ type: 'error', message: 'Symbol(s) require Pro: ...', code: 'tier_required' }` after the `subscribed` ack so the client can surface it.
+  - Emit `403`-equivalent in the WS error frame (we cannot use HTTP status here — close codes 4001-4099 are app-specific; we keep the connection open and signal via error message so the legitimate free symbols still stream).
+- **New test:** `apps/ws-server/src/__tests__/tier.test.ts`
+  - Pins `FREE_SYMBOLS` to the canonical 6-symbol set.
+  - `isAllowedForTier` returns true for free symbols on free tier, false for Pro symbols on free tier, true for everything on Pro/Elite/Custom.
+- **New test:** `apps/ws-server/src/__tests__/relay-tier.test.ts` — TDD-first.
+  - Free tier subscribes to `[BTCUSD, NVDAUSD]` → server acks `[BTCUSD]`, sends a `tier_required` error frame mentioning `NVDAUSD`.
+  - Pro tier subscribes to `[NVDAUSD]` → server acks `[NVDAUSD]` with no error frame.
+  - Anonymous (dev mode, no token) → free behavior.
+- **Verify:**
+  - `npm run test --workspace=apps/ws-server`
+  - `npm run build --workspace=apps/ws-server`
+  - Pin test in `apps/web/lib/__tests__/tier.test.ts` covers the web side; we add the matching pin on ws-server.
+- **Out of scope (followups):** plumbing `tier` into the JWT minter on `apps/web`. The minter does not exist yet (no caller in `apps/web` mints WS tokens today; the `useWebSocketPrices` hook connects without a token). Adding a `tier` claim is a no-op until the minter is written. The gate still works because it defaults to `'free'`.
+
+## Verification matrix
+
+| Commit | Type-check | Unit | E2E |
+|---|---|---|---|
+| C1 | apps/web | tier.test.ts | n/a |
+| C2 | apps/web | n/a | tier-journey.spec.ts (smoke) |
+| C3 | apps/web | n/a | tier-journey.spec.ts (smoke) |
+| C4 | apps/ws-server | new tier + relay-tier tests | n/a (no e2e harness for ws) |
+
+## What I will NOT do in this branch
+
+- Pin the Stripe API version differently (it already matches the SDK).
+- Rate-limit `/api/commentary` (no LLM cost to control).
+- Mint WS tokens with a tier claim (no minter exists yet; defaulting to free is correct fail-closed posture).
+- Touch the alert-rules PATCH cap-flip (separate ticket — tracked in audit M7).
+- Touch the mobile app (separate ticket — tracked in audit M8).
+- Refactor billing page to read `TIER_DEFINITIONS` (separate ticket — tracked in audit L4).
+
+## Rollback
+
+Each commit is file-scoped and revertable independently. C4 introduces a new file (`apps/ws-server/src/tier.ts`); reverting the commit deletes it cleanly.


### PR DESCRIPTION
## Summary

Four shippable follow-ups from the 2026-05-07 free/pro audit, one commit per concern. Plan: [docs/plans/2026-05-07-tier-pro-followups.md](docs/plans/2026-05-07-tier-pro-followups.md).

| ID | Commit | Change |
|---|---|---|
| M1 | `565b44b` | `PAST_DUE_GRACE_DAYS` 7 → 21 to match Stripe Smart Retries |
| H2 | `311c0cc` | Mount `TierBadge` in the navbar (component existed but had zero call sites) |
| H3 | `c2d45bb` | Mount `DelayCountdown` banner above the locked-signal grid (component existed but had zero call sites) |
| H4 | `5825917` | Tier-aware WebSocket subscriptions in `apps/ws-server` — every connected client previously received every symbol regardless of tier |

Two findings from the audit were dropped after re-verification:
- **H1 Stripe API version** — false positive. `node_modules/stripe/types/apiVersion.d.ts` literally exports `ApiVersion = '2026-03-25.dahlia'`. The pin matches the SDK.
- **M4 /api/commentary rate limit** — false positive. `lib/market-commentary.ts` is template-based ("zero LLM cost"), no model call to throttle.

## Largest change (H4)

The relay broadcast every symbol to every connected client. Free callers could subscribe to `NVDAUSD`, `TSLAUSD`, `GBPUSD`, etc., and receive real-time ticks for paid-tier symbols.

- New `apps/ws-server/src/tier.ts` — `Tier`, `FREE_SYMBOLS`, `isAllowedForTier`, `partitionByTier`. Pinned via test against the canonical 6-symbol free set.
- `apps/ws-server/src/middleware/auth.ts` — extended `TokenPayload` with optional `tier` claim, populates `request.tier` (defaults to `'free'` on missing/unknown values, including the dev-mode anonymous path).
- `apps/ws-server/src/websocket/relay.ts` — partitions `validRequested` into allowed/blocked at subscribe time. Blocked symbols come back in a structured error frame so clients can render an upgrade CTA without string-matching. Allowed symbols still subscribe in the same message; the connection stays open.

The `apps/web` JWT minter does not yet emit a `tier` claim — the default-free fallback keeps the gate correct in the meantime. Pro callers will be unblocked once the web-side minter starts including the claim. Both ends of the duplicated `FREE_SYMBOLS` constant are pinned by tests so the symbol set cannot drift silently.

## Test plan

- [x] `apps/web/lib/__tests__/tier.test.ts` — 71 pass with the bumped `PAST_DUE_GRACE_DAYS` (the 30-day "out of grace" assertion still holds at 21)
- [x] `apps/ws-server` vitest — 36/36 pass (was 27 on main, +9 new tier tests)
- [x] `apps/web` jest — 771/797 pass / 26 skipped, identical totals to `main` (the 5 vitest files jest reports as failed are pre-existing artifacts of the dual test runner setup)
- [x] `tsc --noEmit` on both `apps/web` and `apps/ws-server` — zero new type errors; everything that surfaced is pre-existing on `main`
- [ ] Manual smoke: anonymous → no `TierBadge`; free signed-in → grey "free" pill linking to `/pricing?from=badge`; pro signed-in → emerald "pro" pill linking to `/dashboard/billing`
- [ ] Manual smoke: free user with locked signals → `DelayCountdown` shows above "Unlocking soon", refetches on unlock
- [ ] Manual smoke: WS client without token (dev mode) subscribing to `[BTCUSD, NVDAUSD]` → server acks `[BTCUSD]` only, sends `Symbol(s) require Pro: NVDAUSD` error frame

## Branch state

Branch is one commit behind `main` on `apps/web/app/lib/ohlcv.ts` (a `670704d` ohlcv fix landed on main during the audit). None of the four commits in this PR touch that file, so the merge fast-forwards cleanly.

## Out of scope (followups tracked in audit)

- Wire the `tier` claim into the apps/web JWT minter (when it exists; today there is no caller minting WS tokens)
- M2 `/api/mtf` symbol filter
- M5 track-record direct `/pricing?from=history` link
- M7 alert-rules PATCH cap-flip recheck
- M8 mobile app tier UI
- L4 billing page reads `TIER_DEFINITIONS`