### PR TITLE
docs: link webhook integration guide from README (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ curl https://tradeclaw.win/api/strategy-breakdown
 
 Pro subscribers get real-time access to all endpoints with full depth.
 
+**Webhooks / integrations:** see the [webhook integration guide](docs/webhooks.md) for the signal payload schema, polling/cron patterns, and ready-to-run forwarders in [`examples/webhooks/`](examples/webhooks/) (Slack, Discord, n8n, Zapier, Google Sheets).
+
 ## Environment variables
 
 | Variable | Required | Description |


### PR DESCRIPTION
Closes #15.

## Summary
The webhook integration guide (`docs/webhooks.md`) and six working forwarder scripts (`examples/webhooks/`: Slack, Discord, n8n, Zapier, Google Sheets, cron runner) already shipped. The only open acceptance criterion was *linked from README.md* — this adds that link under the API section.

## Changes
- README API section now points to the webhook guide and examples directory.

## Testing
- Markdown-only change; relative links verified against existing `docs/webhooks.md` and `examples/webhooks/`.