### PR TITLE
feat(dashboard): add STOCKS tab for S&P 500 top 20 (#42)

### DIFF
--- a/apps/web/app/dashboard/DashboardClient.tsx
+++ b/apps/web/app/dashboard/DashboardClient.tsx
@@ -158,6 +158,13 @@ const BUY_CONFIDENCE_THRESHOLD = 70;
 const TIMEFRAMES = ['ALL', 'M5', 'M15', 'H1', 'H4', 'D1'];
 
 
+// US mega-caps + index ETFs (issue #42). Symbols mirror apps/web/app/lib/symbol-config.ts.
+const STOCK_SYMBOLS = [
+  'NVDAUSD', 'TSLAUSD', 'AAPLUSD', 'MSFTUSD', 'GOOGLUSD', 'AMZNUSD', 'METAUSD',
+  'SPYUSD', 'QQQUSD', 'AMDUSD', 'JPMUSD', 'JNJUSD', 'VUSD', 'WMTUSD', 'PGUSD',
+  'UNHUSD', 'HDUSD', 'BACUSD', 'MAUSD', 'XOMUSD',
+];
+
 const ASSET_CLASSES = {
   ALL: [
     'XAUUSD', 'XAGUSD',
@@ -167,6 +174,7 @@ const ASSET_CLASSES = {
     'OPUSD', 'FILUSD', 'INJUSD', 'SUIUSD', 'SEIUSD', 'TIAUSD',
     'RENDERUSD', 'FETUSD', 'AAVEUSD', 'PEPEUSD', 'SHIBUSD', 'WIFUSD',
     'EURUSD', 'GBPUSD', 'USDJPY', 'AUDUSD', 'USDCAD', 'NZDUSD', 'USDCHF',
+    ...STOCK_SYMBOLS,
   ],
   CRYPTO: [
     'BTCUSD', 'ETHUSD', 'SOLUSD', 'DOGEUSD', 'BNBUSD', 'XRPUSD',
@@ -177,6 +185,7 @@ const ASSET_CLASSES = {
   ],
   FOREX: ['EURUSD', 'GBPUSD', 'USDJPY', 'AUDUSD', 'USDCAD', 'NZDUSD', 'USDCHF'],
   METALS: ['XAUUSD', 'XAGUSD'],
+  STOCKS: STOCK_SYMBOLS,
 };
 
 type AssetClass = keyof typeof ASSET_CLASSES;


### PR DESCRIPTION
Closes #42.

## Summary
The stock-market plumbing already shipped — 20 mega-cap/ETF symbols in `apps/web/app/lib/symbol-config.ts`, data providers (Finnhub real-time + Twelve Data + FMP) in `lib/data-providers/stocks.ts`, US-equities market-hours gating in `lib/market-hours.ts`, and the RSI/MACD/EMA engine already runs over stocks. The only gap was that stocks were not selectable on the dashboard.

## Changes
- `apps/web/app/dashboard/DashboardClient.tsx`: add a `STOCKS` asset-class tab (20 symbols defined once as `STOCK_SYMBOLS`) and include them in the default `ALL` view. The tab list and signal filter are key-driven, so the new class wires up automatically.

## Testing
- Typechecked `apps/web` — no new errors introduced (pre-existing `@tradeclaw/signals` resolution + implicit-any warnings are unrelated).
- Manual: load /dashboard, click the STOCKS tab, confirm the 20 tickers filter in.

## Notes
- Live stock quotes need `FINNHUB_API_KEY` / `TWELVE_DATA_API_KEY` / `FMP_API_KEY`; without them stocks fall back to deterministic mock data (acceptable for the demo/self-host path).