### PR TITLE
fix(pro-flow v2): grace anchor, OAuth open-redirect, Telegram tier swap, email-grant invite

### DIFF
--- a/apps/web/app/api/auth/github/callback/route.ts
+++ b/apps/web/app/api/auth/github/callback/route.ts
@@ -9,6 +9,7 @@ import {
 import {
   OAUTH_STATE_COOKIE,
   decodeState,
+  safeNext,
 } from '../../../../../lib/oauth-state';
 
 export const dynamic = 'force-dynamic';
@@ -148,15 +149,21 @@ export async function GET(request: NextRequest) {
     !!state.priceId ||
     (state.tier === 'pro' && (state.interval === 'monthly' || state.interval === 'annual'));
 
+  // Re-apply safeNext on every read of state.next. The /start route sanitized
+  // at write time, but a leaked or attacker-crafted state blob could carry a
+  // `//evil.com/` value that would otherwise resolve to a different origin
+  // via scheme-relative URL parsing. Mirrors the posture in google/callback.
+  const safeStateNext = safeNext(state.next);
+
   let target: URL;
   if (hasCheckoutPayload) {
     target = new URL('/signin', appOrigin(request));
     if (state.priceId) target.searchParams.set('priceId', state.priceId);
     if (state.tier) target.searchParams.set('tier', state.tier);
     if (state.interval) target.searchParams.set('interval', state.interval);
-    if (state.next) target.searchParams.set('next', state.next);
-  } else if (state.next) {
-    target = new URL(state.next, appOrigin(request));
+    if (safeStateNext) target.searchParams.set('next', safeStateNext);
+  } else if (safeStateNext) {
+    target = new URL(safeStateNext, appOrigin(request));
   } else {
     target = new URL('/dashboard', appOrigin(request));
   }

--- a/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
@@ -26,6 +26,9 @@ jest.mock('../../../../../lib/db', () => ({
 
 jest.mock('../../../../../lib/telegram', () => ({
   sendInvite: jest.fn().mockResolvedValue('invite-link'),
+  sendInviteWithRetry: jest
+    .fn()
+    .mockResolvedValue({ ok: true, attempts: 1, retryable: false }),
   revokeAccess: jest.fn().mockResolvedValue(undefined),
 }));
 
@@ -40,10 +43,15 @@ import {
   updateSubscriptionStatus,
   getSubscriptionByStripeId,
   getUserById,
+  getUserByStripeCustomerId,
   tryClaimStripeEvent,
   cancelSubscription,
 } from '../../../../../lib/db';
-import { sendInvite } from '../../../../../lib/telegram';
+import {
+  sendInvite,
+  sendInviteWithRetry,
+  revokeAccess,
+} from '../../../../../lib/telegram';
 import { sendPaymentFailedEmail } from '../../../../../lib/transactional-email';
 import { POST } from '../route';
 
@@ -56,6 +64,9 @@ const mockedUpdateSubStatus = updateSubscriptionStatus as jest.MockedFunction<ty
 const mockedGetSubByStripeId = getSubscriptionByStripeId as jest.MockedFunction<typeof getSubscriptionByStripeId>;
 const mockedGetUserById = getUserById as jest.MockedFunction<typeof getUserById>;
 const mockedSendInvite = sendInvite as jest.MockedFunction<typeof sendInvite>;
+const mockedSendInviteRetry = sendInviteWithRetry as jest.MockedFunction<typeof sendInviteWithRetry>;
+const mockedRevokeAccess = revokeAccess as jest.MockedFunction<typeof revokeAccess>;
+const mockedGetUserByCustomerId = getUserByStripeCustomerId as jest.MockedFunction<typeof getUserByStripeCustomerId>;
 const mockedSendDunning = sendPaymentFailedEmail as jest.MockedFunction<typeof sendPaymentFailedEmail>;
 const mockedCancelSub = cancelSubscription as jest.MockedFunction<typeof cancelSubscription>;
 
@@ -567,5 +578,76 @@ describe('POST /api/stripe/webhook — tier transitions', () => {
     expect(tier).toBe('pro');
     expect((expiresAt as Date).getTime()).toBe(annualEnd * 1000);
     expect(mockedUpdateSubStatus).toHaveBeenCalledWith('sub_1', 'active', expect.any(Date));
+    // Same-tier interval switch — no Telegram group swap.
+    expect(mockedRevokeAccess).not.toHaveBeenCalled();
+    expect(mockedSendInviteRetry).not.toHaveBeenCalled();
+  });
+
+  it('customer.subscription.updated (pro→elite) revokes Pro group and invites to Elite group', async () => {
+    // Without the tier swap, a Pro user who upgrades to Elite via the Stripe
+    // portal would keep their Pro group invite and have NO Elite group invite
+    // — paying more for the tier with worse access. Mirror image of the
+    // Elite→Pro downgrade case which previously left users in the Elite group
+    // permanently after they stopped paying for it.
+    const periodEnd = Math.floor(Date.now() / 1000) + 30 * 86400;
+    mockedResolveTier.mockReturnValue('elite');
+    mockedGetSubByStripeId.mockResolvedValueOnce({
+      id: 'sub-row-1',
+      userId: 'user-1',
+      stripeSubscriptionId: 'sub_1',
+      stripeCustomerId: 'cus_1',
+      tier: 'pro',
+      status: 'active',
+      currentPeriodStart: new Date(),
+      currentPeriodEnd: new Date(),
+      cancelAtPeriodEnd: false,
+      trialEnd: null,
+      trialReminderSentAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedGetUserByCustomerId.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_1',
+      tier: 'pro',
+      tierExpiresAt: null,
+      telegramUserId: BigInt(987654321),
+      displayName: null,
+      avatarUrl: null,
+      authProvider: null,
+    });
+
+    mockedGetStripe.mockReturnValue({
+      webhooks: {
+        constructEvent: jest.fn().mockReturnValue({
+          id: 'evt_pro_to_elite',
+          type: 'customer.subscription.updated',
+          data: {
+            object: {
+              id: 'sub_1',
+              status: 'active',
+              cancel_at_period_end: false,
+              customer: 'cus_1',
+              metadata: { userId: 'user-1', tier: 'pro' },
+              items: {
+                data: [
+                  { price: { id: 'price_elite_monthly' }, current_period_end: periodEnd },
+                ],
+              },
+            },
+          },
+        }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(mockedRevokeAccess).toHaveBeenCalledTimes(1);
+    expect(mockedRevokeAccess).toHaveBeenCalledWith('987654321', 'pro');
+    expect(mockedSendInviteRetry).toHaveBeenCalledTimes(1);
+    expect(mockedSendInviteRetry).toHaveBeenCalledWith('user-1', '987654321', 'elite');
   });
 });

--- a/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
@@ -182,6 +182,11 @@ describe('POST /api/stripe/webhook — idempotency', () => {
 describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
   const ORIGINAL_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
 
+  // Period end the failed invoice describes. Used to assert handlePaymentFailed
+  // refreshes current_period_end so the past_due grace window stays anchored to
+  // the live cycle, not whatever value happened to be in the DB at trial start.
+  const FAILED_PERIOD_END_SEC = Math.floor(Date.now() / 1000) + 30 * 86400;
+
   function setupPaymentFailedEvent(): void {
     const failedEvent = {
       id: 'evt_failed_1',
@@ -193,6 +198,9 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
           amount_due: 2900,
           currency: 'usd',
           next_payment_attempt: Math.floor(Date.now() / 1000) + 3 * 86400,
+          lines: {
+            data: [{ period: { end: FAILED_PERIOD_END_SEC } }],
+          },
         },
       },
     };
@@ -244,7 +252,11 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
     const res = await POST(makeRequest());
     expect(res.status).toBe(200);
 
-    expect(mockedUpdateSubStatus).toHaveBeenCalledWith('sub_failed', 'past_due');
+    expect(mockedUpdateSubStatus).toHaveBeenCalledWith(
+      'sub_failed',
+      'past_due',
+      new Date(FAILED_PERIOD_END_SEC * 1000),
+    );
     expect(mockedSendDunning).toHaveBeenCalledTimes(1);
     const [to, opts] = mockedSendDunning.mock.calls[0];
     expect(to).toBe('user@example.com');
@@ -274,7 +286,11 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
     const res = await POST(makeRequest());
     expect(res.status).toBe(200);
 
-    expect(mockedUpdateSubStatus).toHaveBeenCalledWith('sub_failed', 'past_due');
+    expect(mockedUpdateSubStatus).toHaveBeenCalledWith(
+      'sub_failed',
+      'past_due',
+      new Date(FAILED_PERIOD_END_SEC * 1000),
+    );
     expect(mockedSendDunning).not.toHaveBeenCalled();
     expect(mockedGetUserById).not.toHaveBeenCalled();
   });
@@ -311,8 +327,61 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
 
     const res = await POST(makeRequest());
     expect(res.status).toBe(200);
-    expect(mockedUpdateSubStatus).toHaveBeenCalledWith('sub_failed', 'past_due');
+    expect(mockedUpdateSubStatus).toHaveBeenCalledWith(
+      'sub_failed',
+      'past_due',
+      new Date(FAILED_PERIOD_END_SEC * 1000),
+    );
     errSpy.mockRestore();
+  });
+});
+
+describe('POST /api/stripe/webhook — invoice.payment_succeeded period refresh', () => {
+  const ORIGINAL_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
+    mockedTryClaim.mockResolvedValue(true);
+  });
+
+  afterAll(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = ORIGINAL_SECRET;
+  });
+
+  it('trial→paid conversion refreshes current_period_end so the past_due grace window is correct on the next cycle', async () => {
+    // The bug: handlePaymentSucceeded used to call updateSubscriptionStatus
+    // with only (id, 'active'), which left current_period_end frozen at the
+    // trial-end value (day 7). When the next renewal failed weeks later, the
+    // grace window in tier.ts (period_end + 21d) was already in the past and
+    // the user lost access with no grace. Persist the live period_end here.
+    const periodEndSec = Math.floor(Date.now() / 1000) + 30 * 86400;
+
+    mockedGetStripe.mockReturnValue({
+      webhooks: {
+        constructEvent: jest.fn().mockReturnValue({
+          id: 'evt_pay_ok',
+          type: 'invoice.payment_succeeded',
+          data: {
+            object: {
+              parent: { subscription_details: { subscription: 'sub_renewed' } },
+              lines: { data: [{ period: { end: periodEndSec } }] },
+            },
+          },
+        }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(mockedUpdateSubStatus).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateSubStatus).toHaveBeenCalledWith(
+      'sub_renewed',
+      'active',
+      new Date(periodEndSec * 1000),
+    );
   });
 });
 

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -264,13 +264,37 @@ async function handleSubscriptionDeleted(
   }
 }
 
+/**
+ * Pull the new billing-period end from an invoice. After a trial converts to
+ * paid, or any successful renewal, the invoice carries the period covered by
+ * the payment in its line items. We persist that period_end so the past_due
+ * grace window in `getUserTier` is anchored to the current cycle, not a stale
+ * value from trial start. Falls back to null when the invoice has no period
+ * info — caller leaves current_period_end untouched in that case.
+ */
+function invoicePeriodEnd(invoice: Stripe.Invoice): Date | null {
+  // Both Stripe API shapes (legacy InvoiceLineItem.period and newer
+  // line.parent.subscription_item_details.period) expose `period.end` as a
+  // unix-seconds number on the first line item. Pick whichever is present.
+  const firstLine = invoice.lines?.data?.[0] as
+    | { period?: { end?: number | null } | null }
+    | undefined;
+  const end = firstLine?.period?.end;
+  return typeof end === 'number' ? new Date(end * 1000) : null;
+}
+
 async function handlePaymentSucceeded(invoice: Stripe.Invoice): Promise<void> {
   // In Stripe API 2026-03-25.dahlia, subscription is at invoice.parent.subscription_details.subscription
   const sub = invoice.parent?.subscription_details?.subscription;
   const subscriptionId = typeof sub === 'string' ? sub : sub?.id ?? null;
   if (!subscriptionId) return;
 
-  await updateSubscriptionStatus(subscriptionId, 'active');
+  // Refresh current_period_end from the invoice. On trial→paid conversion the
+  // first paid period's end lives in the invoice line item and isn't picked up
+  // by handlePaymentSucceeded otherwise — leaving it at the trial-end value
+  // breaks the past_due grace window math in tier.ts:280 on the next renewal.
+  const periodEnd = invoicePeriodEnd(invoice) ?? undefined;
+  await updateSubscriptionStatus(subscriptionId, 'active', periodEnd);
 }
 
 async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
@@ -286,7 +310,11 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
   const existing = await getSubscriptionByStripeId(subscriptionId);
   const wasAlreadyPastDue = existing?.status === 'past_due';
 
-  await updateSubscriptionStatus(subscriptionId, 'past_due');
+  // Same period_end refresh as handlePaymentSucceeded. The failed invoice still
+  // describes the period the renewal *would have* covered — anchoring the grace
+  // window to that boundary matches our 21-day-past-current-cycle policy.
+  const periodEnd = invoicePeriodEnd(invoice) ?? undefined;
+  await updateSubscriptionStatus(subscriptionId, 'past_due', periodEnd);
 
   if (wasAlreadyPastDue || !existing) return;
 

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -215,6 +215,13 @@ async function handleSubscriptionUpdated(
   const periodEnd = firstItem ? new Date(firstItem.current_period_end * 1000) : null;
   const trialEnd = subscription.trial_end ? new Date(subscription.trial_end * 1000) : null;
 
+  // Capture the previously persisted tier BEFORE we overwrite it so we can
+  // detect Pro↔Elite transitions and swap the Telegram groups accordingly.
+  // The persisted row is the source of truth; metadata.tier was set at
+  // checkout and won't reflect an in-portal upgrade.
+  const previous = await getSubscriptionByStripeId(subscription.id);
+  const previousTier = previous?.tier ?? null;
+
   await updateUserTier(userId, tier, periodEnd);
 
   await updateSubscriptionStatus(
@@ -226,6 +233,41 @@ async function handleSubscriptionUpdated(
   // Keep trial_end in sync — promo extensions, manual edits in the Stripe
   // dashboard, and trial-to-paid conversions all flow through this event.
   await setTrialEnd(subscription.id, trialEnd);
+
+  // Telegram group swap on tier change. Before this, an Elite→Pro downgrade
+  // left the user permanently in the Elite group (revenue leak), and a
+  // Pro→Elite upgrade left them out of the Elite group (the thing they just
+  // paid more for). Only fire when the tier actually changed AND the user
+  // has a linked Telegram — otherwise the no-op cost is one DB round-trip.
+  if (previousTier && previousTier !== tier && (previousTier === 'pro' || previousTier === 'elite')) {
+    const customerId =
+      typeof subscription.customer === 'string' ? subscription.customer : null;
+    if (customerId) {
+      const user = await getUserByStripeCustomerId(customerId);
+      if (user?.telegramUserId) {
+        const telegramUserId = user.telegramUserId.toString();
+        // Revoke first, then invite. If invite fails, the user is at least
+        // not in the wrong group anymore — they can recover via
+        // /api/telegram/resend-invite. The reverse order would leave them in
+        // both groups on a partial failure.
+        try {
+          await revokeAccess(telegramUserId, previousTier);
+        } catch (err) {
+          console.error(
+            `[webhook] tier-change revoke failed (prev=${previousTier} new=${tier}):`,
+            err,
+          );
+        }
+        const result = await sendInviteWithRetry(userId, telegramUserId, tier);
+        if (!result.ok) {
+          console.error(
+            `[webhook] tier-change invite failed (prev=${previousTier} new=${tier}):`,
+            `attempts=${result.attempts} retryable=${result.retryable} err=${result.error}`,
+          );
+        }
+      }
+    }
+  }
 }
 
 async function handleSubscriptionDeleted(

--- a/apps/web/app/api/telegram/route.ts
+++ b/apps/web/app/api/telegram/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { linkTelegramUser, getUserById } from '../../../lib/db';
 import { sendInvite } from '../../../lib/telegram';
+import { getUserTier } from '../../../lib/tier';
 import { verifyTelegramLinkToken } from '../../../lib/telegram-link-token';
 import { verifyTelegramWebhook } from '../../../lib/telegram-webhook-auth';
 
@@ -141,15 +142,21 @@ async function handleBotUpdate(update: TelegramUpdate): Promise<void> {
 
     await linkTelegramUser(userId, BigInt(telegramUserId));
 
-    // If the user already has an active paid subscription, send invite immediately
-    if (user.tier && user.tier !== 'free') {
+    // Resolve the user's effective tier via getUserTier — this is the same
+    // path the dashboard and API gates use, and it accounts for email grants
+    // (PRO_EMAILS env + pro_email_grants table) which never update the
+    // users.tier column. Reading user.tier directly here meant admin-granted
+    // Pro users got the "free tier" message instead of an invite.
+    const effectiveTier = await getUserTier(userId);
+
+    if (effectiveTier === 'pro' || effectiveTier === 'elite') {
       try {
-        await sendInvite(userId, chatId, user.tier as 'pro' | 'elite');
+        await sendInvite(userId, chatId, effectiveTier);
       } catch (err) {
         console.error('[telegram-bot] Failed to send invite after /start:', err);
         await sendTelegramMessage(
           config,
-          `Your Telegram is now linked to your TradeClaw ${user.tier} account.\n\nYour signal group invite will arrive shortly.`
+          `Your Telegram is now linked to your TradeClaw ${effectiveTier} account.\n\nYour signal group invite will arrive shortly.`
         );
       }
     } else {


### PR DESCRIPTION
## Summary
Second-pass audit (systematic-debugging methodology) found four concrete bugs in the Pro user flow that the first audit missed. All are real, verified against the source, and have tests. No new dependencies, no migrations.

Four commits, one concern each:

1. **`fdaad246` — Past-due grace anchored to stale period_end (P0 access bug)**  
   `handlePaymentSucceeded` and `handlePaymentFailed` called `updateSubscriptionStatus(id, status)` with no period_end. On trial→paid conversion the DB row kept `current_period_end = trial_end` (day 7). Weeks later when renewal failed, `getUserTier`'s grace formula (`period_end + 21d`) computed a date already in the past — user lost access immediately, zero grace, despite the documented 21-day policy. Mitigated in practice by `customer.subscription.updated` firing alongside, but defense in depth says don't trust event ordering.

2. **`efd13870` — GitHub OAuth callback open-redirect (P0 security)**  
   GitHub callback used raw `state.next` in `new URL()`. Google callback re-applies `safeNext()` at `:129` with the rationale that "a leaked or attacker-crafted state blob could carry a `//evil.com/` value". One-line import + two-line call swap to mirror Google.

3. **`80303eaf` — `handleSubscriptionUpdated` had no Telegram side-effects (P1)**  
   Pro→Elite upgrade: user paid more but stayed in Pro group only, NOT invited to Elite. Elite→Pro downgrade: user kept Elite group access indefinitely — revenue leak. Capture previous tier from persisted row, revoke + invite on change. Same-tier interval switches unaffected.

4. **`41d8b853` — Telegram bot `/start` used stale `user.tier` column (P1)**  
   Admin-granted Pro users (PRO_EMAILS / pro_email_grants) have `users.tier = 'free'`; their Pro access is resolved at read time via the email-grant fallback in `getUserTier`. The bot's `/start` handler read `user.tier` directly, so admin-granted Pro users linking via the bot got the free-tier message instead of an invite.

## What was claimed but DIDN'T reproduce
- "Telegram re-link orphaned invites": `telegram/route.ts:134-140` refuses re-link with a different chat and routes to support — real risk only if support unlinks AND original invite is still valid.
- "Auto-checkout cross-session attack" on `?resume=checkout`: overstated; SameSite=Lax + Stripe's confirmation page mean it's a phishing surface, not a charge bypass. Worth tightening eventually (P2) but not P0.
- Trial-reminder cron, past-due banner formula, trial countdown logic: all checked, clean.

## Test plan
- [x] `npx jest app/api/stripe app/api/telegram` — 38/38 green
- [x] New test: `trial→paid conversion refreshes current_period_end` (in webhook tests)
- [x] New test: `(pro→elite) revokes Pro group and invites to Elite group` (in webhook tests)
- [x] TypeScript check: only 2 preexisting errors in `WelcomeClient.tsx` (unrelated)
- [x] ESLint check: clean on changed files
- [ ] Manual: log in via GitHub with state containing `next=//evil.com/` → confirm redirect goes to /dashboard, not evil.com
- [ ] Manual: simulate trial→paid conversion in Stripe test mode, confirm DB `current_period_end` advances past trial end
- [ ] Manual: admin-grant Pro to a user via PRO_EMAILS, link Telegram via bot `/start`, confirm Pro group invite arrives
- [ ] Manual: in Stripe portal, change Pro user to Elite (when Elite is wired up), confirm Telegram group swap

## Out of scope (for follow-up PRs)
- `revokeAccess` failure on cancellation silently swallowed — needs retry queue or ledger
- `resume=checkout` should use server-set short-lived cookie instead of URL param
- `SameSite=Strict` instead of Lax on session cookie
- `E2E_FORCE_PRO_TIER` should fail-fast at module load in production
- `/api/telegram/resend-invite` rate limit of 3/600s allows 432 invites/day per user