### PR TITLE
feat(notifications): email delivery for the daily signal digest (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,11 @@ SMTP_PORT=587                         # 587 for STARTTLS, 465 for implicit TLS
 SMTP_USER=                            # e.g. you@gmail.com
 SMTP_PASS=                            # SMTP password / app password
 
+# Daily digest email recipients (optional) — comma-separated. When set, the
+# /api/cron/daily-digest job emails today's top signals via EMAIL_PROVIDER above,
+# independently of Telegram. Leave blank to disable the digest email.
+EMAIL_TO=                             # e.g. me@example.com, team@example.com
+
 # ---------------------------------------------------------------------------
 # Stripe (optional — for paid tiers)
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ curl https://tradeclaw.win/api/strategy-breakdown
 
 Pro subscribers get real-time access to all endpoints with full depth.
 
+## Notifications
+
+TradeClaw can push signals over multiple channels, each enabled by env vars:
+
+- **Telegram** — instant per-signal alerts (`TELEGRAM_BOT_TOKEN` + channel IDs).
+- **Email** — instant per-signal alerts and a daily digest. Pick a provider with `EMAIL_PROVIDER`:
+  - `resend` (default) — `RESEND_API_KEY` + `RESEND_FROM_EMAIL`
+  - `sendgrid` — `SENDGRID_API_KEY`
+  - `smtp` — `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` (requires `npm install nodemailer`)
+- **Daily digest email** — set `EMAIL_TO` (comma-separated) and the `/api/cron/daily-digest` job emails the day's top signals via the configured provider, independently of Telegram.
+- **Webhooks** — see the [webhook integration guide](docs/webhooks.md) and [`examples/webhooks/`](examples/webhooks/).
+
+See `.env.example` for the full list of notification env vars.
+
 ## Environment variables
 
 | Variable | Required | Description |

--- a/apps/web/app/api/cron/daily-digest/route.ts
+++ b/apps/web/app/api/cron/daily-digest/route.ts
@@ -1,12 +1,56 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDailyDigest } from '../../../../lib/daily-digest';
+import { getDailyDigest, digestToPlainText, digestToHtml, type DailyDigest } from '../../../../lib/daily-digest';
+import { sendEmail } from '../../../../lib/email-sender';
 
 const TELEGRAM_API = 'https://api.telegram.org';
 
 // ---------------------------------------------------------------------------
 // GET /api/cron/daily-digest — Vercel Cron handler (08:00 UTC daily)
 // Also supports POST for manual trigger from the preview page.
+// Delivers to Telegram (if configured) and/or email (if EMAIL_TO is set),
+// independently — an email-only self-host works without Telegram tokens.
 // ---------------------------------------------------------------------------
