### PR TITLE
feat(trial): T-3d trial-ending email anchored to realized missed P&L

### DIFF
--- a/apps/web/app/api/cron/trial-reminders/route.ts
+++ b/apps/web/app/api/cron/trial-reminders/route.ts
@@ -1,14 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
+  getTrialingExpiringT3D,
   getTrialingExpiringWithin,
   getTrialingMissingTrialEnd,
   getUserById,
   markTrialReminderSent,
+  markTrialReminderT3DSent,
   setTrialEnd,
 } from '../../../../lib/db';
-import { sendTrialEndingEmail } from '../../../../lib/transactional-email';
+import {
+  sendTrialEndingEmail,
+  sendTrialEndingT3DEmail,
+} from '../../../../lib/transactional-email';
 import { getStripe } from '../../../../lib/stripe';
 import { requireCronAuth } from '../../../../lib/cron-auth';
+import { getMissedProPnL } from '../../../../lib/missed-pnl';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,11 +25,20 @@ export const dynamic = 'force-dynamic';
 const REMIND_FROM_HOURS = 12;
 const REMIND_TO_HOURS = 30;
 
+// Window for the T-3d sweep — 72h ± 12h. Same once-daily cron catches it.
+const T3D_FROM_HOURS = 60;
+const T3D_TO_HOURS = 84;
+
 interface ReminderSummary {
   checked: number;
   sent: number;
   failed: number;
   backfilled: number;
+}
+
+interface CombinedSummary {
+  t3d: { checked: number; sent: number; failed: number };
+  t1d: ReminderSummary;
 }
 
 async function backfillMissingTrialEnds(): Promise<number> {
@@ -113,11 +128,81 @@ async function runReminderSweep(): Promise<ReminderSummary> {
   return { checked: due.length, sent, failed, backfilled };
 }
 
+async function runT3DSweep(): Promise<{ checked: number; sent: number; failed: number }> {
+  const due = await getTrialingExpiringT3D(T3D_FROM_HOURS, T3D_TO_HOURS);
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const sub of due) {
+    if (!sub.trialEnd) continue;
+    try {
+      const user = await getUserById(sub.userId);
+      if (!user?.email) {
+        console.warn('[cron/trial-reminders/t3d] user has no email:', sub.userId);
+        continue;
+      }
+
+      let amountCents = 0;
+      let currency = 'usd';
+      try {
+        const stripeSub = await getStripe().subscriptions.retrieve(sub.stripeSubscriptionId);
+        const item = stripeSub.items.data[0];
+        amountCents = item?.price?.unit_amount ?? 0;
+        currency = item?.price?.currency ?? 'usd';
+      } catch (err) {
+        console.error(
+          '[cron/trial-reminders/t3d] price lookup failed:',
+          sub.stripeSubscriptionId,
+          err instanceof Error ? err.message : err,
+        );
+      }
+
+      // Enrich with missed-P&L from the trial window. Fail-soft: any error
+      // in the enrichment path returns an empty pitch — the email still
+      // ships, just without the dollars hook.
+      const missed = await getMissedProPnL(sub.createdAt);
+
+      const result = await sendTrialEndingT3DEmail(user.email, {
+        trialEndsAt: sub.trialEnd,
+        amountCents,
+        currency,
+        missedSymbols: missed.signals.map((s) => s.symbol),
+        missedPnlPct: missed.totalPnlPct,
+        missedPnlDollars: missed.totalPnlDollars,
+      });
+
+      if (result.ok) {
+        await markTrialReminderT3DSent(sub.stripeSubscriptionId);
+        sent += 1;
+      } else {
+        console.error(
+          '[cron/trial-reminders/t3d] send failed:',
+          result.reason,
+          sub.stripeSubscriptionId,
+        );
+        failed += 1;
+      }
+    } catch (err) {
+      console.error(
+        '[cron/trial-reminders/t3d] handler threw:',
+        sub.stripeSubscriptionId,
+        err instanceof Error ? err.message : err,
+      );
+      failed += 1;
+    }
+  }
+
+  return { checked: due.length, sent, failed };
+}
+
 export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireCronAuth(request);
   if (denied) return denied;
   try {
-    const summary = await runReminderSweep();
+    const t1d = await runReminderSweep();
+    const t3d = await runT3DSweep();
+    const summary: CombinedSummary = { t3d, t1d };
     return NextResponse.json({ ...summary, timestamp: new Date().toISOString() });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Reminder sweep failed';

--- a/apps/web/lib/__tests__/missed-pnl.test.ts
+++ b/apps/web/lib/__tests__/missed-pnl.test.ts
@@ -1,0 +1,99 @@
+import {
+  computeMissedPnl,
+  type MissedPnlSignal,
+} from '../missed-pnl';
+
+function sig(overrides: Partial<MissedPnlSignal> = {}): MissedPnlSignal {
+  return {
+    symbol: 'BTCUSD',
+    direction: 'BUY',
+    pnlPct: 2,
+    createdAt: '2026-05-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('missed-pnl — computeMissedPnl', () => {
+  it('returns empty result when no signals', () => {
+    const result = computeMissedPnl([]);
+    expect(result).toEqual({
+      signals: [],
+      totalPnlPct: 0,
+      totalPnlDollars: 0,
+    });
+  });
+
+  it('picks top N by pnlPct descending', () => {
+    const inputs: MissedPnlSignal[] = [
+      sig({ symbol: 'A', pnlPct: 1 }),
+      sig({ symbol: 'B', pnlPct: 5 }),
+      sig({ symbol: 'C', pnlPct: 3 }),
+      sig({ symbol: 'D', pnlPct: 4 }),
+      sig({ symbol: 'E', pnlPct: 2 }),
+    ];
+    const result = computeMissedPnl(inputs, { topN: 3 });
+    expect(result.signals.map((s) => s.symbol)).toEqual(['B', 'D', 'C']);
+    expect(result.totalPnlPct).toBeCloseTo(12, 5);
+  });
+
+  it('default top N is 3', () => {
+    const inputs: MissedPnlSignal[] = [
+      sig({ symbol: 'A', pnlPct: 1 }),
+      sig({ symbol: 'B', pnlPct: 2 }),
+      sig({ symbol: 'C', pnlPct: 3 }),
+      sig({ symbol: 'D', pnlPct: 4 }),
+    ];
+    const result = computeMissedPnl(inputs);
+    expect(result.signals).toHaveLength(3);
+  });
+
+  it('excludes negative pnlPct — only counts wins they missed', () => {
+    const inputs: MissedPnlSignal[] = [
+      sig({ symbol: 'A', pnlPct: 5 }),
+      sig({ symbol: 'B', pnlPct: -3 }),
+      sig({ symbol: 'C', pnlPct: -10 }),
+      sig({ symbol: 'D', pnlPct: 2 }),
+    ];
+    const result = computeMissedPnl(inputs, { topN: 3 });
+    expect(result.signals.map((s) => s.symbol)).toEqual(['A', 'D']);
+    expect(result.totalPnlPct).toBeCloseTo(7, 5);
+  });
+
+  it('computes dollars from default 1% sizing on $10k', () => {
+    // pnlPct=5 means price moved 5%. 1% of $10k = $100 position.
+    // $100 * 5% = $5 P&L per trade.
+    const inputs: MissedPnlSignal[] = [sig({ pnlPct: 5 })];
+    const result = computeMissedPnl(inputs, { topN: 1 });
+    expect(result.totalPnlPct).toBeCloseTo(5, 5);
+    expect(result.totalPnlDollars).toBeCloseTo(5, 2);
+  });
+
+  it('respects custom positionSizePct and notional', () => {
+    // 2% size on $50k account = $1000 position. 5% move = $50.
+    const inputs: MissedPnlSignal[] = [sig({ pnlPct: 5 })];
+    const result = computeMissedPnl(inputs, {
+      topN: 1,
+      positionSizePct: 2,
+      notional: 50_000,
+    });
+    expect(result.totalPnlDollars).toBeCloseTo(50, 2);
+  });
+
+  it('returns zero dollars when all signals are losses', () => {
+    const inputs: MissedPnlSignal[] = [
+      sig({ pnlPct: -2 }),
+      sig({ pnlPct: -5 }),
+    ];
+    const result = computeMissedPnl(inputs);
+    expect(result.totalPnlPct).toBe(0);
+    expect(result.totalPnlDollars).toBe(0);
+    expect(result.signals).toHaveLength(0);
+  });
+
+  it('rounds dollars to two decimal places', () => {
+    // 3.33% on 1% size of $10k = $3.33
+    const inputs: MissedPnlSignal[] = [sig({ pnlPct: 3.33 })];
+    const result = computeMissedPnl(inputs, { topN: 1 });
+    expect(result.totalPnlDollars).toBeCloseTo(3.33, 2);
+  });
+});

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -389,6 +389,36 @@ export async function markTrialReminderSent(stripeSubscriptionId: string): Promi
   );
 }
 
