### PR TITLE
feat(i18n): runtime locale context + navbar switcher (#16, phase 1)

### DIFF
--- a/apps/web/app/components/locale-provider.tsx
+++ b/apps/web/app/components/locale-provider.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import {
+  type Locale,
+  type Translations,
+  getTranslations,
+  getTextDirection,
+  SUPPORTED_LOCALES,
+} from '../../lib/translations';
+
+/**
+ * Runtime locale context for the authenticated app shell (issue #16).
+ *
+ * The marketing landing pages keep their server-rendered, URL-prefixed i18n
+ * (/es, /zh, /ms, /ar) for SEO. The app shell (navbar + dashboard/app surfaces)
+ * has no SEO requirement, so it reads the chosen locale from this client context,
+ * persisted to localStorage and reflected in <html lang/dir> for RTL.
+ *
+ * Phase 1 ships the foundation + navbar switcher; per-surface string extraction
+ * (dashboard/signals/settings/backtest/compare) is the documented Phase 2.
+ */
+
+const STORAGE_KEY = 'tc_locale';
+
+interface LocaleContextValue {
+  locale: Locale;
+  setLocale: (l: Locale) => void;
+  t: Translations;
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+function isLocale(value: string | null): value is Locale {
+  return value !== null && SUPPORTED_LOCALES.some(l => l.code === value);
+}
+
+export function LocaleProvider({
+  children,
+  initialLocale = 'en',
+}: {
+  children: ReactNode;
+  initialLocale?: Locale;
+}) {
+  const [locale, setLocaleState] = useState<Locale>(initialLocale);
+
+  // Hydrate from the persisted preference after mount (avoids SSR mismatch).
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (isLocale(stored)) setLocaleState(stored);
+  }, []);
+
+  // Keep <html lang/dir> in sync so RTL locales (ar) flip layout direction.
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    document.documentElement.dir = getTextDirection(locale);
+  }, [locale]);
+
+  const setLocale = (l: Locale) => {
+    setLocaleState(l);
+    window.localStorage.setItem(STORAGE_KEY, l);
+  };
+
+  return (
+    <LocaleContext.Provider value={{ locale, setLocale, t: getTranslations(locale) }}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale(): LocaleContextValue {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) throw new Error('useLocale must be used within a LocaleProvider');
+  return ctx;
+}
+
+/** Convenience hook returning the active translation dictionary. */
+export function useTranslations(): Translations {
+  return useLocale().t;
+}

--- a/apps/web/app/components/navbar.tsx
+++ b/apps/web/app/components/navbar.tsx
@@ -6,6 +6,8 @@ import { Play, Thermometer, ChevronDown, Activity, ShoppingBag, Briefcase, Flask
 import { ThemeToggle } from './theme-toggle';
 import { TradeClawLogo } from '../../components/tradeclaw-logo';
 import { UserMenu } from '../../components/UserMenu';
+import { useLocale } from './locale-provider';
+import { SUPPORTED_LOCALES, type Locale } from '../../lib/translations';
 import type { LucideIcon } from 'lucide-react';
 
 interface NavLink {
@@ -92,6 +94,14 @@ export function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
+  const { t, locale, setLocale } = useLocale();
+
+  // Primary-nav labels resolved from the active locale (issue #16, Phase 1).
+  const navLabel: Record<string, string> = {
+    '/dashboard': t.nav.dashboard,
+    '/screener': t.nav.signals,
+    '/track-record': t.nav.trackRecord,
+  };
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 24);
@@ -142,7 +152,7 @@ export function Navbar() {
                 href={link.href}
                 className="hover:text-[var(--foreground)] transition-colors duration-300 flex items-center gap-1.5"
               >
-                {link.label}
+                {navLabel[link.href] ?? link.label}
               </Link>
             ))}
 
