### PR TITLE
test(e2e): stabilize the safe tail — warmup, backtest-load, admin-login

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -20,13 +20,19 @@ export default defineConfig({
     navigationTimeout: 30_000,
   },
   projects: [
+    // Runs once after the webServer is ready and before the test projects.
+    // Warms the signal-generation paths so the first real assertion doesn't pay
+    // the ~10-15s cold-generation cost (see warmup.setup.ts).
+    { name: 'setup', testMatch: /warmup\.setup\.ts/ },
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
     },
     {
       name: 'mobile',
       use: { ...devices['iPhone 14'] },
+      dependencies: ['setup'],
     },
   ],
   webServer: {

--- a/apps/web/tests/e2e/auth/login.spec.ts
+++ b/apps/web/tests/e2e/auth/login.spec.ts
@@ -40,13 +40,14 @@ test.describe('Admin Login', () => {
     await expect(page.locator('text=Invalid secret')).toBeVisible();
   });
 
-  test('redirects to dashboard on successful login', async ({ page }) => {
+  test('redirects to admin on successful login', async ({ page }) => {
     await page.locator('input#secret').fill('correct-secret');
     await page.locator('button[type="submit"]').click();
 
-    // Should navigate to dashboard
-    await page.waitForURL('**/dashboard', { timeout: 10_000 });
-    expect(page.url()).toContain('/dashboard');
+    // A login with no ?redirect= param lands on the admin landing page (/admin),
+    // not the public /dashboard (AdminLoginClient.tsx).
+    await page.waitForURL('**/admin', { timeout: 10_000 });
+    expect(page.url()).toContain('/admin');
   });
 
   test('shows loading state during submission', async ({ page }) => {

--- a/apps/web/tests/e2e/backtest/backtest-flow.spec.ts
+++ b/apps/web/tests/e2e/backtest/backtest-flow.spec.ts
@@ -24,11 +24,12 @@ test.describe('Backtest Single-Preset Flow', () => {
     await dismissStarMilestoneModal(page);
     await page.goto('/backtest');
     await dismissStarMilestoneModal(page);
-    await page.waitForLoadState('domcontentloaded');
-
-    await expect(page.getByText('Configuration')).toBeVisible();
+    // The route shows a Suspense fallback until the heavy client page hydrates,
+    // and the page auto-runs on mount (button label flips to "Fetching data..."
+    // until the run finishes). Wait those out — mirrors the passing siblings.
+    await expect(page.getByText('Configuration')).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText('Preset Strategies')).toBeVisible();
-    await expect(page.getByRole('button', { name: /run backtest/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /run backtest/i })).toBeVisible({ timeout: 60_000 });
   });
 
   test('auto-run completes and shows metrics table', async ({ page }) => {

--- a/apps/web/tests/e2e/features/backtest-comparison.spec.ts
+++ b/apps/web/tests/e2e/features/backtest-comparison.spec.ts
@@ -82,13 +82,12 @@ test.describe('Backtest Comparison', () => {
     await dismissStarMilestoneModal(page);
     await page.goto('/backtest');
     await dismissStarMilestoneModal(page);
-    await page.waitForLoadState('domcontentloaded');
-
-    // Page should render config panel
-    await expect(page.getByText('Configuration')).toBeVisible();
+    // Route shows a Suspense fallback until the client page hydrates, then
+    // auto-runs on mount (button reads "Fetching data..." until done). Wait it
+    // out — mirrors the passing sibling test in this file.
+    await expect(page.getByText('Configuration')).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText('Preset Strategies')).toBeVisible();
-
-    // Run button should be present
-    await expect(page.getByRole('button', { name: /run backtest/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /run backtest/i })).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByRole('button', { name: /run backtest/i })).toBeEnabled({ timeout: 60_000 });
   });
 });

--- a/apps/web/tests/e2e/warmup.setup.ts
+++ b/apps/web/tests/e2e/warmup.setup.ts
@@ -1,0 +1,20 @@
+import { test as setup, expect } from '@playwright/test';
+
+// Warms the signal-generation paths so the first real assertion in the suite
+// doesn't pay the ~10-15s cold cost. The request path warms the in-process
+// OHLCV cache (lib/ohlcv.ts), shared across the suite because CI runs a single
+// `next start` process. Asserts reachability only — never latency or content —
+// so a genuinely broken route still fails in the real specs, not here.
+setup('warm signal-generation paths', async ({ request }) => {
+  const signals = await request.get('/api/signals', { timeout: 60_000 });
+  expect(signals.ok()).toBeTruthy();
+
+  // /api/screener has its own compute + OHLCV-for-sparklines path behind the
+  // ~20s wait in landing-render.spec.ts; warm it directly.
+  const screener = await request.get('/api/screener', { timeout: 60_000 });
+  expect(screener.ok()).toBeTruthy();
+
+  // Public teaser path (tier-journey / landing) — same OHLCV warm.
+  const teaser = await request.get('/api/signals/public', { timeout: 60_000 });
+  expect(teaser.ok()).toBeTruthy();
+});


### PR DESCRIPTION
Round 4 of E2E stabilization (classified + adversarially verified via workflow). Applies only the **safe, no-product-decision** fixes from the remaining tail; deliberately excludes two items that need your call (below).

## Applied (adversarially verified safe)

1. **Signal-generation cold latency** → Playwright `setup` project warms `/api/signals`, `/api/screener`, `/api/signals/public` once after the webServer is ready and before the test projects. The first hit pays ~10-15s (OHLCV fetch + TA gen) and was tripping the 15s action timeout, passing only on retry. Reachability-only asserts — a broken route still fails in the real specs. (Verifier corrected the original proposal: warms the in-process OHLCV cache, and targets `/api/screener` for the screener wait.)
2. **Backtest page-load tests** (`backtest-flow:23`, `backtest-comparison:81`) asserted Configuration/Preset/Run-Backtest before the Suspense fallback hydrated and the on-mount auto-run finished (button reads 'Fetching data...' while running). Added settle-waits mirroring the passing sibling tests. No app change, labels unchanged.
3. **Admin login redirect** (`login:43`) asserted `/dashboard`, but a login with no `?redirect=` lands on `/admin` (AdminLoginClient.tsx). Fixed the assertion to the real destination.

## Verification
- `lint` + `tsc --noEmit` clean. E2E result confirms on this PR's run.

## NOT in this PR — needs your decision (hard-halt under the 7 Laws)

- **Mobile pricing failures** (`pricing.spec.ts` :18/:25/:37/:50/:79/:100 on iPhone-14). The workflow's first theory (bottom MobileNav obscuring the CTA) was **debunked** by the adversarial verifier — no trace evidence, and the CTA isn't near the page bottom. Correct next step is a live trace repro (`npx playwright test tests/e2e/pricing.spec.ts --project=mobile --trace on`) to see whether it's real nav interception or first-hit latency, before any layout/CSS change. Could be a real responsive bug (revenue-path tap target) — your call.
- **CSP shipped report-only without a `report-to` endpoint** (dead config). Promoting to enforced CSP or adding a Reporting-Endpoints group is a prod security-header change — needs approval.