### PR TITLE
feat: deferred follow-ups for #19 (metrics families) and #43 (progressive disclosure)

### DIFF
--- a/apps/web/app/api/metrics/route.ts
+++ b/apps/web/app/api/metrics/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getTrackedSignalsForRequest } from '../../../lib/tracked-signals';
-import { getSymbolBreakdown } from '../../../lib/signal-metrics';
+import { getSymbolBreakdown, getOperatorMemoryCount } from '../../../lib/signal-metrics';
 import { SYMBOLS } from '../../lib/signals';
+import { snapshotDeliveries } from '../../../lib/delivery-metrics';
+import { renderGenLatencyHistogram } from '../../../lib/gen-latency';
 
 export const dynamic = 'force-dynamic';
 
@@ -116,6 +118,17 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // Operator-memory entry count (best-effort; zero on DB failure).
+    let operatorMemoryCount = 0;
+    try {
+      operatorMemoryCount = await getOperatorMemoryCount();
+    } catch {
+      operatorMemoryCount = 0;
+    }
+
+    // Delivery counters (in-process; per-instance, reset on restart).
+    const deliverySamples = snapshotDeliveries();
+
     const lines: Line[] = [
       {
         name: 'tradeclaw_signal_value',
@@ -163,6 +176,18 @@ export async function GET(request: NextRequest) {
         samples: ageSamples,
       },
       {
+        name: 'tradeclaw_webhook_delivery_total',
+        help: 'Alert/webhook delivery attempts by channel and outcome (in-process, per-instance, resets on restart)',
+        type: 'counter',
+        samples: deliverySamples,
+      },
+      {
+        name: 'tradeclaw_operator_memory_entries',
+        help: 'Total operator-memory rows (per user_id+key) in storage',
+        type: 'gauge',
+        samples: [{ labels: {}, value: operatorMemoryCount }],
+      },
+      {
         name: 'tradeclaw_scrape_timestamp_seconds',
         help: 'Unix timestamp (seconds) when these metrics were generated',
         type: 'gauge',
@@ -170,7 +195,7 @@ export async function GET(request: NextRequest) {
       },
     ];
 
-    return new NextResponse(formatLines(lines), {
+    return new NextResponse(formatLines(lines) + renderGenLatencyHistogram(), {
       status: 200,
       headers: {
         'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',

--- a/apps/web/components/guided-tour.tsx
+++ b/apps/web/components/guided-tour.tsx
@@ -10,6 +10,7 @@ const TOUR_DONE_KEY = 'tc_tour_done';
 const TOUR_AUTO_KEY = 'tc_tour_auto_shown';
 const TOUR_STEP_KEY = 'tc_tour_step';
 const TOUR_NEVER_KEY = 'tc_tour_never';
+const TOUR_VISITS_KEY = 'tc_tour_visits';
 
 /* ------------------------------------------------------------------ */
 /*  Tour steps — targeting REAL dashboard elements                     */
@@ -20,6 +21,9 @@ interface TourStep {
   title: string;
   description: string;
   position?: 'bottom' | 'top' | 'auto';
+  // Phase 1 = core interaction loop (always shown). Phase 2 = advanced steps,
+  // revealed only after the user has demonstrated intent (see isPhase2Unlocked).
+  phase: 1 | 2;
 }
 
 const STEPS: TourStep[] = [
@@ -28,38 +32,69 @@ const STEPS: TourStep[] = [
     title: 'Your market snapshot',
     description:
       'See active signals, buy/sell ratio, average confidence, and market bias at a glance. Use this to gauge overall sentiment before diving in.',
+    phase: 1,
   },
   {
     targetId: 'signal-grid',
     title: 'Reading a signal card',
     description:
       'Each card shows: Confidence (how many indicators agree), Entry (price now), SL (auto-calculated stop using ATR volatility), and TP1–TP3 (profit targets at 1.5×, 2.5×, 3.5× risk). Tap the "?" icons for one-line explanations of each metric.',
+    phase: 1,
   },
   {
     targetId: 'dashboard-filters',
     title: 'Filter by what matters',
     description:
       'Narrow signals by timeframe, direction (BUY/SELL), or asset class. Focus on your preferred market in one click.',
+    phase: 1,
   },
   {
     targetId: 'auto-refresh-toggle',
     title: 'Stay in sync',
     description:
       'Toggle auto-refresh to get signals updated every 30 seconds. Pause it when you want to study a signal without it changing.',
+    phase: 2,
   },
   {
     targetId: 'accuracy-stats',
     title: 'Track signal accuracy',
     description:
       'Check historical accuracy rates. No cherry-picking — every signal outcome is logged with full transparency.',
+    phase: 2,
   },
   {
     targetId: null,
     title: 'Ready to go deeper?',
     description:
       'Try the Backtest page to test strategies on historical data, or set up Telegram alerts to never miss a signal. Tap the export button on any signal to copy it for Telegram, Discord, or TradingView. Happy trading!',
+    phase: 2,
   },
 ];
+
+/* ------------------------------------------------------------------ */
+/*  Progressive disclosure (issue #43)                                  */
+/*  Phase 1 (core loop) always shows. Phase 2 (advanced) unlocks after  */
+/*  the 3rd dashboard visit OR once the tour has been completed once.   */
+/* ------------------------------------------------------------------ */
+
+function readVisitCount(): number {
+  try {
+    return parseInt(localStorage.getItem(TOUR_VISITS_KEY) || '0', 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function isPhase2Unlocked(): boolean {
+  try {
+    if (localStorage.getItem(TOUR_DONE_KEY)) return true;
+  } catch { /* ignore */ }
+  return readVisitCount() >= 3;
+}
+
+function getUnlockedSteps(): TourStep[] {
+  return isPhase2Unlocked() ? STEPS : STEPS.filter((s) => s.phase === 1);
+}
 
 /* ------------------------------------------------------------------ */
 /*  Spotlight geometry                                                  */
@@ -115,7 +150,7 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
       const saved = localStorage.getItem(TOUR_STEP_KEY);
       if (saved !== null) {
         const parsed = parseInt(saved, 10);
-        if (parsed >= 0 && parsed < STEPS.length) return parsed;
+        if (parsed >= 0 && parsed < getUnlockedSteps().length) return parsed;
       }
     } catch { /* ignore */ }
     return 0;
@@ -138,6 +173,15 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
   /* ---- Dispatch onboarding event when tour completes ---- */
   const dispatchTourComplete = useCallback(() => {
     window.dispatchEvent(new CustomEvent('tc:tour-complete'));
+  }, []);
+
+  /* ---- Count dashboard visits (drives phase-2 progressive disclosure) ---- */
+  useEffect(() => {
+    try {
+      if (typeof window === 'undefined') return;
+      if (!window.location.pathname.startsWith('/dashboard')) return;
+      localStorage.setItem(TOUR_VISITS_KEY, String(readVisitCount() + 1));
+    } catch { /* ignore */ }
   }, []);
 
   /* ---- Auto-show on first visit (2s delay, dashboard only) ---- */
@@ -173,7 +217,7 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
 
   /* ---- Compute spotlight + tooltip placement ---- */
   const updateSpotlight = useCallback((currentStep: number) => {
-    const targetId = STEPS[currentStep]?.targetId;
+    const targetId = getUnlockedSteps()[currentStep]?.targetId;
     if (!targetId) {
       setSpotlightRect(null);
       setPlacement('center');
@@ -268,7 +312,7 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
   }, [step, saveTourProgress, onClose]);
 
   const next = useCallback(() => {
-    if (step < STEPS.length - 1) {
+    if (step < getUnlockedSteps().length - 1) {
       setStep(s => s + 1);
     } else {
       // Tour complete
@@ -311,8 +355,9 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
 
   if (!active) return null;
 
-  const currentStep = STEPS[step];
-  const isLast = step === STEPS.length - 1;
+  const unlockedSteps = getUnlockedSteps();
+  const currentStep = unlockedSteps[step];
+  const isLast = step === unlockedSteps.length - 1;
   const pad = 10;
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 
@@ -448,7 +493,7 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
       <div
         ref={tooltipRef}
         role="dialog"
-        aria-label={`Tour step ${step + 1} of ${STEPS.length}`}
+        aria-label={`Tour step ${step + 1} of ${unlockedSteps.length}`}
         aria-modal="true"
         className={`bg-zinc-900 border border-emerald-500/30 shadow-2xl shadow-black/40 transition-all duration-400 ${
           isMobile ? 'p-6 pt-4' : 'rounded-xl p-5'
@@ -485,7 +530,7 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
         {/* Header row */}
         <div className="flex items-center justify-between mb-3">
           <span className="text-[11px] text-zinc-500 font-mono tabular-nums">
-            Step {step + 1} of {STEPS.length}
+            Step {step + 1} of {unlockedSteps.length}
           </span>
           <button
             onClick={skip}
@@ -501,7 +546,7 @@ export function GuidedTour({ open: externalOpen, onClose }: GuidedTourProps) {
 
         {/* Step dots */}
         <div className="flex items-center gap-1.5 mb-4">
-          {STEPS.map((_, i) => (
+          {unlockedSteps.map((_, i) => (
             <button
               key={i}
               onClick={() => setStep(i)}

--- a/apps/web/lib/alert-channels.ts
+++ b/apps/web/lib/alert-channels.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { isSafeOutboundUrl } from './safe-outbound-url';
+import { recordDelivery } from './delivery-metrics';
 
 /**
  * Per-user "preferred platform" senders.
@@ -115,8 +116,10 @@ export async function sendTelegramDm(
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     const data = (await res.json()) as { ok: boolean };
+    recordDelivery('telegram', data.ok === true ? 'success' : 'failed');
     return data.ok === true;
   } catch {
+    recordDelivery('telegram', 'failed');
     return false;
   }
 }
@@ -137,8 +140,10 @@ export async function sendDiscordWebhook(
       body: JSON.stringify(formatDiscordEmbed(signal)),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
+    recordDelivery('discord', res.ok ? 'success' : 'failed');
     return res.ok;
   } catch {
+    recordDelivery('discord', 'failed');
     return false;
   }
 }
@@ -162,8 +167,10 @@ export async function sendGenericWebhook(
       body: JSON.stringify({ signal, timestamp: new Date().toISOString() }),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
+    recordDelivery('webhook', res.ok ? 'success' : 'failed');
     return res.ok;
   } catch {
+    recordDelivery('webhook', 'failed');
     return false;
   }
 }
@@ -176,6 +183,7 @@ export async function sendEmail(
   if (!to) return false;
   const { sendSignalEmail } = await import('./email-sender');
   const result = await sendSignalEmail(to, signal);
+  recordDelivery('email', result.ok ? 'success' : 'failed');
   return result.ok;
 }
 

--- a/apps/web/lib/delivery-metrics.ts
+++ b/apps/web/lib/delivery-metrics.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+/**
+ * In-process delivery counters for alert channels and the Telegram Pro broadcast.
+ *
+ * Per-instance and non-durable: counters live in module memory, reset on
+ * restart, and do not aggregate across multiple instances. Enough to spot
+ * rate-limit blocks and delivery failures on a single self-hosted node before
+ * users report missing signals. For durable history, back this with a DB log.
+ *
+ * recordDelivery() is called at each send site; snapshotDeliveries() is read by
+ * /api/metrics and exposed as tradeclaw_webhook_delivery_total{channel,status}.
+ */
+
+export type DeliveryChannel = 'telegram' | 'discord' | 'email' | 'webhook' | 'telegram_pro_broadcast';
+export type DeliveryStatus = 'success' | 'failed';
+
+export interface DeliverySample {
+  labels: { channel: string; status: string };
+  value: number;
+}
+
+const counters = new Map<string, number>();
+
+export function recordDelivery(channel: DeliveryChannel, status: DeliveryStatus): void {
+  const key = `${channel}::${status}`;
+  counters.set(key, (counters.get(key) ?? 0) + 1);
+}
+
+export function snapshotDeliveries(): DeliverySample[] {
+  const samples: DeliverySample[] = [];
+  for (const [key, value] of counters) {
+    const [channel, status] = key.split('::');
+    samples.push({ labels: { channel, status }, value });
+  }
+  return samples;
+}

--- a/apps/web/lib/gen-latency.ts
+++ b/apps/web/lib/gen-latency.ts
@@ -1,0 +1,46 @@
+import 'server-only';
+
+/**
+ * In-process histogram for signal-generation latency (seconds).
+ *
+ * Module-level cumulative bucket counters; per-instance and reset on restart.
+ * Instrumented around the cron precompute boundary (signal-worker.ts), which is
+ * the real generation path — `getSignals({ skipCache: true })` forces a fresh
+ * TA run rather than serving cached results. The per-request fetch path is
+ * deliberately NOT instrumented here so the metric stays a true "generation"
+ * latency rather than a mix of generate-and-serve timings.
+ */
+
+const BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10] as const;
+
+const bucketCounts = new Map<number, number>(BUCKETS.map((b) => [b, 0]));
+let sum = 0;
+let count = 0;
+
+export function observeSignalGenDuration(seconds: number): void {
+  if (!Number.isFinite(seconds) || seconds < 0) return;
+  sum += seconds;
+  count += 1;
+  // Prometheus histogram buckets are cumulative (le = less-than-or-equal).
+  for (const b of BUCKETS) {
+    if (seconds <= b) bucketCounts.set(b, (bucketCounts.get(b) ?? 0) + 1);
+  }
+}
+
+const METRIC = 'tradeclaw_signal_gen_duration_seconds';
+
+/** Render the histogram as Prometheus exposition text (HELP/TYPE + samples). */
+export function renderGenLatencyHistogram(): string {
+  const out: string[] = [
+    `# HELP ${METRIC} Signal generation latency in seconds (cron precompute path). Per-instance, resets on restart.`,
+    `# TYPE ${METRIC} histogram`,
+  ];
+  for (const b of BUCKETS) {
+    out.push(`${METRIC}_bucket{le="${b}"} ${bucketCounts.get(b) ?? 0}`);
+  }
+  out.push(`${METRIC}_bucket{le="+Inf"} ${count}`);
+  out.push(`${METRIC}_sum ${sum}`);
+  out.push(`${METRIC}_count ${count}`);
+  out.push('');
+  return out.join('\n');
+}

--- a/apps/web/lib/signal-metrics.ts
+++ b/apps/web/lib/signal-metrics.ts
@@ -112,6 +112,13 @@ export async function getSymbolBreakdown(days: number): Promise<SymbolBreakdownR
   });
 }
 
+export async function getOperatorMemoryCount(): Promise<number> {
+  const rows = await query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM operator_memory`,
+  );
+  return rows.length > 0 ? Number(rows[0].count) : 0;
+}
+
 export async function getRecommendations(): Promise<Recommendation[]> {
   const recommendations: Recommendation[] = [];
 

--- a/apps/web/lib/signal-worker.ts
+++ b/apps/web/lib/signal-worker.ts
@@ -13,6 +13,7 @@ import { getSignals } from '../app/lib/signals';
 import { safeProfileId } from '../app/lib/signal-generator';
 import { getActivePreset } from '../app/api/cron/signals/preset-dispatch';
 import { redis, isRedisAvailable, ensureRedis, redisKey } from './redis';
+import { observeSignalGenDuration } from './gen-latency';
 
 const CACHE_KEY = redisKey('signals:latest');
 const CACHE_TTL_SECONDS = 6 * 60; // 6 minutes (cron runs every 5)
@@ -29,9 +30,11 @@ export async function precomputeSignals(): Promise<void> {
   const preset = getActivePreset();
   const profileId = safeProfileId(preset.id);
 
+  const genStartMs = Date.now();
   try {
     // Generate fresh signals (bypass cache to avoid reading stale data)
     const { signals, syntheticSymbols } = await getSignals({}, { skipCache: true });
+    observeSignalGenDuration((Date.now() - genStartMs) / 1000);
 
     const payload: CachedSignalsPayload = {
       signals,

--- a/apps/web/lib/telegram-pro-broadcast.ts
+++ b/apps/web/lib/telegram-pro-broadcast.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { getBotToken, getProGroupId, getProSignalsTopicId } from './telegram-channels';
 import { getSignalTelegramProMessageId, markTelegramProPosted } from './signal-history';
 import { recordBroadcastResult } from './observability';
+import { recordDelivery } from './delivery-metrics';
 
 /**
  * Pro-tier real-time broadcast.
@@ -156,6 +157,7 @@ export async function broadcastSignalsToProGroup(
       };
       if (data.ok) {
         sent++;
+        recordDelivery('telegram_pro_broadcast', 'success');
         // Persist message_id so the position-monitor cron can post TP/SL
         // outcome replies threaded under the original signal in the Pro
         // group. Uses telegram_pro_message_id, separate from the free
@@ -167,9 +169,11 @@ export async function broadcastSignalsToProGroup(
         }
       } else {
         failed++;
+        recordDelivery('telegram_pro_broadcast', 'failed');
       }
     } catch {
       failed++;
+      recordDelivery('telegram_pro_broadcast', 'failed');
     }
   }
 

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -63,6 +63,9 @@ the same compose network.)
 | `tradeclaw_scrape_timestamp_seconds`| gauge | When this scrape was generated (unix seconds) |
 | `tradeclaw_signal_outcomes_total`   | gauge | Resolved outcomes per symbol+result over 30d (hit / sl / open) |
 | `tradeclaw_signal_age_seconds`      | gauge | Seconds since the most recent signal per symbol (freshness) |
+| `tradeclaw_webhook_delivery_total`  | counter | Alert/webhook delivery attempts by `channel` + `status` (in-process, per-instance, resets on restart) |
+| `tradeclaw_operator_memory_entries` | gauge | Total operator-memory rows in storage |
+| `tradeclaw_signal_gen_duration_seconds` | histogram | Signal-generation latency from the cron precompute path (per-instance, resets on restart) |
 
 The dashboard ships two extra panels for these: a **Signal Freshness**
 bar gauge (green <5m, yellow 5–15m, red >15m) that surfaces exchange


### PR DESCRIPTION
## What

Implements the deferred follow-up items from issues #19 and #43 (round 2). Builds on the round-1 enhancements already in `main`.

### #19 — new /api/metrics families
- **`tradeclaw_operator_memory_entries`** (gauge) — row count from the `operator_memory` table; best-effort, zero on DB failure.
- **`tradeclaw_webhook_delivery_total{channel,status}`** (counter) — in-process counters (`lib/delivery-metrics.ts`) recorded at the real alert-channel (`telegram`/`discord`/`webhook`/`email`) and Telegram Pro broadcast send sites. Per-instance; resets on restart (documented in HELP + README).
- **`tradeclaw_signal_gen_duration_seconds`** (histogram) — latency timed around the cron precompute boundary in `signal-worker.ts` (the true generation path, `skipCache:true`); the per-request fetch path is deliberately not counted so the metric stays a clean "generation" latency.
- `grafana/README.md` documents all three.

### #43 — 2-phase progressive disclosure
Phase 1 (stats, signal card, filters) always shows; phase 2 (auto-refresh, accuracy, go-deeper) unlocks after the 3rd dashboard visit or once the tour completes. Visit counter in `localStorage`; step dots, header, aria-label, resume clamp, and navigation all key off the unlocked subset.

## Not built (honest blockers)
- **#19 backtest-queue depth** — no async queue exists; backtests run synchronously in the request. A depth gauge would be meaningless. Not fabricated.
- **#37 entry/SL/TP shape overlays + crosshair sync** — require the licensed TradingView `charting_library` (not npm-installable). The native lightweight-charts tab (`SignalChart.tsx`) already draws entry/SL/TP price lines via `createPriceLine`, so the capability already exists in-app.

## Verification
- `eslint` clean on all changed files.
- `tsc --noEmit`: no new errors. The one `signal-worker.ts` `minConfidence` error pre-exists on `main` (line 104, unrelated to the 3 additive timing lines).
- Delivery/latency counters are additive instrumentation (no behavior change to send/generation logic). Both are per-instance and documented as such.

## Notes
Done on a feature branch + PR rather than direct-to-main, given the active multi-agent fleet pushing to `main`.