@@ -185,6 +195,18 @@ export function Navbar() {
 
           {/* CTA */}
           <div className="flex items-center gap-2 shrink-0">
+            <select
+              aria-label={t.nav.language}
+              value={locale}
+              onChange={(e) => setLocale(e.target.value as Locale)}
+              className="bg-transparent border border-[var(--border)] rounded-full px-2 py-1 text-xs text-[var(--text-secondary)] hover:text-[var(--foreground)] focus:outline-none focus:ring-1 focus:ring-emerald-500/40 cursor-pointer"
+            >
+              {SUPPORTED_LOCALES.map((l) => (
+                <option key={l.code} value={l.code} className="bg-[var(--bg-card)] text-[var(--foreground)]">
+                  {l.label}
+                </option>
+              ))}
+            </select>
             <UserMenu size="compact" />
             <Link
               href="/dashboard"

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,6 +6,7 @@ import { MobileNav } from "./components/mobile-nav";
 import { PWAInstallPrompt } from "./components/pwa-install";
 import { DemoBanner } from "./components/demo-banner";
 import { ThemeProvider } from "./components/theme-provider";
+import { LocaleProvider } from "./components/locale-provider";
 import { SiteFooter } from "./components/site-footer";
 import { MilestoneCelebrationModal } from "../components/milestone-modal";
 import { FeatureUnlockBanner } from "../components/feature-unlock-banner";
@@ -156,22 +157,24 @@ export default function RootLayout({
             <PostHogPageView />
           </Suspense>
           <ThemeProvider>
-            <script
-              type="application/ld+json"
-              dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-            />
-            <SWRegister />
-            {process.env.NEXT_PUBLIC_DEMO_MODE === 'true' && <DemoBanner />}
-            <div className="flex-1 pb-16 md:pb-0">
-              {children}
-            </div>
-            <SiteFooter />
-            <MobileNav />
-            <PWAInstallPrompt />
-            <MilestoneCelebrationModal />
-            <FeatureUnlockBanner />
-            <OnboardingChecklist />
-            <StarProgressBar />
+            <LocaleProvider>
+              <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+              />
+              <SWRegister />
+              {process.env.NEXT_PUBLIC_DEMO_MODE === 'true' && <DemoBanner />}
+              <div className="flex-1 pb-16 md:pb-0">
+                {children}
+              </div>
+              <SiteFooter />
+              <MobileNav />
+              <PWAInstallPrompt />
+              <MilestoneCelebrationModal />
+              <FeatureUnlockBanner />
+              <OnboardingChecklist />
+              <StarProgressBar />
+            </LocaleProvider>
           </ThemeProvider>
         </AnalyticsProvider>
       </body>

--- a/apps/web/lib/translations.ts
+++ b/apps/web/lib/translations.ts
@@ -66,9 +66,18 @@ export interface Translations {
     viewHeatmap: string;
     deployOn: string;
   };
+  // App shell strings (issue #16). Phase 1 covers primary nav + the language
+  // switcher; remaining app surfaces are extracted in Phase 2.
+  nav: {
+    dashboard: string;
+    signals: string;
+    trackRecord: string;
+    language: string;
+  };
 }
 
 const en: Translations = {
+  nav: { dashboard: "Dashboard", signals: "Signals", trackRecord: "Track Record", language: "Language" },
   meta: {
     title: "TradeClaw — Open-Source AI Trading Signals",
     description: "Self-hosted AI trading signals for forex, crypto, and metals. Free forever. Deploy in 5 minutes with Docker.",
@@ -134,6 +143,7 @@ const en: Translations = {
 };
 
 const es: Translations = {
+  nav: { dashboard: "Panel", signals: "Señales", trackRecord: "Historial", language: "Idioma" },
   meta: {
     title: "TradeClaw — Señales de Trading con IA de Código Abierto",
     description: "Señales de trading con IA autoalojadas para forex, cripto y metales. Gratis para siempre. Despliega en 5 minutos con Docker.",
@@ -199,6 +209,7 @@ const es: Translations = {
 };
 
 const zh: Translations = {
+  nav: { dashboard: "仪表板", signals: "信号", trackRecord: "战绩", language: "语言" },
   meta: {
     title: "TradeClaw — 开源 AI 交易信号平台",
     description: "自托管 AI 交易信号，支持外汇、加密货币和贵金属。永久免费。5 分钟内用 Docker 部署。",
@@ -265,6 +276,7 @@ const zh: Translations = {
 
 // Malay (Bahasa Malaysia) — initial translation, native-speaker review pending (#16).
 const ms: Translations = {
+  nav: { dashboard: "Papan Pemuka", signals: "Isyarat", trackRecord: "Rekod Prestasi", language: "Bahasa" },
   meta: {
     title: "TradeClaw — Isyarat Dagangan AI Sumber Terbuka",
     description: "Isyarat dagangan AI dihos sendiri untuk forex, kripto, dan logam. Percuma selamanya. Pasang dalam 5 minit dengan Docker.",
@@ -331,6 +343,7 @@ const ms: Translations = {
 
 // Arabic — initial translation, RTL layout. Native-speaker review pending (#16).
 const ar: Translations = {
+  nav: { dashboard: "لوحة التحكم", signals: "الإشارات", trackRecord: "سجل الأداء", language: "اللغة" },
   meta: {
     title: "TradeClaw — إشارات تداول بالذكاء الاصطناعي مفتوحة المصدر",
     description: "إشارات تداول بالذكاء الاصطناعي ذاتية الاستضافة للفوركس والعملات الرقمية والمعادن. مجانية إلى الأبد. النشر في 5 دقائق مع Docker.",


### PR DESCRIPTION
Toward #16 (does not fully close — see Phase 2).

## Context
Today i18n covers **only the landing page**, via separate `/es /zh /ms /ar` route pages. The app shell (navbar, dashboard, signals, settings) is hardcoded English at non-prefixed routes, and the `Translations` interface has zero app/nav keys. Full-app coverage needs (a) a runtime locale mechanism the static per-route pattern can't provide, and (b) extraction of hundreds of UI strings across every surface into 5 locales + native-speaker review. That's a multi-PR effort, so this lands the **foundation + the two concrete acceptance criteria** first.

## Phase 1 (this PR)
- **`LocaleProvider`** (client context): locale state, **localStorage persistence** (`tc_locale`), and `<html lang/dir>` sync so **RTL (ar)** flips layout. Exposes `useLocale()` / `useTranslations()`.
- Wired into the **root layout** so the whole app shell can consume it.
- **Navbar language switcher** (EN/ES/中文/MS/AR), always visible, sets + persists locale — satisfies *switcher in navbar* + *localStorage persistence*.
- Primary nav links (Dashboard / Signals / Track Record) now translate from the active locale — the reference pattern for Phase 2. `Translations` gains a `nav` section across all 5 locales.

## Phase 2 (follow-up, not in this PR)
Extract remaining app strings (full nav dropdowns, dashboard, signals, settings, backtest, compare) into the dictionary × 5 locales, then native-speaker review of the `ms` + `ar` strings. This is the large, reviewable-in-slices remainder; doing it in one commit would be an unreviewable, high-risk mega-diff.

## Testing
- `tsc --noEmit` on `apps/web` → no new errors. The `Translations` interface change is satisfied by all 5 locale objects; no other constructors exist.
- Manual: switch locale in navbar → primary links retranslate, choice persists across reload, `ar` sets `dir=rtl`.

## Architecture note
Two i18n systems coexist by design: landing = server-rendered URL-prefixed (SEO); app shell = client runtime context (authed pages, no SEO need). Convergence onto one system can be evaluated in Phase 2.