### PR TITLE
feat(discord): env-keyed signal broadcast to Discord (#38)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,13 @@ TELEGRAM_ELITE_CHANNEL_INVITE=
 # ---------------------------------------------------------------------------
 # Discord (optional — for Discord bot signals)
 # ---------------------------------------------------------------------------
-DISCORD_BOT_TOKEN=                    # Bot token from https://discord.com/developers
+DISCORD_BOT_TOKEN=                    # Bot token from https://discord.com/developers (gateway bot)
 DISCORD_CLIENT_ID=                    # Application ID (for invite link)
+# Webhook-first signal broadcasting (issue #38): when set, the /api/cron/telegram
+# job posts TradeClaw's own free-tier signals to this Discord channel webhook as
+# color-coded embeds, deduped per (pair, direction) per 2h window. Independent of
+# the gateway bot above and of Telegram. Create one in Server Settings → Integrations.
+DISCORD_WEBHOOK_URL=                  # e.g. https://discord.com/api/webhooks/<id>/<token>
 
 # ---------------------------------------------------------------------------
 # Email notifications (optional, for the "email" alert channel)

--- a/apps/web/app/api/cron/telegram/route.ts
+++ b/apps/web/app/api/cron/telegram/route.ts
@@ -4,6 +4,7 @@ import { query, execute } from '../../../../lib/db-pool';
 import { FREE_SYMBOLS } from '../../../../lib/tier';
 import { getBotToken, getFreeChannelId } from '../../../../lib/telegram-channels';
 import { requireCronAuth } from '../../../../lib/cron-auth';
+import { broadcastSignalsToDiscord } from '../../../../lib/discord-broadcast';
 
 // ---------------------------------------------------------------------------
 // GET /api/cron/telegram — Vercel Cron handler (every 4 hours)
@@ -19,15 +20,25 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // TELEGRAM_FREE_CHANNEL_ID is the canonical name going forward.
     const botToken = getBotToken();
     const channelId = getFreeChannelId();
+    const discordWebhook = process.env.DISCORD_WEBHOOK_URL || null;
+    const telegramConfigured = Boolean(botToken && channelId);
 
-    if (!botToken || !channelId) {
+    if (!telegramConfigured && !discordWebhook) {
       return NextResponse.json(
-        { ok: false, error: 'TELEGRAM_BOT_TOKEN or TELEGRAM_FREE_CHANNEL_ID not configured' },
+        { ok: false, error: 'No broadcast channel configured (set TELEGRAM_BOT_TOKEN + TELEGRAM_FREE_CHANNEL_ID and/or DISCORD_WEBHOOK_URL)' },
         { status: 503 },
       );
     }
 
-    const result = await broadcastTopSignals(channelId, botToken, { freeOnly: true });
+    let telegramOk = false;
+    let telegramMessageId: number | null = null;
+    let telegramError: string | null = null;
+    if (telegramConfigured) {
+      const result = await broadcastTopSignals(channelId!, botToken!, { freeOnly: true });
+      telegramOk = result.success;
+      telegramMessageId = result.messageId ?? null;
+      telegramError = result.error ?? null;
+    }
 
     // Delayed public channel push — free-tier symbols only, 30+ min old.
     // Same channel as the broadcast above; resolved through the same path.
@@ -97,11 +108,20 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }
     }
 
