### PR TITLE
chore(ci): cut Playwright artifact retention to 3 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,19 +219,19 @@ jobs:
         with:
           name: playwright-report
           path: apps/web/playwright-report
-          retention-days: 14
+          retention-days: 3
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-junit
           path: apps/web/test-results/results.xml
-          retention-days: 14
+          retention-days: 3
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-traces
           path: apps/web/test-results
-          retention-days: 7
+          retention-days: 3
           if-no-files-found: ignore


### PR DESCRIPTION
## What
Drops `retention-days` from 14→3 (report, junit) and 7→3 (traces) on the three Playwright artifact uploads in the e2e job.

## Why
Actions storage sat at ~1.8 GB / 2 GB. ~95% of it was Playwright report+traces (120–150 MB each), re-uploaded on every push because the e2e job fails every run (`if: failure()` trace upload always fires). Existing 294 artifacts were already purged manually; this stops the storage from refilling to the cap.

## Impact
- No change to CI logic, jobs, or gating — only how long artifacts are kept.
- 3 days is enough to debug a red e2e run; older ones expire on their own.
- Repo is public, so this was never a billing cost ($0) — this just keeps the storage gauge low and avoids any upload-blocking if a spend limit is ever hit.

## Out of scope
The root cause (e2e webkit/mobile timing out every run) is untouched — separate follow-up if you want the suite fixed or gated.