### PR TITLE
chore(build): include @tradeclaw/trading-agents in root build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspace=apps/web",
-    "build": "npm run build --workspace=packages/signals && npm run build --workspace=apps/web",
+    "build": "npm run build --workspace=packages/signals && npm run build --workspace=packages/trading-agents && npm run build --workspace=apps/web",
     "build:signals": "npm run build --workspace=packages/signals",
+    "build:trading-agents": "npm run build --workspace=packages/trading-agents",
     "build:agent": "npm run build --workspace=packages/agent",
     "build:all": "npm run build:signals && npm run build:agent && npm run build && npm run ws:build",
     "lint": "npm run lint --workspace=apps/web",


### PR DESCRIPTION
Follow-up to the CI-green restore (#97).

`apps/web` imports `@tradeclaw/trading-agents`, but the root `build` script only built `signals` + `apps/web`. It works today because trading-agents resolves from `src/` — but a future switch of its `exports` to `dist/` would break the build with no warning. This builds it explicitly and adds a `build:trading-agents` script for parity with `build:signals`.

No behavior change today; defensive only.