### PR TITLE
feat(pricing): Elite Coming Soon card — waitlist + WTP survey

### DIFF
--- a/apps/web/app/api/elite/interest/route.ts
+++ b/apps/web/app/api/elite/interest/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  hashIpForInterest,
+  upsertEliteInterest,
+  validateEliteInterest,
+  type EliteInterestInput,
+  type WtpChoice,
+} from '../../../../lib/elite-interest';
+import { check } from '../../../../lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+interface ParsedBody {
+  email: string;
+  wantsLiveTrade: boolean;
+  wantsCopyTrade: boolean;
+  wtpChoice: WtpChoice | null;
+  source: string | null;
+}
+
+function getClientIp(req: NextRequest): string | null {
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0]?.trim() || null;
+  const realIp = req.headers.get('x-real-ip');
+  if (realIp) return realIp.trim();
+  return null;
+}
+
+function parseBody(raw: unknown): { ok: true; body: ParsedBody } | { ok: false; error: string } {
+  if (typeof raw !== 'object' || raw === null) {
+    return { ok: false, error: 'Body must be a JSON object' };
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r.email !== 'string') {
+    return { ok: false, error: 'email is required' };
+  }
+  const wantsLiveTrade = Boolean(r.wantsLiveTrade);
+  const wantsCopyTrade = Boolean(r.wantsCopyTrade);
+  const wtpChoiceRaw = r.wtpChoice;
+  const wtpChoice: WtpChoice | null =
+    wtpChoiceRaw === null || wtpChoiceRaw === undefined
+      ? null
+      : (String(wtpChoiceRaw) as WtpChoice);
+  const source = typeof r.source === 'string' ? r.source.slice(0, 64) : null;
+  return {
+    ok: true,
+    body: { email: r.email, wantsLiveTrade, wantsCopyTrade, wtpChoice, source },
+  };
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const ip = getClientIp(req);
+  const rateKey = `elite-interest:${ip ?? 'anon'}`;
+  const decision = check(rateKey, { max: RATE_LIMIT_MAX, windowMs: RATE_LIMIT_WINDOW_MS });
+  if (!decision.allowed) {
+    return NextResponse.json(
+      { error: 'rate_limited', retryAfterSec: 60 },
+      { status: 429 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = parseBody(raw);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const input: EliteInterestInput = {
+    email: parsed.body.email,
+    wantsLiveTrade: parsed.body.wantsLiveTrade,
+    wantsCopyTrade: parsed.body.wantsCopyTrade,
+    wtpChoice: parsed.body.wtpChoice,
+    ipHash: await hashIpForInterest(ip),
+    source: parsed.body.source ?? 'pricing',
+  };
+
+  const validation = validateEliteInterest(input);
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  try {
+    const record = await upsertEliteInterest(input);
+    return NextResponse.json({
+      ok: true,
+      isNew: record.isNew,
+      message: record.isNew
+        ? "You're on the Elite list. We'll email when we open the doors."
+        : 'Updated your preferences. Thanks for the input.',
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Persistence failed';
+    console.error('[api/elite/interest] upsert failed:', message);
+    return NextResponse.json({ error: 'Could not save your interest. Try again shortly.' }, { status: 500 });
+  }
+}

--- a/apps/web/app/pricing/PricingCards.tsx
+++ b/apps/web/app/pricing/PricingCards.tsx
@@ -6,6 +6,7 @@ import {
   TIER_DEFINITIONS,
   type TierDefinition,
 } from '../../lib/stripe-tiers';
+import { EliteInterestForm } from '../../components/EliteInterestForm';
 
 type Interval = 'monthly' | 'annual';
 
@@ -306,6 +307,58 @@ export function PricingCards() {
         <FreeCard def={freeDef} />
         <ProCard def={proDef} interval={billingInterval} />
       </div>
+      <EliteComingSoonCard />
     </>
+  );
+}
+
+function EliteComingSoonCard() {
+  return (
+    <div
+      data-testid="elite-coming-soon-card"
+      className="mx-auto mt-8 max-w-3xl rounded-2xl border border-amber-500/30 bg-gradient-to-br from-amber-500/[0.04] to-emerald-500/[0.04] p-6 shadow-[0_0_40px_rgba(245,158,11,0.06)]"
+    >
+      <div className="grid gap-6 md:grid-cols-2">
+        <div>
+          <div className="mb-3 flex items-center gap-2">
+            <span className="rounded-full bg-amber-500/20 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider text-amber-300">
+              Coming soon
+            </span>
+            <span className="text-xs font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+              Elite
+            </span>
+          </div>
+          <h3 className="text-2xl font-bold text-[var(--foreground)]">
+            Hands-off Pro.
+          </h3>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            Pricing TBD — help us set it. Tell us which pieces you&apos;d use and what you&apos;d pay.
+          </p>
+          <ul className="mt-5 flex flex-col gap-3 text-sm text-[var(--foreground)]">
+            <li className="flex items-start gap-2">
+              <span className="mt-1 inline-block h-2 w-2 shrink-0 rounded-full bg-emerald-400" />
+              <div>
+                <div className="font-semibold text-emerald-400">Copy trade</div>
+                <div className="text-[var(--text-secondary)]">
+                  Your account mirrors our Pro signals automatically — entries, exits, sizing. The moat.
+                </div>
+              </div>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 inline-block h-2 w-2 shrink-0 rounded-full bg-amber-400" />
+              <div>
+                <div className="font-semibold text-[var(--foreground)]">Connect to live trade</div>
+                <div className="text-[var(--text-secondary)]">
+                  Pro signals pushed straight to your broker (MT5, Alpaca, IB), no manual entry.
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--glass-bg)] p-5">
+          <EliteInterestForm source="pricing" />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/components/EliteInterestForm.tsx
+++ b/apps/web/components/EliteInterestForm.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+
+type WtpChoice = '49' | '99' | '199' | '499' | '999_plus' | 'other';
+
+interface WtpOption {
+  value: WtpChoice;
+  label: string;
+}
+
+const WTP_OPTIONS: WtpOption[] = [
+  { value: '49', label: '$49/mo' },
+  { value: '99', label: '$99/mo' },
+  { value: '199', label: '$199/mo' },
+  { value: '499', label: '$499/mo' },
+  { value: '999_plus', label: '$999+/mo' },
+  { value: 'other', label: 'Not sure yet' },
+];
+
+export interface EliteInterestFormProps {
+  source?: string;
+}
+
+export function EliteInterestForm({ source = 'pricing' }: EliteInterestFormProps) {
+  const [email, setEmail] = useState('');
+  const [wantsLiveTrade, setWantsLiveTrade] = useState(true);
+  const [wantsCopyTrade, setWantsCopyTrade] = useState(true);
+  const [wtpChoice, setWtpChoice] = useState<WtpChoice | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/elite/interest', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          wantsLiveTrade,
+          wantsCopyTrade,
+          wtpChoice,
+          source,
+        }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        message?: string;
+        error?: string;
+      };
+      if (!res.ok || !payload.ok) {
+        throw new Error(payload.error ?? 'Submission failed');
+      }
+      setSuccessMessage(payload.message ?? "You're on the list.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (successMessage) {
+    return (
+      <div
+        role="status"
+        data-testid="elite-interest-success"
+        className="rounded-lg border border-emerald-500/40 bg-emerald-500/[0.08] p-4 text-center text-sm text-emerald-200"
+      >
+        {successMessage}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      data-testid="elite-interest-form"
+      className="flex flex-col gap-4"
+    >
+      <div>
+        <label htmlFor="elite-email" className="mb-1 block text-xs font-medium uppercase tracking-wider text-[var(--text-secondary)]">
+          Email
+        </label>
+        <input
+          id="elite-email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--text-secondary)] focus:border-emerald-500 focus:outline-none"
+        />
+      </div>
+
+      <fieldset>
+        <legend className="mb-2 text-xs font-medium uppercase tracking-wider text-[var(--text-secondary)]">
+          Most interested in
+        </legend>
+        <div className="flex flex-col gap-2">
+          <label className="flex items-start gap-2 text-sm text-[var(--foreground)]">
+            <input
+              type="checkbox"
+              checked={wantsCopyTrade}
+              onChange={(e) => setWantsCopyTrade(e.target.checked)}
+              className="mt-1 accent-emerald-500"
+            />
+            <span>
+              <span className="font-semibold text-emerald-400">Copy trade</span> — your account mirrors our Pro signals automatically
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-sm text-[var(--foreground)]">
+            <input
+              type="checkbox"
+              checked={wantsLiveTrade}
+              onChange={(e) => setWantsLiveTrade(e.target.checked)}
+              className="mt-1 accent-emerald-500"
+            />
+            <span>
+              Connect to live trade — Pro signals pushed straight to your broker
+            </span>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend className="mb-2 text-xs font-medium uppercase tracking-wider text-[var(--text-secondary)]">
+          What would you pay per month?
+        </legend>
+        <div className="grid grid-cols-3 gap-2">
+          {WTP_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setWtpChoice(opt.value)}
+              aria-pressed={wtpChoice === opt.value}
+              className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                wtpChoice === opt.value
+                  ? 'border-emerald-500 bg-emerald-500/[0.12] text-emerald-200'
+                  : 'border-[var(--border)] bg-[var(--background)] text-[var(--foreground)] hover:border-[var(--glass-border-accent)]'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <button
+        type="submit"
+        disabled={submitting || (!wantsLiveTrade && !wantsCopyTrade)}
+        data-testid="elite-interest-submit"
+        className="rounded-lg bg-emerald-500 py-2.5 text-sm font-semibold text-black transition-all hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {submitting ? 'Sending…' : 'Get on the Elite list'}
+      </button>
+
+      {error && (
+        <p role="alert" className="text-center text-xs text-red-400">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/apps/web/lib/__tests__/elite-interest.test.ts
+++ b/apps/web/lib/__tests__/elite-interest.test.ts
@@ -1,0 +1,84 @@
+import {
+  validateEliteInterest,
+  wtpChoiceToCents,
+  type EliteInterestInput,
+} from '../elite-interest';
+
+function valid(overrides: Partial<EliteInterestInput> = {}): EliteInterestInput {
+  return {
+    email: 'trader@example.com',
+    wantsLiveTrade: true,
+    wantsCopyTrade: true,
+    wtpChoice: '99',
+    ...overrides,
+  };
+}
+
+describe('elite-interest — wtpChoiceToCents', () => {
+  it('maps each fixed bucket to cents', () => {
+    expect(wtpChoiceToCents('49')).toBe(4900);
+    expect(wtpChoiceToCents('99')).toBe(9900);
+    expect(wtpChoiceToCents('199')).toBe(19900);
+    expect(wtpChoiceToCents('499')).toBe(49900);
+    expect(wtpChoiceToCents('999_plus')).toBe(99900);
+  });
+
+  it('returns null for "other" and null inputs', () => {
+    expect(wtpChoiceToCents('other')).toBeNull();
+    expect(wtpChoiceToCents(null)).toBeNull();
+  });
+});
+
+describe('elite-interest — validateEliteInterest', () => {
+  it('accepts a fully filled valid input', () => {
+    expect(validateEliteInterest(valid())).toEqual({ ok: true });
+  });
+
+  it('accepts null wtpChoice (user skipped the survey)', () => {
+    expect(validateEliteInterest(valid({ wtpChoice: null }))).toEqual({ ok: true });
+  });
+
+  it('rejects missing email', () => {
+    const result = validateEliteInterest(valid({ email: '' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/email/i);
+  });
+
+  it('rejects malformed email', () => {
+    const result = validateEliteInterest(valid({ email: 'not-an-email' }));
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects too-long email to prevent DB-truncation attacks', () => {
+    const long = 'a'.repeat(260) + '@x.com';
+    const result = validateEliteInterest(valid({ email: long }));
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects when neither feature checkbox is selected', () => {
+    const result = validateEliteInterest(
+      valid({ wantsLiveTrade: false, wantsCopyTrade: false }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/select.*at least one/i);
+  });
+
+  it('accepts wantsLiveTrade only', () => {
+    expect(
+      validateEliteInterest(valid({ wantsLiveTrade: true, wantsCopyTrade: false })),
+    ).toEqual({ ok: true });
+  });
+
+  it('accepts wantsCopyTrade only', () => {
+    expect(
+      validateEliteInterest(valid({ wantsLiveTrade: false, wantsCopyTrade: true })),
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects an invalid wtpChoice value', () => {
+    const result = validateEliteInterest(
+      valid({ wtpChoice: 'bogus' as unknown as EliteInterestInput['wtpChoice'] }),
+    );
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/web/lib/elite-interest.ts
+++ b/apps/web/lib/elite-interest.ts
@@ -1,0 +1,168 @@
+import { execute, queryOne } from './db-pool';
+
+export type WtpChoice = '49' | '99' | '199' | '499' | '999_plus' | 'other';
+
+export const WTP_CHOICES: readonly WtpChoice[] = [
+  '49',
+  '99',
+  '199',
+  '499',
+  '999_plus',
+  'other',
+] as const;
+
+export interface EliteInterestInput {
+  email: string;
+  wantsLiveTrade: boolean;
+  wantsCopyTrade: boolean;
+  wtpChoice: WtpChoice | null;
+  ipHash?: string | null;
+  source?: string | null;
+}
+
+export interface EliteInterestRecord {
+  id: number;
+  email: string;
+  wantsLiveTrade: boolean;
+  wantsCopyTrade: boolean;
+  wtpChoice: WtpChoice | null;
+  wtpMonthlyCents: number | null;
+  source: string | null;
+  createdAt: Date;
+  isNew: boolean;
+}
+
+const MAX_EMAIL_LEN = 254;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Map the survey's fixed buckets to monetary cents so downstream
+ * aggregation can do integer math. 'other' / null preserve the
+ * "user declined to anchor a price" signal.
+ */
+export function wtpChoiceToCents(choice: WtpChoice | null): number | null {
+  switch (choice) {
+    case '49':
+      return 4900;
+    case '99':
+      return 9900;
+    case '199':
+      return 19900;
+    case '499':
+      return 49900;
+    case '999_plus':
+      return 99900;
+    case 'other':
+    case null:
+      return null;
+  }
+}
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export function validateEliteInterest(input: EliteInterestInput): ValidationResult {
+  const email = (input.email ?? '').trim();
+  if (!email) return { ok: false, error: 'Email is required' };
+  if (email.length > MAX_EMAIL_LEN) return { ok: false, error: 'Email is too long' };
+  if (!EMAIL_REGEX.test(email)) return { ok: false, error: 'Email looks malformed' };
+
+  if (!input.wantsLiveTrade && !input.wantsCopyTrade) {
+    return { ok: false, error: 'Select at least one feature' };
+  }
+
+  if (input.wtpChoice !== null && !WTP_CHOICES.includes(input.wtpChoice)) {
+    return { ok: false, error: 'Invalid willingness-to-pay choice' };
+  }
+
+  return { ok: true };
+}
+
+interface InterestRow {
+  id: string;
+  email: string;
+  wants_live_trade: boolean;
+  wants_copy_trade: boolean;
+  wtp_choice: WtpChoice | null;
+  wtp_monthly_cents: number | null;
+  source: string | null;
+  created_at: string;
+}
+
+/**
+ * Upsert by lowercase email — repeat submissions overwrite the prior
+ * intent rather than producing duplicate rows. Returns isNew=true on
+ * the first insert, false on a subsequent update.
+ */
+export async function upsertEliteInterest(
+  input: EliteInterestInput,
+): Promise<EliteInterestRecord> {
+  const email = input.email.trim().toLowerCase();
+  const wtpCents = wtpChoiceToCents(input.wtpChoice);
+
+  // Use ON CONFLICT to detect new vs update via xmax — xmax=0 means
+  // INSERT (new row), nonzero means UPDATE.
+  const row = await queryOne<InterestRow & { is_new: boolean }>(
+    `INSERT INTO elite_interest
+       (email, wants_live_trade, wants_copy_trade, wtp_monthly_cents, wtp_choice, ip_hash, source)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (LOWER(email)) DO UPDATE SET
+       wants_live_trade = EXCLUDED.wants_live_trade,
+       wants_copy_trade = EXCLUDED.wants_copy_trade,
+       wtp_monthly_cents = EXCLUDED.wtp_monthly_cents,
+       wtp_choice = EXCLUDED.wtp_choice,
+       source = COALESCE(EXCLUDED.source, elite_interest.source),
+       updated_at = NOW()
+     RETURNING id, email, wants_live_trade, wants_copy_trade,
+               wtp_choice, wtp_monthly_cents, source, created_at,
+               (xmax = 0) AS is_new`,
+    [
+      email,
+      input.wantsLiveTrade,
+      input.wantsCopyTrade,
+      wtpCents,
+      input.wtpChoice,
+      input.ipHash ?? null,
+      input.source ?? null,
+    ],
+  );
+
+  if (!row) {
+    throw new Error('elite_interest upsert returned no row');
+  }
+
+  return {
+    id: Number(row.id),
+    email: row.email,
+    wantsLiveTrade: row.wants_live_trade,
+    wantsCopyTrade: row.wants_copy_trade,
+    wtpChoice: row.wtp_choice,
+    wtpMonthlyCents: row.wtp_monthly_cents,
+    source: row.source,
+    createdAt: new Date(row.created_at),
+    isNew: row.is_new,
+  };
+}
+
+export async function getEliteInterestCount(): Promise<number> {
+  try {
+    const row = await queryOne<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM elite_interest`,
+    );
+    return Number(row?.c ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+export async function hashIpForInterest(ip: string | null | undefined): Promise<string | null> {
+  if (!ip) return null;
+  const salt = process.env.ELITE_IP_HASH_SALT ?? '';
+  if (!salt) return null;
+  const { createHash } = await import('crypto');
+  return createHash('sha256').update(`${salt}|${ip}`).digest('hex');
+}
+
+// Re-export execute for tests that mock the DB layer.
+export const __test__ = { execute };

--- a/apps/web/migrations/030_elite_interest.sql
+++ b/apps/web/migrations/030_elite_interest.sql
@@ -1,0 +1,50 @@
+-- Elite-tier interest capture + willingness-to-pay (WTP) survey.
+--
+-- Background: Elite is the third tier above Pro. Its two pillars per the
+-- product roadmap are (a) connect-to-live-trade — pushing Pro signals
+-- into the user's broker — and (b) copy-trade, framed as the moat. Both
+-- features are non-trivial to ship, so the pricing page surfaces an Elite
+-- "Coming Soon" card with a waitlist + WTP form to gauge demand and price
+-- point before any Stripe products exist.
+--
+-- Columns:
+-- - email:               normalized lowercase, primary identity. UNIQUE so
+--                        a repeat submission is treated as an update of
+--                        intent rather than two rows.
+-- - wants_live_trade,
+--   wants_copy_trade:    feature interest checkboxes from the form.
+-- - wtp_monthly_cents:   willingness-to-pay survey answer, stored as cents
+--                        so currency-free integer math works. NULL when
+--                        the user picked "other" / declined to answer.
+-- - wtp_choice:          the raw survey selection ('49', '99', '199',
+--                        '499', '999_plus', 'other'). Kept alongside cents
+--                        so re-analysis later doesn't lose the bucket.
+-- - ip_hash:             SHA-256 of the client IP + secret salt, used for
+--                        rate-limit dedup without storing raw IPs.
+-- - source:              free-text "where did this submission come from"
+--                        (e.g. 'pricing', 'dashboard-banner'); helps
+--                        attribution.
+--
+-- Apply on Railway:
+--   psql "$DATABASE_URL" -f apps/web/migrations/030_elite_interest.sql
+--
+-- Idempotent (CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS elite_interest (
+  id                  BIGSERIAL PRIMARY KEY,
+  email               TEXT NOT NULL,
+  wants_live_trade    BOOLEAN NOT NULL DEFAULT FALSE,
+  wants_copy_trade    BOOLEAN NOT NULL DEFAULT FALSE,
+  wtp_monthly_cents   INTEGER NULL,
+  wtp_choice          TEXT NULL,
+  ip_hash             TEXT NULL,
+  source              TEXT NULL,
+  created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_elite_interest_email
+  ON elite_interest (LOWER(email));
+
+CREATE INDEX IF NOT EXISTS idx_elite_interest_created_at
+  ON elite_interest (created_at DESC);


### PR DESCRIPTION
## Summary
Item #4 (redefined) from the 2026-05-11 PM audit. Ships an Elite "Coming Soon" surface on /pricing with two value pillars: **copy-trade (the moat)** and connect-to-live-trade. No Stripe products created — pure lead capture + price discovery so the actual Elite build is evidence-driven.

Three commits, one per layer:
1. **`feat(db)`**: migration `030_elite_interest.sql` — new \`elite_interest\` table with email (lowercase UNIQUE), feature checkboxes, WTP bucket (cents + label), salted IP hash, source attribution. Idempotent and additive only.
2. **`feat(elite)`**: service layer — \`lib/elite-interest.ts\` (validateEliteInterest, wtpChoiceToCents, upsertEliteInterest, hashIpForInterest). 11 unit tests on the pure helpers.
3. **`feat(pricing)`**: route + UI — \`/api/elite/interest\` POST with 5 req/hr rate-limit and IP hashing; \`EliteInterestForm\` client component; \`EliteComingSoonCard\` rendered below the existing Free/Pro grid.

## ⚠️ Pre-merge step
**Apply migration on Railway BEFORE merging this PR**:
\`\`\`
railway run --service web psql "\$DATABASE_URL" -f apps/web/migrations/030_elite_interest.sql
\`\`\`

## Optional env var
\`ELITE_IP_HASH_SALT\` (Railway web service) — when set, the API hashes client IPs with SHA-256 before storing for rate-limit dedup. When unset, \`ip_hash\` stays NULL and the feature still works.

## Test plan
- [x] 11 unit tests pass (WTP mapping + every validation branch)
- [x] rate-limit interaction sanity-checked
- [x] type-check clean
- [ ] Apply migration 030 on Railway
- [ ] Submit form on staging — verify row in \`elite_interest\`; resubmit with different price — verify it updates, doesn't duplicate

## Survey buckets (locked-down)
\`49\` / \`99\` / \`199\` / \`499\` / \`999_plus\` / \`other\` — mapped to cents in the lib for downstream aggregation.

## Plan doc
\`docs/plans/2026-05-12-pro-audit-execution.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)