### PR TITLE
feat(monitoring): opt-in Grafana + Prometheus compose profile (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ Open [http://localhost:3000](http://localhost:3000). Requires PostgreSQL. Migrat
 | `ghcr.io/naimkatiman/tradeclaw:vX.Y.Z` | A specific release tag |
 | `ghcr.io/naimkatiman/tradeclaw:sha-<git-sha>` | A specific commit |
 
+## Monitoring (Grafana + Prometheus)
+
+TradeClaw exposes a Prometheus-compatible metrics endpoint at `/api/metrics` (signal direction, confidence, RSI, counts, freshness, outcomes). An opt-in monitoring stack ships with the compose file:
+
+```bash
+docker compose --profile monitoring up -d   # adds prometheus (:9090) + grafana (:3001)
+```
+
+Then open Grafana at [http://localhost:3001](http://localhost:3001) (default login `admin`/`admin`, override with `GRAFANA_ADMIN_PASSWORD`), add Prometheus (`http://prometheus:9090`) as a data source, and import `grafana/tradeclaw-dashboard.json`. The default `docker compose up` does not start these services. See [`grafana/README.md`](grafana/README.md) for the metrics reference and panel details.
+
 ## Local development (from source)
 
 TradeClaw is an npm-workspaces monorepo. You need Node.js 20+, npm, and a PostgreSQL instance (the web app falls back to bundled SQLite if `DATABASE_URL` is unset, but Postgres is recommended).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,38 @@ services:
       retries: 5
     restart: unless-stopped
 
+  # Monitoring stack (opt-in): `docker compose --profile monitoring up -d`.
+  # Scrapes the app's /api/metrics endpoint. Kept out of the default stack so
+  # `docker compose up` stays lean.
+  prometheus:
+    image: prom/prometheus:latest
+    profiles: ["monitoring"]
+    volumes:
+      - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      # Lets prometheus.yml's host.docker.internal target resolve on Linux.
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    profiles: ["monitoring"]
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "${GRAFANA_PORT:-3001}:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
 volumes:
   db_data:
   redis_data:
+  prometheus_data:
+  grafana_data:


### PR DESCRIPTION
Closes #19.

## Summary
The Prometheus metrics endpoint (`apps/web/app/api/metrics/route.ts`), Grafana dashboard (`grafana/tradeclaw-dashboard.json`), and scrape config (`grafana/prometheus.yml`) already shipped. The remaining acceptance item was bundling the stack into compose.

## Changes
- `docker-compose.yml`: add `prometheus` (:9090) and `grafana` (:3001) services under a `monitoring` profile, plus `prometheus_data`/`grafana_data` volumes. `extra_hosts` maps `host.docker.internal` so the existing scrape target resolves on Linux too.
- `README.md`: new Monitoring section with the `--profile monitoring` command and dashboard-import steps.

## Testing
- `docker compose --profile monitoring config` parses cleanly (validated with dummy env).
- Default `docker compose config` still lists only db/migrate/redis/app/scanner/ws-server — monitoring services are correctly gated behind the profile.

## Notes
- Kept the signal heatmap as the shipped stat/timeseries panels rather than adding a new heatmap panel (the dashboard already covers direction/confidence/RSI/outcomes/freshness).
- README edit is in the Docker section to avoid colliding with #15/#20 README edits.