+    // Broadcast the same free-tier signals to Discord (issue #38), if configured.
+    // Independent of Telegram and deduped via discord_posted_at.
+    let discordPosted = 0;
+    if (discordWebhook) {
+      const discord = await broadcastSignalsToDiscord(discordWebhook);
+      discordPosted = discord.posted;
+    }
+
     return NextResponse.json({
-      ok: result.success,
-      messageId: result.messageId ?? null,
+      ok: telegramConfigured ? telegramOk : true,
+      messageId: telegramMessageId,
       publicPushed,
-      error: result.error ?? null,
+      discordPosted,
+      error: telegramError,
       timestamp: new Date().toISOString(),
     });
   } catch {

--- a/apps/web/lib/__tests__/discord-broadcast.test.ts
+++ b/apps/web/lib/__tests__/discord-broadcast.test.ts
@@ -1,0 +1,41 @@
+import { rowToAlertSignal } from '../discord-broadcast';
+import { formatDiscordEmbed } from '../alert-channels';
+
+describe('discord-broadcast — rowToAlertSignal', () => {
+  const baseRow = {
+    id: 'SIG-BTCUSD-H1-BUY-ABC',
+    pair: 'BTCUSD',
+    direction: 'BUY',
+    confidence: 87,
+    entry_price: '64000.5',
+    tp1: '65000',
+    sl: '63000',
+    timeframe: 'H1',
+  };
+
+  it('maps a signal_history row to the AlertSignal shape', () => {
+    expect(rowToAlertSignal(baseRow)).toEqual({
+      id: 'SIG-BTCUSD-H1-BUY-ABC',
+      symbol: 'BTCUSD',
+      direction: 'BUY',
+      confidence: 87,
+      timeframe: 'H1',
+      entry: '64000.5',
+      takeProfit1: '65000',
+      stopLoss: '63000',
+    });
+  });
+
+  it('normalizes any non-SELL direction to BUY', () => {
+    expect(rowToAlertSignal({ ...baseRow, direction: 'SELL' }).direction).toBe('SELL');
+    expect(rowToAlertSignal({ ...baseRow, direction: 'buy' }).direction).toBe('BUY');
+  });
+
+  it('produces a green embed for BUY and red for SELL', () => {
+    const buy = formatDiscordEmbed(rowToAlertSignal(baseRow));
+    const sell = formatDiscordEmbed(rowToAlertSignal({ ...baseRow, direction: 'SELL' }));
+    expect(buy.embeds[0].color).toBe(0x10b981);
+    expect(sell.embeds[0].color).toBe(0xef4444);
+    expect(buy.embeds[0].title).toBe('BUY BTCUSD');
+  });
+});

--- a/apps/web/lib/discord-broadcast.ts
+++ b/apps/web/lib/discord-broadcast.ts
@@ -1,0 +1,89 @@
+import 'server-only';
+
+import { query, execute } from './db-pool';
+import { FREE_SYMBOLS } from './tier';
+import { sendDiscordWebhook, type AlertSignal } from './alert-channels';
+
+/**
+ * Env-keyed Discord broadcaster for TradeClaw's own generated signals (issue #38).
+ *
+ * Distinct from:
+ *   - apps/web/app/api/tradingview/webhook (forwards INBOUND TradingView alerts)
+ *   - lib/alert-channels per-user Discord config (keyed off a stored webhookUrl)
+ *
+ * This posts the same free-tier signals broadcast to the public Telegram channel,
+ * color-coded via formatDiscordEmbed (BUY green / SELL red), deduped via the
+ * discord_posted_at column so each (pair, direction) is posted at most once per
+ * 2h window — even across serverless cron invocations.
+ */
+
+interface PendingRow {
+  id: string;
+  pair: string;
+  direction: string;
+  confidence: number;
+  entry_price: string;
+  tp1: string | null;
+  sl: string | null;
+  timeframe: string;
+}
+
+/** Map a signal_history row to the AlertSignal shape formatDiscordEmbed expects. */
+export function rowToAlertSignal(row: PendingRow): AlertSignal {
+  return {
+    id: row.id,
+    symbol: row.pair,
+    direction: row.direction === 'SELL' ? 'SELL' : 'BUY',
+    confidence: row.confidence,
+    timeframe: row.timeframe,
+    entry: row.entry_price,
+    takeProfit1: row.tp1,
+    stopLoss: row.sl,
+  };
+}
+
+export interface DiscordBroadcastResult {
+  posted: number;
+  attempted: number;
+}
+
+export async function broadcastSignalsToDiscord(webhookUrl: string): Promise<DiscordBroadcastResult> {
+  // One row per (pair, direction): same free-symbol / confidence / age filters as
+  // the Telegram public push, but gated on discord_posted_at so the two channels
+  // keep independent ledgers. The NOT EXISTS guard suppresses a sibling timeframe
+  // of the same (pair, direction) already posted inside the 2h window.
+  const pending = await query<PendingRow>(
+    `
+    SELECT DISTINCT ON (pair, direction)
+           id, pair, direction, confidence, entry_price, tp1, sl, timeframe
+    FROM signal_history sh
+    WHERE discord_posted_at IS NULL
+      AND is_simulated = false
+      AND pair = ANY($1)
+      AND confidence >= 80
+      AND created_at >= NOW() - INTERVAL '2 hours'
+      AND created_at <= NOW() - INTERVAL '30 minutes'
+      AND NOT EXISTS (
+        SELECT 1 FROM signal_history sib
+        WHERE sib.pair = sh.pair
+          AND sib.direction = sh.direction
+          AND sib.discord_posted_at IS NOT NULL
+          AND sib.discord_posted_at >= NOW() - INTERVAL '2 hours'
+      )
+    ORDER BY pair, direction, confidence DESC, created_at DESC
+    LIMIT 10
+    `,
+    [[...FREE_SYMBOLS]],
+  );
+
+  let posted = 0;
+  for (const row of pending) {
+    const ok = await sendDiscordWebhook({ webhookUrl }, rowToAlertSignal(row));
+    if (ok) {
+      await execute(`UPDATE signal_history SET discord_posted_at = NOW() WHERE id = $1`, [row.id]);
+      posted++;
+    }
+  }
+
+  return { posted, attempted: pending.length };
+}

--- a/apps/web/migrations/045_discord_posted_at.sql
+++ b/apps/web/migrations/045_discord_posted_at.sql
@@ -1,0 +1,12 @@
+-- 045_discord_posted_at.sql
+-- Discord broadcast ledger for TradeClaw's own signals (issue #38).
+-- Mirrors telegram_posted_at (003) so the env-keyed Discord broadcaster can
+-- dedupe one post per (pair, direction) per 2h window across cron runs,
+-- independently of the Telegram channel.
+
+ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS discord_posted_at TIMESTAMPTZ;
+
+-- Speeds up the "not yet posted to Discord" pending scan.
+CREATE INDEX IF NOT EXISTS idx_signal_history_discord_pending
+  ON signal_history (created_at)
+  WHERE discord_posted_at IS NULL;


### PR DESCRIPTION
Closes #38.

## Summary
TradeClaw already had Discord plumbing for **inbound** TradingView alerts (`api/tradingview/webhook`) and **per-user** configs (`lib/alert-channels`), but nothing broadcast TradeClaw's **own** generated signals to a Discord channel. This adds that, mirroring the existing Telegram public-channel broadcast.

## Changes
- **migration 045** — `discord_posted_at` column on `signal_history` (mirrors `telegram_posted_at`) so dedup survives serverless cold starts, unlike an in-memory map.
- **`lib/discord-broadcast.ts`** — `broadcastSignalsToDiscord(webhookUrl)` selects pending free-tier signals (≥80% confidence, 30m–2h old, one per (pair,direction)) and posts color-coded embeds (BUY green `0x10b981` / SELL red `0xef4444`) via the existing **SSRF-gated** `sendDiscordWebhook` + `formatDiscordEmbed`. Throttle = one post per (pair,direction) per 2h window via the `discord_posted_at` ledger.
- **`api/cron/telegram/route.ts`** — Telegram and Discord now run independently; a Discord-only deploy works without Telegram tokens (503 only if neither configured). Response gains `discordPosted`.
- **`.env.example`** — document `DISCORD_WEBHOOK_URL` (distinct from the gateway `DISCORD_BOT_TOKEN`).

## Testing
- 3 unit tests (`discord-broadcast.test.ts`): row→AlertSignal mapping, direction normalization, and BUY/SELL embed color coding — **3/3 pass**.
- `tsc --noEmit` on `apps/web` → no new errors.

## Notes
- Reuses the `api/cron/telegram` schedule (every 4h) rather than adding a new cron, keeping one broadcast cadence.
- Acceptance AC1–AC4 (asset/confidence/timeframe embed, env webhook, color coding, throttle) covered. The owner-suggested `SignalDeliveryService` unification is left as a follow-up; this keeps the thin per-channel sender already in the codebase.
- Migration must be applied to existing deploys (`discord_posted_at` is additive, `IF NOT EXISTS`).