### PR TITLE
feat(signals): wire MTF re-boost so confidence reaches premium band

### DIFF
--- a/apps/web/app/lib/signals.ts
+++ b/apps/web/app/lib/signals.ts
@@ -3,7 +3,12 @@
 
 import { getMultiOHLCV } from './ohlcv';
 import { calculateAllIndicators } from './ta-engine';
-import { generateSignalsFromTA, type StrategyProfileId } from './signal-generator';
+import {
+  generateSignalsFromTA,
+  generateMultiTFSignal,
+  type SignalMode,
+  type StrategyProfileId,
+} from './signal-generator';
 
 // Signal types — shared from @tradeclaw/signals
 import type { TradingSignal, IndicatorSummary } from '@tradeclaw/signals';
@@ -175,6 +180,44 @@ export async function getSignals(params: {
     }
   } catch {
     // TA engine crashed — return empty rather than misleading random signals
+  }
+
+  // MTF re-boost. The per-TF engine in signal-generator.ts caps confidence at
+  // 70 whenever the score-based confidence crosses 75, with the comment
+  // "caller can re-boost via MTF". This is that caller. One MTF call per
+  // (symbol, mode) in parallel, applied to every signal whose direction
+  // matches the dominant TF. Without this, confidence>=85 is structurally
+  // unreachable and the equity card's premium band is permanently empty.
+  if (allSignals.length > 0) {
+    try {
+      const tfMode = (tf: string): SignalMode =>
+        tf === 'M5' || tf === 'M15' ? 'scalp' : 'swing';
+      const mtfKeys = new Set(allSignals.map(s => `${s.symbol}|${tfMode(s.timeframe)}`));
+      const mtfPairs = await Promise.all(
+        [...mtfKeys].map(async key => {
+          const [symbol, mode] = key.split('|') as [string, SignalMode];
+          const mtf = await generateMultiTFSignal(symbol, mode);
+          return [key, mtf] as const;
+        }),
+      );
+      const mtfByKey = new Map(mtfPairs);
+      for (const sig of allSignals) {
+        const mtf = mtfByKey.get(`${sig.symbol}|${tfMode(sig.timeframe)}`);
+        if (!mtf) continue;
+        if (mtf.dominantDirection === sig.direction) {
+          // 3/3 aligned → +15, 2/3 → +5. Clamp at 95 to leave 100 as
+          // unattainable, matching scaleConfidence's own cap.
+          sig.confidence = Math.min(95, sig.confidence + mtf.confluenceBonus);
+        } else if (mtf.isConflicted) {
+          // Mixed TFs (1 vs 2) → -20. Push below PUBLISHED_SIGNAL_MIN_CONFIDENCE
+          // and the downstream cron filter drops the signal. Clamp at 0.
+          sig.confidence = Math.max(0, sig.confidence + mtf.confluenceBonus);
+        }
+        // Dominant direction NEUTRAL or opposite-without-conflict → unchanged.
+      }
+    } catch {
+      // MTF fetch failed — leave signals at engine-emitted confidence.
+    }
   }
 
   // Apply filters


### PR DESCRIPTION
## Summary

- Wire the half-finished MTF re-boost in `apps/web/app/lib/signals.ts` so signals can clear the premium-band threshold
- After all timeframes resolve, run `generateMultiTFSignal` once per `(symbol, mode)` in parallel and apply `confluenceBonus` to each matching-direction signal: +15 for 3/3 TF agreement (70 → 85, premium), +5 for 2/3 (70 → 75), -20 when conflicted (clamp at 0; downstream `PUBLISHED_SIGNAL_MIN_CONFIDENCE` filter drops the signal). Upper clamp at 95 matches `scaleConfidence`'s own cap.
- One file, 44 insertions / 1 deletion. No engine math changes — only wires an existing helper into the live path.

## Why

`apps/web/app/lib/signal-generator.ts:724-726` (BUY) and `:788-790` (SELL) hard-cap confidence to 70 whenever score-based confidence reaches 75, with the comment _"caller can re-boost via MTF"_. **No caller in the live path was applying the bonus** — only `apps/web/app/api/mtf/route.ts` (a separate dashboard endpoint) consumed `confluenceBonus`. As a result:

- All 1,977 rows in `signal_history` sit at confidence ∈ [70..74] (verified via `/api/signals/history?period=90d&limit=2000`)
- `PRO_PREMIUM_MIN_CONFIDENCE = 85` is structurally unreachable
- `/api/signals/equity?band=premium` returns 0 signals across every window (7d / 30d / 90d / 180d / all)
- The "PRO VIEW" lock badge on `/track-record` implies a stronger Pro-only track record that doesn't exist

This PR fulfils what the comment in `signal-generator.ts:726` already promised — the math (`generateMultiTFSignal`, `confluenceBonus` -20…+15) was already there and tested via the MTF dashboard route; we just plug it into `getSignals`.

## Test plan

- [x] `tsc --noEmit` clean on the edited file (pre-existing TS errors in `app/welcome/WelcomeClient.tsx` are unrelated)
- [x] `npm run build -w apps/web` passes — 300 routes generated in 18.8s
- [x] Unit-style logic smoke test: 7/7 cases pass
  - 3/3 aligned (70 → 85)
  - 2/3 aligned (70 → 75)
  - Neutral MTF (70 → 70)
  - Conflicted MTF (70 → 50, clamp at 0)
  - Opposite dominant without conflict (70 → 70)
  - Upper-clamp (90 + 15 → 95)
  - Null MTF (70 → 70)
- [ ] Post-deploy probe: `curl 'https://tradeclaw.win/api/signals/equity?period=7d&band=premium' | jq '.summary.totalSignals'` → expect > 0 within ~24h of cron resolution
- [ ] Eyeball `/api/signals` on production after deploy — confidence distribution should now show a long tail above 75, not the prior 70-74 ceiling

## Deploy

GitHub auto-deploy is OFF on the `web` Railway service. After merge, deploy with:

```
railway up --detach
```

from repo root (Railway CLI must be linked to `tradeclaw/production/web`).

## Not in scope

- **Historical backfill of `signal_history.confidence`** — would require re-running MTF against historical bars (fresh OHLCV at each timestamp for H1/H4/D1 or M5/M15/H1). The premium-band card will fill within ~1 week of normal traffic; forward-only is fine.
- **Per-TF cap removal** — leaving `signal-generator.ts:726/790` as-is. The cap is the right floor when MTF data is unavailable; this PR just adds the re-boost when data IS available.