+
+function emailRecipients(): string[] {
+  return (process.env.EMAIL_TO ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+async function postToTelegram(digest: DailyDigest): Promise<{ sent: boolean; messageId?: number | null; error?: string }> {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  const channelId = process.env.TELEGRAM_CHANNEL_ID;
+  if (!botToken || !channelId) return { sent: false, error: 'not_configured' };
+
+  const res = await fetch(`${TELEGRAM_API}/bot${botToken}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: channelId,
+      text: digest.message,
+      parse_mode: 'MarkdownV2',
+      disable_web_page_preview: true,
+    }),
+  });
+  const data = (await res.json()) as { ok: boolean; result?: { message_id: number }; description?: string };
+  if (!data.ok) return { sent: false, error: data.description ?? 'Telegram API error' };
+  return { sent: true, messageId: data.result?.message_id ?? null };
+}
+
+async function sendDigestEmails(digest: DailyDigest): Promise<{ sent: boolean; recipients: number; delivered: number; error?: string }> {
+  const recipients = emailRecipients();
+  if (recipients.length === 0) return { sent: false, recipients: 0, delivered: 0, error: 'not_configured' };
+
+  const payload = {
+    subject: `TradeClaw Daily Signal Digest — ${digest.date}`,
+    text: digestToPlainText(digest),
+    html: digestToHtml(digest),
+  };
+  const results = await Promise.all(recipients.map(to => sendEmail(to, payload)));
+  const delivered = results.filter(r => r.ok).length;
+  return { sent: delivered > 0, recipients: recipients.length, delivered };
+}
 
 async function handler(request: NextRequest): Promise<NextResponse> {
   // Auth guard — Vercel cron sends CRON_SECRET as bearer token
@@ -19,12 +63,12 @@ async function handler(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const botToken = process.env.TELEGRAM_BOT_TOKEN;
-    const channelId = process.env.TELEGRAM_CHANNEL_ID;
+    const telegramConfigured = Boolean(process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHANNEL_ID);
+    const emailConfigured = emailRecipients().length > 0;
 
-    if (!botToken || !channelId) {
+    if (!telegramConfigured && !emailConfigured) {
       return NextResponse.json(
-        { sent: false, error: 'TELEGRAM_BOT_TOKEN or TELEGRAM_CHANNEL_ID not configured' },
+        { sent: false, error: 'No delivery channel configured (set TELEGRAM_BOT_TOKEN + TELEGRAM_CHANNEL_ID and/or EMAIL_TO)' },
         { status: 503 },
       );
     }
@@ -35,46 +79,20 @@ async function handler(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({
         sent: false,
         count: 0,
-        channel: channelId,
         error: 'No high-confidence signals to send',
         timestamp: new Date().toISOString(),
       });
     }
 
-    // Post to Telegram channel
-    const res = await fetch(`${TELEGRAM_API}/bot${botToken}/sendMessage`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: channelId,
-        text: digest.message,
-        parse_mode: 'MarkdownV2',
-        disable_web_page_preview: true,
-      }),
-    });
-
-    const data = (await res.json()) as {
-      ok: boolean;
-      result?: { message_id: number };
-      description?: string;
-    };
-
-    if (!data.ok) {
-      return NextResponse.json({
-        sent: false,
-        count: digest.count,
-        channel: channelId,
-        error: data.description ?? 'Telegram API error',
-        timestamp: new Date().toISOString(),
-      });
-    }
+    const telegram = telegramConfigured ? await postToTelegram(digest) : { sent: false, error: 'not_configured' };
+    const email = emailConfigured ? await sendDigestEmails(digest) : { sent: false, recipients: 0, delivered: 0, error: 'not_configured' };
 
     return NextResponse.json({
-      sent: true,
+      sent: telegram.sent || email.sent,
       count: digest.count,
-      channel: channelId,
-      messageId: data.result?.message_id ?? null,
       date: digest.date,
+      telegram,
+      email,
       timestamp: new Date().toISOString(),
     });
   } catch (err) {

--- a/apps/web/lib/daily-digest.ts
+++ b/apps/web/lib/daily-digest.ts
@@ -163,3 +163,45 @@ export function digestToPlainText(digest: DailyDigest): string {
 
   return lines.join('\n');
 }
+
+function htmlEsc(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Return a mobile-friendly HTML version of the digest for email delivery.
+ * Content mirrors the Telegram digest (today's top signals by confidence).
+ */
+export function digestToHtml(digest: DailyDigest): string {
+  const wrap = (inner: string): string =>
+    `<div style="background:#050505;color:#e5e5e5;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:24px;max-width:600px;margin:0 auto;">` +
+    `<h1 style="color:#10b981;font-size:18px;margin:0 0 16px;">📅 Daily Signal Digest — ${htmlEsc(digest.date)}</h1>` +
+    inner +
+    `<p style="color:#737373;font-size:12px;margin-top:24px;">🤖 <a href="https://tradeclaw.win" style="color:#10b981;">TradeClaw</a> · Not financial advice. DYOR.</p>` +
+    `</div>`;
+
+  if (digest.count === 0) {
+    return wrap(`<p style="color:#a3a3a3;">No high-confidence signals today. Markets quiet.</p>`);
+  }
+
+  const cards = digest.signals
+    .map((sig, i) => {
+      const color = sig.direction === 'BUY' ? '#10b981' : '#ef4444';
+      const rsi = sig.indicators.rsi ? `RSI ${sig.indicators.rsi.value.toFixed(1)}` : '';
+      const macd = sig.indicators.macd ? `MACD ${sig.indicators.macd.signal}` : '';
+      const meta = [rsi, macd].filter(Boolean).join(' · ');
+      return (
+        `<div style="border:1px solid #1f1f1f;border-radius:12px;padding:16px;margin-bottom:12px;">` +
+        `<div style="font-weight:600;color:${color};font-size:15px;">#${i + 1} ${htmlEsc(sig.direction)} ${htmlEsc(sig.symbol)} · ${sig.confidence}%</div>` +
+        `<div style="font-size:13px;color:#a3a3a3;margin-top:6px;">Entry $${htmlEsc(fmtPrice(sig.entry))} · TP $${htmlEsc(fmtPrice(sig.takeProfit1))} · SL $${htmlEsc(fmtPrice(sig.stopLoss))}</div>` +
+        (meta ? `<div style="font-size:12px;color:#737373;margin-top:4px;">${htmlEsc(meta)}</div>` : '') +
+        `</div>`
+      );
+    })
+    .join('');
+
+  return wrap(`<p style="color:#a3a3a3;font-size:13px;margin:0 0 16px;">Top ${digest.count} signals by confidence</p>${cards}`);
+}

--- a/apps/web/lib/email-sender.ts
+++ b/apps/web/lib/email-sender.ts
@@ -99,6 +99,13 @@ export interface EmailSendResult {
   providerId?: string;
 }
 