+/**
+ * Trialing subs in the T-3d window that haven't received the T-3d email.
+ * Mirrors getTrialingExpiringWithin but predicates on the new column added
+ * in migration 029 so the T-1d and T-3d sweeps stay independent.
+ */
+export async function getTrialingExpiringT3D(
+  hoursFrom: number,
+  hoursTo: number,
+): Promise<SubscriptionRecord[]> {
+  const rows = await query<SubscriptionRow>(
+    `SELECT ${SUBSCRIPTION_COLUMNS}
+     FROM subscriptions
+     WHERE status = 'trialing'
+       AND trial_end IS NOT NULL
+       AND trial_end BETWEEN NOW() + ($1 || ' hours')::interval
+                         AND NOW() + ($2 || ' hours')::interval
+       AND trial_reminder_t3d_sent_at IS NULL`,
+    [hoursFrom, hoursTo],
+  );
+  return rows.map(toSubscriptionRecord);
+}
+
+export async function markTrialReminderT3DSent(stripeSubscriptionId: string): Promise<void> {
+  await execute(
+    `UPDATE subscriptions SET trial_reminder_t3d_sent_at = NOW(), updated_at = NOW()
+     WHERE stripe_subscription_id = $1`,
+    [stripeSubscriptionId],
+  );
+}
+
 export async function cancelSubscription(
   stripeSubscriptionId: string,
 ): Promise<void> {

--- a/apps/web/lib/missed-pnl.ts
+++ b/apps/web/lib/missed-pnl.ts
@@ -1,0 +1,108 @@
+import { query } from './db-pool';
+import { PRO_PREMIUM_MIN_CONFIDENCE } from './tier';
+
+export interface MissedPnlSignal {
+  symbol: string;
+  direction: 'BUY' | 'SELL';
+  pnlPct: number;
+  createdAt: string;
+}
+
+export interface MissedPnlOptions {
+  topN?: number;
+  positionSizePct?: number;
+  notional?: number;
+}
+
+export interface MissedPnlResult {
+  signals: MissedPnlSignal[];
+  totalPnlPct: number;
+  totalPnlDollars: number;
+}
+
+const DEFAULT_TOP_N = 3;
+const DEFAULT_POSITION_SIZE_PCT = 1;
+const DEFAULT_NOTIONAL = 10_000;
+
+function roundTo(n: number, decimals: number): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round(n * factor) / factor;
+}
+
+export function computeMissedPnl(
+  signals: MissedPnlSignal[],
+  opts: MissedPnlOptions = {},
+): MissedPnlResult {
+  const topN = opts.topN ?? DEFAULT_TOP_N;
+  const positionSizePct = opts.positionSizePct ?? DEFAULT_POSITION_SIZE_PCT;
+  const notional = opts.notional ?? DEFAULT_NOTIONAL;
+
+  const wins = signals
+    .filter((s) => s.pnlPct > 0)
+    .sort((a, b) => b.pnlPct - a.pnlPct)
+    .slice(0, topN);
+
+  const totalPnlPct = wins.reduce((acc, s) => acc + s.pnlPct, 0);
+
+  // Dollars = pnlPct (as %) * position size as $ / 100
+  //        = pnlPct * (positionSizePct / 100 * notional) / 100
+  //        = pnlPct * positionSizePct * notional / 10_000
+  const totalPnlDollarsRaw = (totalPnlPct * positionSizePct * notional) / 10_000;
+
+  return {
+    signals: wins,
+    totalPnlPct: roundTo(totalPnlPct, 2),
+    totalPnlDollars: roundTo(totalPnlDollarsRaw, 2),
+  };
+}
+
+interface PnlRow {
+  pair: string;
+  direction: 'BUY' | 'SELL';
+  pnl_pct: string;
+  created_at: string;
+}
+
+/**
+ * Pull Pro-band winning signals from the user's trial window and compute
+ * the missed-P&L pitch. Pro band = confidence at or above
+ * PRO_PREMIUM_MIN_CONFIDENCE (the threshold free callers cannot see).
+ *
+ * Fail-soft: empty result on any DB error so the cron never blocks an
+ * email send because the pitch enrichment failed.
+ */
+export async function getMissedProPnL(
+  trialStart: Date,
+  opts: MissedPnlOptions = {},
+): Promise<MissedPnlResult> {
+  try {
+    const rows = await query<PnlRow>(
+      `SELECT pair, direction,
+              (outcome_24h->>'pnlPct')::numeric::text AS pnl_pct,
+              created_at
+         FROM signal_history
+        WHERE created_at >= $1
+          AND created_at <= NOW()
+          AND is_simulated = FALSE
+          AND outcome_24h IS NOT NULL
+          AND confidence >= $2
+          AND (outcome_24h->>'pnlPct')::numeric > 0
+          AND NOT ((outcome_24h->>'pnlPct')::numeric = 0
+                   AND (outcome_24h->>'hit')::boolean = FALSE)
+        ORDER BY (outcome_24h->>'pnlPct')::numeric DESC
+        LIMIT 25`,
+      [trialStart, PRO_PREMIUM_MIN_CONFIDENCE],
+    );
+
+    const signals: MissedPnlSignal[] = rows.map((r) => ({
+      symbol: r.pair,
+      direction: r.direction,
+      pnlPct: Number(r.pnl_pct),
+      createdAt: new Date(r.created_at).toISOString(),
+    }));
+
+    return computeMissedPnl(signals, opts);
+  } catch {
+    return computeMissedPnl([], opts);
+  }
+}

