### PR TITLE
feat(pricing): quote audited /track-record numbers above pricing cards

### DIFF
--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,8 +1,12 @@
+import Link from 'next/link';
 import { Navbar } from '../components/navbar';
 import { SiteFooter } from '../../components/landing/site-footer';
 import { PricingCards } from './PricingCards';
 import { FREE_SYMBOLS } from '../../lib/tier-client';
 import { TIER_HISTORY_DAYS } from '../../lib/tier';
+import { getPricingStats } from '../../lib/pricing-stats';
+
+export const revalidate = 600;
 
 interface Feature {
   label: string;
@@ -52,7 +56,10 @@ function renderValue(val: string | boolean) {
   return <span className="text-sm text-[var(--foreground)]">{val}</span>;
 }
 
-export default function PricingPage() {
+export default async function PricingPage() {
+  const stats = await getPricingStats();
+  const hasNumbers = stats.closedSignalsAllTime > 0 && stats.winRatePct !== null;
+
   return (
     <>
       <Navbar />
@@ -66,6 +73,46 @@ export default function PricingPage() {
             Start free. Upgrade when you&apos;re ready for instant signal delivery, private groups, and full analytics.
           </p>
         </div>
+
+        {hasNumbers && (
+          <div className="mx-auto mt-10 max-w-3xl">
+            <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/[0.04] px-6 py-5">
+              <div className="grid grid-cols-3 gap-4 text-center">
+                <div>
+                  <div className="text-2xl font-bold text-[var(--foreground)] sm:text-3xl">
+                    {stats.winRatePct?.toFixed(1)}%
+                  </div>
+                  <div className="mt-1 text-xs uppercase tracking-wider text-[var(--text-secondary)]">
+                    Win rate
+                  </div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-[var(--foreground)] sm:text-3xl">
+                    {stats.closedSignalsAllTime.toLocaleString()}
+                  </div>
+                  <div className="mt-1 text-xs uppercase tracking-wider text-[var(--text-secondary)]">
+                    Resolved signals
+                  </div>
+                </div>
+                <div>
+                  <div className={`text-2xl font-bold sm:text-3xl ${stats.cumulativePnlPct >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                    {stats.cumulativePnlPct >= 0 ? '+' : ''}
+                    {stats.cumulativePnlPct.toFixed(1)}%
+                  </div>
+                  <div className="mt-1 text-xs uppercase tracking-wider text-[var(--text-secondary)]">
+                    Cumulative PnL
+                  </div>
+                </div>
+              </div>
+              <p className="mt-4 text-center text-xs text-[var(--text-secondary)]">
+                Every signal, entry, and outcome is recorded in our public Postgres.{' '}
+                <Link href="/track-record" className="text-emerald-400 hover:underline">
+                  Verify the full archive →
+                </Link>
+              </p>
+            </div>
+          </div>
+        )}
 
         <div className="mt-12">
           <PricingCards />

--- a/apps/web/lib/__tests__/pricing-stats.test.ts
+++ b/apps/web/lib/__tests__/pricing-stats.test.ts
@@ -1,0 +1,59 @@
+import { computePricingStats, type RawPricingAgg } from '../pricing-stats';
+
+describe('pricing-stats — computePricingStats', () => {
+  it('returns nulls when no rows resolved yet', () => {
+    const stats = computePricingStats(null);
+    expect(stats).toEqual({
+      closedSignalsAllTime: 0,
+      winRatePct: null,
+      cumulativePnlPct: 0,
+    });
+  });
+
+  it('computes win rate and cumulative PnL from raw aggregate', () => {
+    const agg: RawPricingAgg = {
+      closed_count: '100',
+      wins: '73',
+      cumulative_pnl: '128.5',
+    };
+    const stats = computePricingStats(agg);
+    expect(stats.closedSignalsAllTime).toBe(100);
+    expect(stats.winRatePct).toBe(73);
+    expect(stats.cumulativePnlPct).toBeCloseTo(128.5, 1);
+  });
+
+  it('rounds win rate to one decimal', () => {
+    const agg: RawPricingAgg = {
+      closed_count: '300',
+      wins: '187',
+      cumulative_pnl: '42.0',
+    };
+    // 187 / 300 = 0.6233... → 62.3
+    const stats = computePricingStats(agg);
+    expect(stats.winRatePct).toBeCloseTo(62.3, 1);
+  });
+
+  it('treats zero closed count as null win rate, not NaN', () => {
+    const agg: RawPricingAgg = {
+      closed_count: '0',
+      wins: '0',
+      cumulative_pnl: '0',
+    };
+    const stats = computePricingStats(agg);
+    expect(stats.closedSignalsAllTime).toBe(0);
+    expect(stats.winRatePct).toBeNull();
+    expect(stats.cumulativePnlPct).toBe(0);
+  });
+
+  it('coerces string fields safely; non-numeric → 0 / null', () => {
+    const agg: RawPricingAgg = {
+      closed_count: 'abc',
+      wins: 'xyz',
+      cumulative_pnl: 'NaN',
+    };
+    const stats = computePricingStats(agg);
+    expect(stats.closedSignalsAllTime).toBe(0);
+    expect(stats.winRatePct).toBeNull();
+    expect(stats.cumulativePnlPct).toBe(0);
+  });
+});

--- a/apps/web/lib/pricing-stats.ts
+++ b/apps/web/lib/pricing-stats.ts
@@ -1,0 +1,58 @@
+import { queryOne } from './db-pool';
+
+export interface RawPricingAgg {
+  closed_count: string;
+  wins: string;
+  cumulative_pnl: string;
+}
+
+export interface PricingStats {
+  closedSignalsAllTime: number;
+  winRatePct: number | null;
+  cumulativePnlPct: number;
+}
+
+function safeNumber(input: string | null | undefined): number {
+  if (input == null) return 0;
+  const n = Number(input);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function computePricingStats(agg: RawPricingAgg | null): PricingStats {
+  if (!agg) {
+    return { closedSignalsAllTime: 0, winRatePct: null, cumulativePnlPct: 0 };
+  }
+  const closed = safeNumber(agg.closed_count);
+  const wins = safeNumber(agg.wins);
+  const cumulative = safeNumber(agg.cumulative_pnl);
+  const winRatePct = closed > 0 ? Math.round((wins / closed) * 1000) / 10 : null;
+  return {
+    closedSignalsAllTime: closed,
+    winRatePct,
+    cumulativePnlPct: cumulative,
+  };
+}
+
+export async function getPricingStats(): Promise<PricingStats> {
+  try {
+    const row = await queryOne<RawPricingAgg>(
+      `WITH closed AS (
+         SELECT (outcome_24h->>'pnlPct')::numeric AS pnl_pct,
+                (outcome_24h->>'hit')::boolean   AS hit
+           FROM signal_history
+          WHERE outcome_24h IS NOT NULL
+            AND is_simulated = FALSE
+            AND NOT ((outcome_24h->>'pnlPct')::numeric = 0
+                     AND (outcome_24h->>'hit')::boolean = FALSE)
+       )
+       SELECT
+         COUNT(*)::text                                              AS closed_count,
+         COALESCE(SUM(CASE WHEN hit THEN 1 ELSE 0 END), 0)::text     AS wins,
+         COALESCE(SUM(pnl_pct), 0)::text                             AS cumulative_pnl
+         FROM closed`
+    );
+    return computePricingStats(row ?? null);
+  } catch {
+    return computePricingStats(null);
+  }
+}

--- a/docs/plans/2026-05-12-pro-audit-execution.md
+++ b/docs/plans/2026-05-12-pro-audit-execution.md
@@ -1,0 +1,142 @@
+# Pro Audit Execution — Session Plan
+
+**Date:** 2026-05-12
+**Source:** PM audit recommendations dated 2026-05-11 (chat transcript)
+**Driver:** `/proceed-with-claude-recommendation` under 7 Laws
+
+## Status
+
+| # | Action | Branch | Status |
+|---|---|---|---|
+| 1 | tier-pro-followups C1-C4 | `fix/tier-pro-followups` | **DONE** — PR #69 (`c8339c3c`) + `bbae0f2f` |
+| 2 | Quote `/track-record` numbers on pricing page | `feat/pricing-track-record-numbers` | pending |
+| 3 | T-3d trial-ending email with realized missed P&L | `feat/trial-t3d-email` | pending |
+| 4 | Elite "Coming Soon" + waitlist + WTP survey | `feat/elite-coming-soon` | pending |
+| 5 | Reframe Pro features as outcomes (copy) | `chore/pro-feature-copy` | pending |
+
+## Course-correction (2026-05-12)
+
+User redefined item #4: Elite ships as **"Coming Soon"** with two value pillars:
+1. **Connect to live trade** (register interest signup)
+2. **Copy trade** — explicitly framed as the moat
+
+Plus a **willingness-to-pay survey** captured at the same form. No Stripe products yet. Lead capture + price discovery only.
+
+## Per-item scope, verification, fallback
+
+### Item #2 — Pricing track-record numbers
+
+**Where:** [apps/web/app/pricing/page.tsx](../../apps/web/app/pricing/page.tsx) between hero and IntervalToggle.
+
+**Numbers to render:**
+- All-time resolved signal count (`closedSignalsAllTime`)
+- All-time win rate (% of `outcome_24h.hit = true` over non-zero closed)
+- All-time cumulative PnL % (`cumulativePnlAllTime`)
+
+**Helper:** Extend [landing-stats.ts](../../apps/web/lib/landing-stats.ts) with a new `getPricingStats()` that runs against the full history, not 30d. Single query, no new tables.
+
+**Caching:** Server component reads stats with `unstable_cache` or page-level `revalidate = 600` (10 min). Numbers don't need real-time on pricing.
+
+**Risk:** None — read-only Postgres query against existing `signal_history` table.
+
+**Verify:**
+- Unit test for `getPricingStats()` (mock `queryOne` returns known shape, assert math)
+- Manual: dev server, visit `/pricing`, see the stat strip with non-zero numbers
+- Type-check + smallest pricing-page test
+
+**Inline fallback (no Postgres in dev):** render `—` placeholder, do not crash.
+
+**Out of scope:**
+- No new tables/migrations
+- No `/track-record` page changes
+- No copy changes to the comparison table (that's item #5)
+
+### Item #5 — Reframe Pro features as outcomes
+
+**Where:**
+- [stripe-tiers.ts](../../apps/web/lib/stripe-tiers.ts) `TIER_DEFINITIONS[pro].features`
+- [pricing/page.tsx](../../apps/web/app/pricing/page.tsx) `FEATURES` comparison table
+
+**Change type:** Copy-only. No new logic, no new components.
+
+**Examples of reframe:**
+- BEFORE: "Multi-timeframe analysis (RSI, EMA, MACD, Bollinger, Stochastic)"
+- AFTER: "Confluence-gated entries — 4+ indicators must align across H1/H4/D1 before a signal fires"
+- BEFORE: "Public win-rate audit at /track-record"
+- AFTER: "Verify every signal in our public Postgres — every entry, exit, and outcome on record"
+
+**Risk:** None. Copy.
+
+**Verify:** type-check, render `/pricing` in dev.
+
+### Item #3 — T-3d trial-ending email
+
+**Where:**
+- [apps/web/app/api/cron/trial-reminders/route.ts](../../apps/web/app/api/cron/trial-reminders/route.ts) — extend with T-3d branch
+- [apps/web/lib/trial-end-email.ts](../../apps/web/lib/trial-end-email.ts) — new T-3d template + missed-P&L compute
+
+**Missed-P&L definition** (closes the open design question):
+For a trial user with no paper-trading data, compute against the top N Pro-only signals they could have taken during their trial:
+1. Pull Pro signals from `signal_history` filtered by `created_at >= trial_start` AND `confidence >= PRO_PREMIUM_MIN_CONFIDENCE` AND `outcome_24h IS NOT NULL`.
+2. Take top 3 by `(outcome_24h->>'pnlPct')::numeric` (positive only — we show what they missed, not what they avoided).
+3. Sum the % gains. Show "If you'd taken our top 3 Pro signals at 1% size, you'd be up $X on a $10k account."
+
+**Sizing assumption:** 1% per trade, $10k notional (matches `/track-record` methodology from project memory).
+
+**Risk:** Medium — sending emails. Mitigations: gate behind `CRON_SECRET`, idempotent ledger via existing `trial_email_log` (or equivalent), test mode honors `EMAIL_TEST_RECIPIENT`.
+
+**Verify:**
+- Unit test for missed-P&L compute (seeded `signal_history` rows, assert correct top-3 and sum)
+- Manual: invoke cron with `?dry_run=1`, inspect output
+- Read `trial_email_log` after a wet run
+
+**Out of scope:**
+- Do NOT remove the T-1d email
+- Do NOT change trial duration
+- Do NOT add a T-0/T-1h email — separate ticket
+
+### Item #4 — Elite "Coming Soon" + waitlist + WTP survey
+
+**Where:**
+- [pricing/PricingCards.tsx](../../apps/web/app/pricing/PricingCards.tsx) — add 3rd card with Coming Soon state
+- New table migration `029_elite_interest.sql` with `(id, email, wtp_monthly_cents, wants_live_trade, wants_copy_trade, created_at, ip_hash)`
+- New API route `apps/web/app/api/elite/interest/route.ts` for POST (rate-limited)
+- New component `apps/web/components/EliteInterestForm.tsx`
+
+**Value props on card:**
+- "Connect to live trade" (Pro signals → your broker)
+- "Copy trade" — **highlighted as the moat**
+- "Pricing TBD — help us set it. Tell us what you'd pay."
+
+**Form fields:**
+- Email
+- Single select: "Most interested in" → live-trade / copy-trade / both
+- Single select: "Willing to pay per month" → $49 / $99 / $199 / $499 / $999+ / "other (free text)"
+
+**Risk:** Adds a Postgres table. Migration is `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX` — idempotent. Rate limit at 5 req / IP / hr via existing pattern.
+
+**Verify:**
+- Unit tests for POST handler (valid → 200, dup email → 200 idempotent, missing fields → 400, rate-limit → 429)
+- E2E test for form submit + success state
+- Manual: submit form in dev, query `elite_interest` table
+
+**Out of scope:**
+- No Stripe price IDs
+- No Telegram group provisioning
+- No actual copy-trade execution code (that's a separate product)
+- No admin dashboard to view interest entries (deferred)
+
+## Order of execution
+
+Walking the user's original order: #2 → #3 → #4 → #5.
+
+Each item ships as its own branch, its own PR, one concern per commit.
+
+## What I will NOT do in this session
+
+- Touch unrelated files
+- Reformat / rename / refactor anything outside the named files per item
+- Run `git push origin main` (only push to feature branches)
+- Run `railway up` — deploy is the user's call
+- Modify CI, migrations folder ordering, or any file not named above per item
+- Combine items into one branch


### PR DESCRIPTION
## Summary
Item #2 from the 2026-05-11 PM audit. Surfaces the public Postgres audit numbers (win rate, resolved-signal count, cumulative PnL) on /pricing.

- `apps/web/lib/pricing-stats.ts`: new `getPricingStats()` + pure `computePricingStats()` helper. Queries `signal_history` with the same is_simulated / zero-zero filters as landing-stats but **all-time** instead of 30d.
- `apps/web/lib/__tests__/pricing-stats.test.ts`: 5 unit tests covering empty / normal / rounding / divide-by-zero / bad-input cases
- `apps/web/app/pricing/page.tsx`: server component is now async, renders a 3-up stats strip between hero and pricing cards. Page-level ISR (`revalidate = 600`). Strip hides gracefully when no resolved signals yet.

## Why
The pricing page rendered our single highest-credibility asset — the public Postgres audit at /track-record — as feature-comparison row #6 with no number quoted. The strip puts the moat above the fold and deep-links to the full archive for verification.

## Plan doc
`docs/plans/2026-05-12-pro-audit-execution.md` (committed as part of this PR)

## Test plan
- [x] 5 unit tests pass
- [x] type-check clean (pre-existing WelcomeClient.tsx errors are unrelated)
- [ ] Visual: load /pricing, confirm strip renders with non-zero numbers when DB has resolved signals; confirm `/track-record` link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)