+/** Provider-agnostic email payload. */
+export interface EmailPayload {
+  subject: string;
+  text: string;
+  html: string;
+}
+
 type EmailProvider = 'resend' | 'sendgrid' | 'smtp';
 
 function getProvider(): EmailProvider {
@@ -111,7 +118,7 @@ function getProvider(): EmailProvider {
 async function sendViaResend(
   to: string,
   from: string,
-  signal: AlertSignal,
+  payload: EmailPayload,
 ): Promise<EmailSendResult> {
   const apiKey = getResendKey();
   if (!apiKey) return { ok: false, reason: 'no_api_key' };
@@ -126,9 +133,9 @@ async function sendViaResend(
       body: JSON.stringify({
         from,
         to: [to],
-        subject: buildSubject(signal),
-        text: buildPlainText(signal),
-        html: buildHtml(signal),
+        subject: payload.subject,
+        text: payload.text,
+        html: payload.html,
       }),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
@@ -144,7 +151,7 @@ async function sendViaResend(
 async function sendViaSendGrid(
   to: string,
   from: string,
-  signal: AlertSignal,
+  payload: EmailPayload,
 ): Promise<EmailSendResult> {
   const apiKey = process.env.SENDGRID_API_KEY;
   if (!apiKey) return { ok: false, reason: 'no_api_key' };
@@ -159,10 +166,10 @@ async function sendViaSendGrid(
       body: JSON.stringify({
         personalizations: [{ to: [{ email: to }] }],
         from: { email: from.replace(/^.*<|>.*$/g, '').trim() || from },
-        subject: buildSubject(signal),
+        subject: payload.subject,
         content: [
-          { type: 'text/plain', value: buildPlainText(signal) },
-          { type: 'text/html', value: buildHtml(signal) },
+          { type: 'text/plain', value: payload.text },
+          { type: 'text/html', value: payload.html },
         ],
       }),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -188,7 +195,7 @@ async function sendViaSendGrid(
 async function sendViaSMTP(
   to: string,
   from: string,
-  signal: AlertSignal,
+  payload: EmailPayload,
 ): Promise<EmailSendResult> {
   const host = process.env.SMTP_HOST;
   const port = parseInt(process.env.SMTP_PORT || '587', 10);
@@ -218,9 +225,9 @@ async function sendViaSMTP(
     const info = await transport.sendMail({
       from,
       to,
-      subject: buildSubject(signal),
-      text: buildPlainText(signal),
-      html: buildHtml(signal),
+      subject: payload.subject,
+      text: payload.text,
+      html: payload.html,
     });
     return { ok: true, providerId: info.messageId };
   } catch {
@@ -228,9 +235,13 @@ async function sendViaSMTP(
   }
 }
 
-export async function sendSignalEmail(
+/**
+ * Provider-agnostic send for any subject/text/html email (digests, etc.).
+ * Routes through the same EMAIL_PROVIDER switch and from-address as signal alerts.
+ */
+export async function sendEmail(
   to: string,
-  signal: AlertSignal,
+  payload: EmailPayload,
 ): Promise<EmailSendResult> {
   if (!to) return { ok: false, reason: 'no_to_address' };
 
@@ -238,7 +249,18 @@ export async function sendSignalEmail(
   if (!from) return { ok: false, reason: 'no_from_address' };
 
   const provider = getProvider();
-  if (provider === 'smtp') return sendViaSMTP(to, from, signal);
-  if (provider === 'sendgrid') return sendViaSendGrid(to, from, signal);
-  return sendViaResend(to, from, signal);
+  if (provider === 'smtp') return sendViaSMTP(to, from, payload);
+  if (provider === 'sendgrid') return sendViaSendGrid(to, from, payload);
+  return sendViaResend(to, from, payload);
+}
+
+export async function sendSignalEmail(
+  to: string,
+  signal: AlertSignal,
+): Promise<EmailSendResult> {
+  return sendEmail(to, {
+    subject: buildSubject(signal),
+    text: buildPlainText(signal),
+    html: buildHtml(signal),
+  });
 }


### PR DESCRIPTION
Closes #20.

## Summary
Instant per-signal email alerts (Resend / SendGrid / SMTP, wired through `lib/alert-channels.ts` and the alert-rules dispatch loop) already shipped. The only gap was the **daily digest**, which posted to Telegram only. This adds an email path.

## Changes
- `lib/email-sender.ts` — extract a provider-agnostic `sendEmail(to, {subject,text,html})`; `sendSignalEmail` now delegates to it. No behavior change to the instant-alert envelope.
- `lib/daily-digest.ts` — add `digestToHtml(digest)` (mobile-friendly, content mirrors the Telegram digest).
- `app/api/cron/daily-digest/route.ts` — deliver to Telegram **and/or** `EMAIL_TO` recipients independently; an email-only self-host now works without Telegram tokens. Returns per-channel status.
- `.env.example` — document `EMAIL_TO` (comma-separated). `README.md` — new Notifications section.

## Testing
- `npx jest` on `email-sender.test.ts` + `alert-channels.test.ts` → **30/30 pass** (refactor preserved behavior).
- `tsc --noEmit` on `apps/web` → no new type errors in changed files.

## Notes
- Digest send time stays at the existing 08:00 UTC cron (not per-user timezone) and uses a global `EMAIL_TO` list rather than per-user channel configs — matches the self-host model. Per-user-timezone scheduling can be a follow-up.
- README Notifications section edits the same region as #15's webhook link; if both merge, expect a trivial conflict to resolve.