### PR TITLE
fix(ci): restore green CI — lint, type-check, and signals build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: ${{ github.workspace }}
+      - name: Build signals (dev server resolves @tradeclaw/signals from dist)
+        run: npm run build:signals
+        working-directory: ${{ github.workspace }}
       - name: Apply migrations to sidecar Postgres
         # Bypass the Railway-tuned migration runner (which forces SSL) by
         # piping each .sql file through psql directly. CI starts from an empty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # @tradeclaw/signals resolves through its dist build; type-check needs it present.
+      - run: npm run build:signals
       - run: npm run lint
       - run: npx tsc --noEmit --project apps/web/tsconfig.json
 

--- a/apps/web/app/api/auth/telegram/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/telegram/__tests__/route.test.ts
@@ -46,14 +46,14 @@ describe('/api/auth/telegram', () => {
 
   it('returns 503 when TELEGRAM_BOT_TOKEN is not set', async () => {
     delete process.env.TELEGRAM_BOT_TOKEN;
-    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as any);
+    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(503);
     const data = await res.json();
     expect(data.error).toBe('telegram_not_configured');
   });
 
   it('returns 400 for missing fields', async () => {
-    const res = await POST(makeRequest({ first_name: 'Test', auth_date: 1, hash: 'x' }) as any);
+    const res = await POST(makeRequest({ first_name: 'Test', auth_date: 1, hash: 'x' }) as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe('missing_fields');
   });
@@ -61,7 +61,7 @@ describe('/api/auth/telegram', () => {
   it('returns 401 for invalid hash', async () => {
     mockVerifyTelegramLogin.mockReturnValue(false);
     mockIsTelegramAuthDateFresh.mockReturnValue(true);
-    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as any);
+    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
     expect((await res.json()).error).toBe('invalid_hash');
   });
@@ -69,7 +69,7 @@ describe('/api/auth/telegram', () => {
   it('returns 401 for expired auth_date', async () => {
     mockVerifyTelegramLogin.mockReturnValue(true);
     mockIsTelegramAuthDateFresh.mockReturnValue(false);
-    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as any);
+    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
     expect((await res.json()).error).toBe('auth_expired');
   });
@@ -89,7 +89,7 @@ describe('/api/auth/telegram', () => {
         photo_url: 'https://example.com/photo.jpg',
         auth_date: Math.floor(Date.now() / 1000),
         hash: 'validhash',
-      }) as any,
+      }) as unknown as Parameters<typeof POST>[0],
     );
 
     expect(res.status).toBe(200);
@@ -121,7 +121,7 @@ describe('/api/auth/telegram', () => {
         username: 'testuser',
         auth_date: 1,
         hash: 'x',
-      }) as any,
+      }) as unknown as Parameters<typeof POST>[0],
     );
 
     expect(mockUpsertTelegramUser).toHaveBeenCalledWith(
@@ -141,7 +141,7 @@ describe('/api/auth/telegram', () => {
         first_name: '',
         auth_date: 1,
         hash: 'x',
-      }) as any,
+      }) as unknown as Parameters<typeof POST>[0],
     );
 
     expect(mockUpsertTelegramUser).toHaveBeenCalledWith(
@@ -154,7 +154,7 @@ describe('/api/auth/telegram', () => {
     mockIsTelegramAuthDateFresh.mockReturnValue(true);
     mockUpsertTelegramUser.mockRejectedValue(new Error('db down'));
 
-    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as any);
+    const res = await POST(makeRequest({ id: 1, first_name: 'Test', auth_date: 1, hash: 'x' }) as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('server_error');
   });

--- a/apps/web/app/api/referrals/route.ts
+++ b/apps/web/app/api/referrals/route.ts
@@ -3,6 +3,7 @@ import { readSessionFromRequest } from '../../../lib/user-session';
 import {
   getReferralRevenueForReferrer,
   getReferredUsersCount,
+  getUserById,
 } from '../../../lib/db';
 
 export const runtime = 'nodejs';
@@ -31,12 +32,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const [revenue, referredCount] = await Promise.all([
+    const [revenue, referredCount, user] = await Promise.all([
       getReferralRevenueForReferrer(session.userId),
       getReferredUsersCount(session.userId),
+      getUserById(session.userId),
     ]);
 
-    const referralCode = session.referralCode ?? null;
+    const referralCode = user?.referralCode ?? null;
     const referralLink = referralCode
       ? `https://tradeclaw.win/pricing?ref=${referralCode}`
       : null;

--- a/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/__tests__/route.test.ts
@@ -262,6 +262,7 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
       avatarUrl: null,
       authProvider: null,
       referralCode: null,
+      referredBy: null,
     });
 
     const res = await POST(makeRequest());
@@ -338,6 +339,7 @@ describe('POST /api/stripe/webhook — invoice.payment_failed dunning', () => {
       avatarUrl: null,
       authProvider: null,
       referralCode: null,
+      referredBy: null,
     });
     mockedSendDunning.mockResolvedValueOnce({ ok: false, reason: 'provider_error' });
 
@@ -713,6 +715,7 @@ describe('POST /api/stripe/webhook — tier transitions', () => {
       avatarUrl: null,
       authProvider: null,
       referralCode: null,
+      referredBy: null,
     });
 
     mockedGetStripe.mockReturnValue({

--- a/apps/web/app/components/locale-provider.tsx
+++ b/apps/web/app/components/locale-provider.tsx
@@ -47,6 +47,8 @@ export function LocaleProvider({
   // Hydrate from the persisted preference after mount (avoids SSR mismatch).
   useEffect(() => {
     const stored = window.localStorage.getItem(STORAGE_KEY);
+    // Hydration must happen after mount to avoid an SSR/client markup mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (isLocale(stored)) setLocaleState(stored);
   }, []);
 

--- a/apps/web/app/referrals/ReferralsClient.tsx
+++ b/apps/web/app/referrals/ReferralsClient.tsx
@@ -45,6 +45,9 @@ export function ReferralsClient() {
 
   useEffect(() => {
     if (status === 'anonymous') {
+      // Session status resolves client-side after mount; clearing the loading
+      // flag here is the intended response to that async transition.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoading(false);
       return;
     }

--- a/apps/web/app/signal/[id]/page.tsx
+++ b/apps/web/app/signal/[id]/page.tsx
@@ -304,7 +304,6 @@ export default async function SignalPage(
 
   const isBuy = signal.direction === 'BUY';
   const signalPath = `/signal/${symbol}-${timeframe}-${direction}`;
-  const now = Date.now();
 
   return (
     <div className="min-h-[100dvh] bg-[#050505] text-white">

--- a/apps/web/app/signin/page.tsx
+++ b/apps/web/app/signin/page.tsx
@@ -37,7 +37,7 @@ function SigninInner() {
   const [telegramBusy, setTelegramBusy] = useState(false);
   const [telegramErr, setTelegramErr] = useState<string | null>(null);
 
-  const proceedRef = useRef<() => Promise<void>>();
+  const proceedRef = useRef<(() => Promise<void>) | undefined>(undefined);
 
   async function proceedAfterSession(): Promise<void> {
     const checkoutBody =

--- a/apps/web/app/strategies/comparison/ComparisonClient.tsx
+++ b/apps/web/app/strategies/comparison/ComparisonClient.tsx
@@ -46,6 +46,8 @@ export function ComparisonClient() {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
+    // Reset the spinner whenever the selected period changes before refetching.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     fetch(`/api/strategy-breakdown?period=${period}`)
       .then((res) => {

--- a/apps/web/lib/__tests__/strategy-breakdown.test.ts
+++ b/apps/web/lib/__tests__/strategy-breakdown.test.ts
@@ -158,7 +158,7 @@ describe('computeStrategyBreakdown multi-strategy winners', () => {
         outcomes: { '4h': null, '24h': { hit: true, pnlPct: 2.1, price: 100 } },
       },
     ];
-    const result = computeStrategyBreakdown(records as any, 'all');
+    const result = computeStrategyBreakdown(records as unknown as SignalHistoryRecord[], 'all');
     const classic = result.find((r) => r.strategyId === 'classic')!;
     const hmm = result.find((r) => r.strategyId === 'hmm-top3')!;
 

--- a/apps/web/lib/signal-worker.ts
+++ b/apps/web/lib/signal-worker.ts
@@ -100,8 +100,9 @@ export async function getSignalsCached(params: {
       const upper = params.direction.toUpperCase();
       signals = signals.filter((s) => s.direction === upper);
     }
-    if (params.minConfidence && params.minConfidence > 0) {
-      signals = signals.filter((s) => s.confidence >= params.minConfidence);
+    const minConfidence = params.minConfidence;
+    if (minConfidence && minConfidence > 0) {
+      signals = signals.filter((s) => s.confidence >= minConfidence);
     }
 
     return { signals, syntheticSymbols: cached.syntheticSymbols };


### PR DESCRIPTION
## What

Restores a green CI pipeline on `main`. The `Lint & Type Check` job has been failing since at least 2026-05-30, which masked a second failure underneath it (`tsc`) and blocked every downstream job (build, tests, e2e, docker, backtests all skipped) — and with it every PR merge, including the deferred-follow-ups PR #96.

## Root causes

1. **13 ESLint errors** across 6 files (pre-existing; 5 of 6 predate the recent issue settlement): `no-explicit-any` in two tests, three React Compiler `set-state-in-effect` violations on intentional hydration/fetch effects, and a dead `Date.now()` in a server component.
2. **6 `tsc --noEmit` errors** under the lint failure: referral code read from a non-existent session field, `useRef` missing its React 19 initial value, a non-narrowed `minConfidence` inside a filter closure, and stripe webhook test fixtures missing the required `referredBy` field.
3. **Structural CI gap:** the lint job runs `tsc` but never builds `@tradeclaw/signals`, whose `exports` resolve through `dist/`. On a fresh checkout `tsc` could never resolve it — the type-check step was unable to pass regardless of code.

## Changes (3 separated commits)

- `fix(lint)` — clear the 13 eslint errors (test casts, scoped disables with rationale, dead-code removal).
- `fix(types)` — clear the 6 tsc errors.
- `ci` — build `@tradeclaw/signals` after install, before lint/tsc.

## Verification (local, from a clean dist state)

- `npm run build:signals && npm run lint` → clean (warnings only)
- `npx tsc --noEmit --project apps/web/tsconfig.json` → 0 errors
- `npm test` → 997 passed, 26 skipped, 0 failed
- `npm run build` → compiled successfully, all 325 pages generated (local run only trips a Windows-only EBUSY on the standalone copy step; not reproducible on ubuntu-latest)

## Notes

- `main` is not branch-protected, so no required-check config needs updating.
- Other resolution paths (`core`, `strategies`, `trading-agents`) already resolve to `src`, so only `signals` needs a build step.