--- a/apps/web/lib/transactional-email.ts
+++ b/apps/web/lib/transactional-email.ts
@@ -233,6 +233,140 @@ export async function sendTrialEndingEmail(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Trial-ending reminder (T-3d) — anchored to realized missed P&L
+// ---------------------------------------------------------------------------
+
+export interface TrialEndingT3DEmailOpts {
+  trialEndsAt: Date;
+  amountCents: number;
+  currency: string;
+  /** Top-N missed Pro signal symbols (max 3) — already filtered to winners only. */
+  missedSymbols: string[];
+  /** Cumulative pnlPct of the top-N missed signals. */
+  missedPnlPct: number;
+  /** Equivalent $ if user had taken those signals at 1% sizing on $10k. */
+  missedPnlDollars: number;
+}
+
+function buildTrialEndingT3DSubject(opts: TrialEndingT3DEmailOpts): string {
+  if (opts.missedPnlDollars > 0) {
+    const dollarsRounded = Math.round(opts.missedPnlDollars);
+    return `You missed $${dollarsRounded} in Pro signals — trial ends in 3 days`;
+  }
+  return 'Your TradeClaw Pro trial ends in 3 days';
+}
+
+function buildTrialEndingT3DText(opts: TrialEndingT3DEmailOpts): string {
+  const amount = opts.amountCents > 0 ? fmtAmount(opts.amountCents, opts.currency) : '';
+  const endDate = fmtDate(opts.trialEndsAt);
+  const symbolList = opts.missedSymbols.slice(0, 3).join(', ');
+  const lines: string[] = [];
+
+  if (opts.missedPnlDollars > 0 && symbolList) {
+    lines.push(
+      `If you'd taken our top ${opts.missedSymbols.length} Pro signals during your trial`,
+      `(${symbolList}) at 1% sizing on a $10k account,`,
+      `you'd be up $${opts.missedPnlDollars.toFixed(2)} (${opts.missedPnlPct.toFixed(1)}%).`,
+      '',
+    );
+  }
+
+  lines.push(
+    `Your TradeClaw Pro trial ends ${endDate} — 3 days from now.`,
+    '',
+    amount ? `We'll charge ${amount} to your card on file when the trial converts.` : '',
+    '',
+    'Want to keep the Pro signals coming? No action needed.',
+    '',
+    'Want to cancel? Do it now to avoid the charge:',
+    'https://tradeclaw.win/dashboard/billing',
+    '',
+    'Every signal, entry, and outcome is in our public Postgres at',
+    'https://tradeclaw.win/track-record — verify before you decide.',
+    '',
+    'Questions? Reply to this email or contact support@tradeclaw.win.',
+    '',
+    'TradeClaw',
+    'https://tradeclaw.win',
+  );
+  return lines.filter((l) => l !== '').join('\n');
+}
+
+function buildTrialEndingT3DHtml(opts: TrialEndingT3DEmailOpts): string {
+  const amount = opts.amountCents > 0 ? fmtAmount(opts.amountCents, opts.currency) : '';
+  const endDate = fmtDate(opts.trialEndsAt);
+  const symbolList = opts.missedSymbols.slice(0, 3).join(', ');
+  const showPitch = opts.missedPnlDollars > 0 && symbolList.length > 0;
+
+  return [
+    `<!doctype html><html><body style="background:#0a0a0a;margin:0;padding:24px;color:#e2e8f0">`,
+    `<table cellpadding="0" cellspacing="0" style="max-width:520px;margin:0 auto;background:#111;border:1px solid #1f2937;border-radius:12px;overflow:hidden">`,
+    `<tr><td style="padding:20px 24px;border-bottom:1px solid #1f2937">`,
+    `<div style="font:600 14px/1 system-ui;color:#10b981;letter-spacing:0.06em;text-transform:uppercase">Trial ending in 3 days</div>`,
+    `<div style="font:600 22px/1.2 system-ui;color:#fff;margin-top:6px">Trial ends ${endDate}</div>`,
+    `</td></tr>`,
+    showPitch
+      ? `<tr><td style="padding:20px 24px;background:#0d2b1f;border-bottom:1px solid #1f2937">
+           <div style="font:600 13px/1 system-ui;color:#10b981;letter-spacing:0.04em;text-transform:uppercase;margin-bottom:8px">Missed during your trial</div>
+           <div style="font:700 28px/1.1 system-ui;color:#fff">+$${opts.missedPnlDollars.toFixed(2)}</div>
+           <div style="font:14px/1.5 system-ui;color:#cbd5e1;margin-top:8px">
+             If you&apos;d taken our top Pro signals (<strong style="color:#fff">${symbolList}</strong>) at 1% sizing on a $10k account, you&apos;d be up <strong style="color:#10b981">${opts.missedPnlPct.toFixed(1)}%</strong>.
+           </div>
+         </td></tr>`
+      : '',
+    `<tr><td style="padding:20px 24px;font:14px/1.6 system-ui;color:#cbd5e1">`,
+    amount
+      ? `<p style="margin:0 0 14px">We&apos;ll charge <strong style="color:#fff">${amount}</strong> on ${endDate} when the trial converts.</p>`
+      : `<p style="margin:0 0 14px">Your trial converts to paid on ${endDate}.</p>`,
+    `<p style="margin:0 0 18px">Want to keep the Pro signals coming? No action needed.</p>`,
+    `<p style="margin:0 0 18px"><a href="https://tradeclaw.win/dashboard/billing" style="display:inline-block;background:#10b981;color:#0a0a0a;font:600 14px/1 system-ui;padding:12px 20px;border-radius:8px;text-decoration:none">Manage billing</a></p>`,
+    `<p style="margin:0;color:#94a3b8;font-size:13px">Every entry and outcome is auditable in our public Postgres at <a href="https://tradeclaw.win/track-record" style="color:#10b981;text-decoration:none">tradeclaw.win/track-record</a>.</p>`,
+    `</td></tr>`,
+    `<tr><td style="padding:14px 24px;border-top:1px solid #1f2937;font:12px/1.5 system-ui;color:#64748b">`,
+    `Questions? Reply or contact <a href="mailto:support@tradeclaw.win" style="color:#10b981;text-decoration:none">support@tradeclaw.win</a>.`,
+    `</td></tr>`,
+    `</table></body></html>`,
+  ].filter((s) => s !== '').join('');
+}
+
+export async function sendTrialEndingT3DEmail(
+  to: string,
+  opts: TrialEndingT3DEmailOpts,
+): Promise<EmailSendResult> {
+  if (!to) return { ok: false, reason: 'no_to_address' };
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return { ok: false, reason: 'no_api_key' };
+
+  const from = process.env.RESEND_FROM_EMAIL;
+  if (!from) return { ok: false, reason: 'no_from_address' };
+
+  try {
+    const res = await fetch(RESEND_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from,
+        to: [to],
+        subject: buildTrialEndingT3DSubject(opts),
+        text: buildTrialEndingT3DText(opts),
+        html: buildTrialEndingT3DHtml(opts),
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!res.ok) return { ok: false, reason: 'provider_error' };
+    const data = (await res.json().catch(() => ({}))) as { id?: string };
+    return { ok: true, providerId: data.id };
+  } catch {
+    return { ok: false, reason: 'network_error' };
+  }
+}
+
 export const __test__ = {
   buildPaymentFailedSubject,
   buildPaymentFailedText,
@@ -240,6 +374,9 @@ export const __test__ = {
   buildTrialEndingSubject,
   buildTrialEndingText,
   buildTrialEndingHtml,
+  buildTrialEndingT3DSubject,
+  buildTrialEndingT3DText,
+  buildTrialEndingT3DHtml,
   fmtAmount,
   fmtDate,
 };

--- a/apps/web/migrations/029_trial_t3d_reminder.sql
+++ b/apps/web/migrations/029_trial_t3d_reminder.sql
@@ -1,0 +1,32 @@
+-- T-3d trial reminder support.
+--
+-- Background: the existing T-1d email (migration 023) lands when the
+-- trial is already over from a cancel-decision standpoint — Stripe Smart
+-- Retries don't run on trial conversions, and most users who want to
+-- cancel a trial decide 2-3 days before the charge, not 24 hours before.
+--
+-- To anchor the cancel decision to concrete dollars instead of a generic
+-- countdown, /api/cron/trial-reminders gains a T-3d sweep that emails:
+--   "If you'd taken our top 3 Pro signals at 1% sizing during your trial,
+--    you'd be up $X. Card hits in 3 days."
+--
+-- - trial_reminder_t3d_sent_at: Set by /api/cron/trial-reminders when the
+--                               T-3d email lands. Separate column from
+--                               trial_reminder_sent_at so the T-1d email
+--                               still ships independently — both can fire
+--                               for the same subscription across the trial.
+--
+-- Column is nullable. No backfill — existing trialing subs simply skip
+-- the T-3d window since the cron predicates on the new column being NULL.
+--
+-- Apply on Railway with:
+--   psql "$DATABASE_URL" -f apps/web/migrations/029_trial_t3d_reminder.sql
+
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS trial_reminder_t3d_sent_at TIMESTAMP WITH TIME ZONE NULL;
+
+-- Cron query path mirrors idx_subscriptions_trialing_due — partial index
+-- keeps it small (only trialing rows that haven't been T-3d emailed yet).
+CREATE INDEX IF NOT EXISTS idx_subscriptions_trialing_t3d_due
+  ON subscriptions (trial_end)
+  WHERE status = 'trialing' AND trial_reminder_t3d_sent_at IS NULL;


### PR DESCRIPTION
## Summary
Item #3 from the 2026-05-11 PM audit. New T-3d email anchors the cancel decision to concrete dollars instead of a generic countdown — what the user **would have made** during their trial if they'd taken the top Pro signals.

Three commits, one per layer:
1. **`feat(db)`**: migration `029_trial_t3d_reminder.sql` — adds `trial_reminder_t3d_sent_at` column to `subscriptions` + partial index for the cron query path. Idempotent (IF NOT EXISTS) and additive only.
2. **`feat(trial)`**: service layer — `lib/missed-pnl.ts` (pure compute + DB query, 1% sizing on \$10k by default), `lib/db.ts` T-3d helpers, `lib/transactional-email.ts` T-3d template.
3. **`feat(cron/trial-reminders)`**: extend the cron handler with a T-3d sweep (window 60-84h) alongside the existing T-1d sweep (12-30h). Independent idempotency, both can fire for one trial.

## ⚠️ Pre-merge step
**Apply migration on Railway BEFORE merging this PR**:
\`\`\`
railway run --service web psql "\$DATABASE_URL" -f apps/web/migrations/029_trial_t3d_reminder.sql
\`\`\`

The migration is idempotent and additive. The new cron path predicates on the new column being NULL, so existing trialing subs simply skip the T-3d window — no backfill needed.

## Test plan
- [x] 8 new `missed-pnl` unit tests + 18 existing `transactional-email` tests pass
- [x] type-check clean
- [ ] Apply migration 029 on Railway
- [ ] Hit `/api/cron/trial-reminders` with `CRON_SECRET` on staging; confirm JSON response has new `{ t3d, t1d, timestamp }` shape
- [ ] Seed a trialing row in the T-3d window, run cron, verify email sent + `trial_reminder_t3d_sent_at` populated

## Response shape change
Cron route response changed from `{ checked, sent, failed, backfilled }` to `{ t3d, t1d, timestamp }`. Any external observability tile reading the old top-level fields will see undefined.

## Plan doc
`docs/plans/2026-05-12-pro-audit-execution.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)