### PR TITLE
fix(track-record): align metrics to documented methodology (why-no-uptrend audit)

### DIFF
--- a/apps/web/app/api/signals/equity/route.test.ts
+++ b/apps/web/app/api/signals/equity/route.test.ts
@@ -101,3 +101,59 @@ describe('GET /api/signals/equity rolling win rates', () => {
     expect(body.summary.winRate).toBe(50);
   });
 });
+
+describe('GET /api/signals/equity summary metrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('pins fixed-fractional sizing constants and caps single-trade equity at HARD_R_CAP', async () => {
+    // entry 100, SL 99 → riskPct = 1% → a +19% close is a raw +19R outlier.
+    primeSlice([
+      record({
+        id: 'cap-19R',
+        entryPrice: 100,
+        sl: 99,
+        outcomes: { '4h': null, '24h': { price: 119, pnlPct: 19, hit: true } },
+      }),
+    ]);
+
+    const res = await GET(makeReq('/api/signals/equity'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Sizing methodology must not silently loosen (the prior 100%-bankroll
+    // blowup is what produced the unrunnable +800%/-69% curve).
+    expect(body.summary.riskPerTradePct).toBe(1.0);
+    expect(body.summary.hardRCap).toBe(8);
+    expect(body.summary.roundTripCostPct).toBe(0.02);
+    // R-stats keep the RAW 19R (engine quality is undistorted)…
+    expect(body.summary.avgRWin).toBe(19);
+    // …but the equity path is bounded: 8R × 1% − 0.02% cost = +7.98% on one trade.
+    expect(body.summary.totalReturn).toBeCloseTo(7.98, 2);
+  });
+
+  it('computes expectancyR from the sized-trade population, not the full-population win-rate', async () => {
+    // A + B are sized (have SL); C is a legacy null-SL resolved row that counts
+    // toward the headline win-rate but not toward sizing or R-stats.
+    primeSlice([
+      record({ id: 'sized-win', entryPrice: 100, sl: 99, outcomes: { '4h': null, '24h': { price: 102, pnlPct: 2, hit: true } } }),
+      record({ id: 'sized-loss', entryPrice: 100, sl: 99, outcomes: { '4h': null, '24h': { price: 99, pnlPct: -1, hit: false } } }),
+      record({ id: 'nullsl-win', entryPrice: 100, sl: undefined, outcomes: { '4h': null, '24h': { price: 105, pnlPct: 5, hit: true } } }),
+    ]);
+
+    const res = await GET(makeReq('/api/signals/equity'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Headline win-rate is full-population (2 wins / 3 resolved) to stay
+    // byte-matched with /api/signals/history.
+    expect(body.summary.winRate).toBe(66.7);
+    expect(body.summary.sizedTrades).toBe(2);
+    expect(body.summary.avgRWin).toBe(2);
+    expect(body.summary.avgRLoss).toBe(-1);
+    // Coherent expectancy uses the sized population: 0.5*(+2R) + 0.5*(-1R) = +0.5R.
+    // The old full-population formula would have returned 0.667*2 + 0.333*-1 = +1.0R.
+    expect(body.summary.expectancyR).toBe(0.5);
+  });
+});

--- a/apps/web/app/api/signals/equity/route.ts
+++ b/apps/web/app/api/signals/equity/route.ts
@@ -217,7 +217,12 @@ function computeEquityCurve(
   const dailyValues = [...dailyReturnPct.values()];
   if (dailyValues.length >= 5) {
     const mean = dailyValues.reduce((s, v) => s + v, 0) / dailyValues.length;
-    const variance = dailyValues.reduce((s, v) => s + (v - mean) ** 2, 0) / dailyValues.length;
+    // Sample variance (÷ N-1, Bessel's correction): daily returns are a SAMPLE
+    // of the strategy's day-to-day behaviour, not the whole population, so the
+    // population estimator (÷ N) under-states stddev and inflates Sharpe — the
+    // bias is largest at the N=5 floor (~12%). Guard above guarantees N≥5 so
+    // N-1≥4 > 0.
+    const variance = dailyValues.reduce((s, v) => s + (v - mean) ** 2, 0) / (dailyValues.length - 1);
     const stddev = Math.sqrt(variance);
     if (stddev > 0) {
       sharpeRatio = +((mean / stddev) * Math.sqrt(365)).toFixed(2);
@@ -229,11 +234,17 @@ function computeEquityCurve(
   const avgRWin = winRCount > 0 ? +(winRSum / winRCount).toFixed(2) : null;
   const avgRLoss = lossRCount > 0 ? +(lossRSum / lossRCount).toFixed(2) : null;
   const winRateFraction = sorted.length > 0 ? wins / sorted.length : 0;
-  // Expectancy(R) = p(win) * avgRWin + p(loss) * avgRLoss. Break-even
-  // win-rate solves expectancy = 0, i.e. p* = -avgRLoss / (avgRWin - avgRLoss).
-  // Both halves need at least one trade or expectancy is unknowable.
+  // Expectancy(R) = p(win) * avgRWin + p(loss) * avgRLoss. It MUST use the same
+  // population the R-averages come from — the sized-trade subset (rows with SL).
+  // The headline winRate is full-population (includes legacy null-SL resolved
+  // rows) to preserve the byte-match with /api/signals/history; mixing that
+  // full-population win-rate with SL-subset R-averages produces an incoherent
+  // expectancy whenever the two populations differ. Break-even win-rate solves
+  // expectancy = 0, i.e. p* = -avgRLoss / (avgRWin - avgRLoss). Both halves need
+  // at least one trade or expectancy is unknowable.
+  const sizedWinRate = winRCount + lossRCount > 0 ? winRCount / (winRCount + lossRCount) : 0;
   const expectancyR = avgRWin !== null && avgRLoss !== null
-    ? +(winRateFraction * avgRWin + (1 - winRateFraction) * avgRLoss).toFixed(2)
+    ? +(sizedWinRate * avgRWin + (1 - sizedWinRate) * avgRLoss).toFixed(2)
     : null;
   const breakEvenWinRate = avgRWin !== null && avgRLoss !== null && avgRWin - avgRLoss !== 0
     ? +(((-avgRLoss) / (avgRWin - avgRLoss)) * 100).toFixed(1)

--- a/apps/web/app/api/signals/history/route.ts
+++ b/apps/web/app/api/signals/history/route.ts
@@ -167,8 +167,13 @@ export async function GET(request: NextRequest) {
     const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
     const expired = records.filter(r => {
       if (r.isSimulated || r.gateBlocked) return false;
-      if (r.outcomes['24h'] && !isRealOutcome(r.outcomes['24h'])) return true;
-      return !r.outcomes['24h'] && (now - r.timestamp) >= TWENTY_FOUR_HOURS_MS;
+      // Two kinds of expired: auto-expire placeholders (fail isRealOutcome) and
+      // drift-expired closes (real pnl but target='expired'). Both are excluded
+      // from resolved/win-rate by isCountedResolved, so both belong in this
+      // transparency bucket — otherwise drift-expired rows vanish from every count.
+      const o = r.outcomes['24h'];
+      if (o && (!isRealOutcome(o) || o.target === 'expired')) return true;
+      return !o && (now - r.timestamp) >= TWENTY_FOUR_HOURS_MS;
     }).length;
     const gateBlocked = records.filter(r => r.gateBlocked).length;
     const pending = records.filter(r =>

--- a/apps/web/lib/landing-stats.ts
+++ b/apps/web/lib/landing-stats.ts
@@ -60,6 +60,10 @@ export async function getLandingStats(): Promise<LandingStats> {
         WHERE outcome_24h IS NOT NULL
           AND created_at >= NOW() - INTERVAL '30 days'
           AND is_simulated = FALSE
+          -- Auto-expired (no TP/SL hit) rows are transparency-only, not
+          -- resolved trades — exclude from cumulative P&L / profit factor to
+          -- match isCountedResolved and the stat-hints "resolved" contract.
+          AND outcome_24h->>'target' IS DISTINCT FROM 'expired'
           AND NOT ((outcome_24h->>'pnlPct')::numeric = 0
                    AND (outcome_24h->>'hit')::boolean = FALSE)
      )
@@ -88,19 +92,19 @@ export async function getLandingStats(): Promise<LandingStats> {
 
   const recentRes = await queryOne<RecentWinRateRow>(
     `WITH recent AS (
-       SELECT (outcome_24h->>'hit')::boolean AS hit,
-              outcome_24h->>'target' AS target,
-              (outcome_24h->>'pnlPct')::numeric AS pnl_pct
+       SELECT (outcome_24h->>'hit')::boolean AS hit
          FROM signal_history
         WHERE outcome_24h IS NOT NULL
           AND is_simulated = FALSE
+          -- Exclude auto-expired rows entirely: the stat-hints contract says
+          -- expired is "not counted in win-rate". Counting expired-with-drift
+          -- as a win (the old OR clause) contradicted that promise.
+          AND outcome_24h->>'target' IS DISTINCT FROM 'expired'
         ORDER BY created_at DESC
         LIMIT 100
      )
      SELECT COUNT(*)::text AS total,
-            SUM(CASE WHEN hit = true
-                      OR (target = 'expired' AND pnl_pct > 0)
-                 THEN 1 ELSE 0 END)::text AS wins
+            SUM(CASE WHEN hit = true THEN 1 ELSE 0 END)::text AS wins
        FROM recent`
   );
   const recentTotal = Number(recentRes?.total ?? 0);

--- a/apps/web/lib/signal-history.ts
+++ b/apps/web/lib/signal-history.ts
@@ -37,7 +37,16 @@ export function isRealOutcome(o: SignalOutcome | null | undefined): o is SignalO
 export function isCountedResolved(r: SignalHistoryRecord): boolean {
   if (r.isSimulated) return false;
   if (r.gateBlocked) return false;
-  return isRealOutcome(r.outcomes['24h']);
+  const o = r.outcomes['24h'];
+  if (!isRealOutcome(o)) return false;
+  // Auto-expired closes (window elapsed with neither TP nor SL hit) are
+  // recorded for transparency only. The UI captions promise it: stat-hints
+  // `resolved` = "TP or SL hit … Excludes … auto-expired rows" and `winRate24h`
+  // = "Excludes auto-expired and gate-blocked rows". Honor that contract in the
+  // one canonical predicate so equity, win-rate, and resolved counts match the
+  // stated methodology instead of folding drift-expired rows in as wins/losses.
+  if (o.target === 'expired') return false;
+  return true;
 }
 
 export interface SignalHistoryRecord {

--- a/docs/plans/2026-06-10-track-record-pro-uptrend.md
+++ b/docs/plans/2026-06-10-track-record-pro-uptrend.md
@@ -1,0 +1,45 @@
+# Track Record — "why no uptrend" audit + fix plan
+
+Date: 2026-06-10
+Branch: `worktree-fix+track-record-pro-uptrend`
+Author: Claude (Opus 4.8) for Naim
+Method: 43-agent audit workflow (6 subsystem audits → adversarial verify → synthesis), reconciled against direct reads of the equity route, live signal generator, tier gate, and frontend.
+
+## One-line restatement
+
+The public equity curve runs to +700% then bleeds to +170% (−73% max drawdown); find why it has no sustained uptrend, fix the genuine bugs, and make the track record reflect the strategy actually deployed in Pro.
+
+## Verdict (the honest answer)
+
+There is no hidden uptrend that bugs are eating. Three causes, unequal blame:
+
+1. **Measurement choice (dominant for the visible shape).** The default view measures the **all-signal firehose** (`band='all'`, 1% risk on ~100 signals/day) and the cron **records the raw scanner output while discarding the regime/circuit-breaker/allocator gate decision** that actually shapes the Pro broadcast. So the public curve is the *least* representative slice of the engine, not the product.
+2. **Thin real edge (dominant for the ceiling).** Gross expectancy ≈ **+0.06R** against a borrowed, uncalibrated confidence signal (TradingView `Recommend.All`) and autocorrelated multi-TF "confluence". At that edge with 1% sizing over 3,192 trades, the path is a biased random walk — it *will* spike and give back. No display change manufactures edge.
+3. **Genuine bugs (minor, mostly self-penalizing).** The heavy hitters from the old diagnosis (SL-priority same-bar loss, −1.5R gap floor, 100%-bankroll sizing) are **already fixed or are intentional conservative choices that bias the curve down**. The real bugs left are metric-coherence + a documented-contract violation, not curve-destroyers.
+
+`audit: 36 candidate findings, 20 confirmed real.` Full memo archived in the workflow transcript.
+
+## In scope NOW (this branch) — track-record-surface bug fixes
+
+All locally verifiable, branch-isolated, one concern per commit. These align the displayed numbers to the engine's own documented definitions; they do not flatter the curve.
+
+- **A. Exclude auto-expired closes from win-rate/equity.** The UI promises "Excludes auto-expired rows / not counted in win-rate" (`stat-hints.ts:29-32`) but `isRealOutcome` counts drift-expired rows as wins/losses and `landing-stats.ts:101-103` explicitly scores `target='expired' AND pnl_pct>0` as a win. Fix `isCountedResolved`, the history `expired` counter, and both landing-stats CTEs. Win-rate and resolved-count will shift to match the stated methodology (direction indeterminate; resolved count drops). Verify magnitude against prod before merge.
+- **B. Compute `expectancyR` from the sized-trade population.** Currently multiplies a full-population win-rate by SL-subset R-averages — incoherent when legacy null-SL rows exist (`equity/route.ts:236`). Add `sizedWins`; keep `summary.winRate` full-population to preserve the `/history` byte-match invariant.
+- **C. Use sample stddev (÷N−1) for the daily Sharpe** (`equity/route.ts:219-220`). Removes a small upward bias (largest at the N=5 floor).
+- **D. Regression test pinning the sizing constants** (`riskPerTradePct=1`, `hardRCap=8`, `roundTripCostPct=0.02`, ~19R fixture clips to ~8%) so the prior sizing-blowup fix can't silently loosen.
+
+Verification: `npm test` on `equity/route.test.ts`, `signal-history*` tests, landing-stats test; `tsc --noEmit` on apps/web.
+
+## Deferred — OWNER DECISIONS (not implemented; need your call)
+
+1. **Broadcast-filtered "Pro strategy" scope — the real answer to your ask.** Make the gated subset measurable: re-sequence the cron to run regime + risk pipeline *before* persistence, tag rows `broadcast_blocked`, keep raw rows, and expose a "broadcast-filtered" equity scope next to all/premium. **Needs a DB migration you apply to prod + ~2 weeks of data before it shows anything.** Do NOT silently default the public curve to `band='premium'` — the premium band's edge is unproven (borrowed confidence), so that would be cherry-picking. Recommend: greenlight this as Phase 2.
+2. **`/results` "Verified Backtests" fabrication.** `backtest-results.ts` ships hand-typed metrics (+12%–45%, 55–72% WR) + a seeded-PRNG equity curve, presented as real engine output with false "realistic slippage and fees / 12 months historical data" copy. Separate surface, but a real honesty/liability defect. Recommend: relabel "Illustrative — not live engine results", strip the false copy, drop the "Verified" badge.
+3. **Edge calibration — the only real uptrend lever.** Calibrate confidence to realized P(TP1-before-SL) and shrink the autocorrelated confluence bonus. This is the only change that lifts the +0.06R ceiling. Larger effort; flag for a dedicated plan.
+
+## Explicitly NOT bugs (do not spend effort)
+
+SL-priority same-bar loss (intentional, test-guarded, biases down); −1.5R gap floor (already fixed `219d7cc`, raises losses toward zero); 100%-bankroll sizing (already replaced `0082e01`); default `band='all'` headline (the anti-cherry-pick choice); round-trip 2bps cost (correct + disclosed); zero-anchored y-axis; `run-backtest.ts` hardcoded TP/SL (offline harness, not the live curve).
+
+## Honesty line
+
+A fix is honest when it makes the displayed number track reality regardless of direction. A–D do that (A's sign is indeterminate; it just stops the code contradicting its own captions). The cherry-pick to avoid is defaulting the public curve to premium-only before the gated subset has earned it with real data.


### PR DESCRIPTION
## Why no uptrend (audit verdict)

A 43-agent audit (36 findings, 20 confirmed real) answered the owner's question: the public equity curve runs +700% → +170% (−73% DD) not because bugs eat a hidden uptrend, but because of three things, in order of blame:

1. **Measurement choice (dominant for the shape).** The default view measures the unfiltered firehose (`band='all'`, ~100 signals/day at 1% risk), and the cron records raw scanner output while **discarding the regime/circuit-breaker/allocator gate decision** — so the Pro-deployed subset's performance is never recorded.
2. **Thin real edge (dominant for the ceiling).** Gross expectancy ≈ +0.06R against a borrowed, uncalibrated confidence signal. No display change manufactures edge.
3. **Genuine bugs are minor / self-penalizing.** The scary ones (SL-priority, −1.5R gap floor, 100%-bankroll sizing) are already fixed or are deliberate conservatism.

Full write-up: `docs/plans/2026-06-10-track-record-pro-uptrend.md`.

## What this PR changes

These align the displayed numbers to the engine's **own documented definitions** — they do not flatter the curve. (Defaulting the public curve to premium-only was explicitly rejected as cherry-picking; not done here.)

- **Exclude auto-expired closes from win-rate / equity / landing stats.** The UI captions promise expired rows are excluded, but `isCountedResolved` counted drift-expired closes as wins/losses and `landing-stats` scored expired-with-profit as a win. (`signal-history.ts`, `history/route.ts`, `landing-stats.ts`)
- **`expectancyR` uses the sized-trade population** instead of mixing a full-population win-rate with SL-subset R-averages. Headline `winRate` stays full-population to preserve the `/history` byte-match. (`equity/route.ts`)
- **Daily Sharpe uses sample stddev (÷N−1)** — removes a small upward bias. (`equity/route.ts`)
- **Regression test** pinning `RISK_PER_TRADE_PCT=1`, `HARD_R_CAP=8`, `ROUND_TRIP_COST_PCT=0.02` and the 8R clip, so the prior sizing blowup can't silently return. (`equity/route.test.ts`)

## ⚠️ Before merge

**Fix A changes published numbers.** Resolved-signal count will drop and win-rate will shift to match the documented methodology (direction indeterminate). Eyeball the new prod numbers before merging — the magnitude depends on what fraction of 24h outcomes are auto-expired (not measurable from this checkout, no DB).

## Verification

- Affected suites (`equity/route`, `history/route`, `signal-history-mae`, `landing-stats`): 27 tests pass.
- Full suite: 1094 passed, 0 failed.
- `tsc --noEmit` on `apps/web`: clean.

## Deferred (owner decisions, not in this PR)

1. **Broadcast-filtered "Pro strategy" scope** — the real answer to "use the best strategies in pro". Record the gate decision the Pro feed applies (cron re-sequence + `broadcast_blocked` column). Needs a DB migration applied to prod + ~2 weeks of data.
2. **`/results` fabricated "Verified Backtests"** — hand-typed metrics + seeded-PRNG curve with false "slippage and fees" copy. Honesty/liability fix on a separate page.
3. **Edge calibration** — confidence → realized P(TP1-before-SL); the only lever that raises the +0.06R ceiling.
