### PR TITLE
Phase 1: record the Pro-broadcast gate decision — make the sellable track record measurable

### DIFF
--- a/apps/web/app/api/calibration/__tests__/route.test.ts
+++ b/apps/web/app/api/calibration/__tests__/route.test.ts
@@ -86,6 +86,19 @@ describe('GET /api/calibration', () => {
     expect(body.brier).toBeCloseTo(expectedBrier, 6);
   });
 
+  it('confidence exactly 100 lands in the top bucket instead of falling out of all buckets', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord({ id: 'conf100', confidence: 100 }),
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.totalSignals).toBe(1);
+    const top = body.buckets.find((b: { label: string }) => b.label === '90-99%');
+    expect(top).toMatchObject({ count: 1, wins: 1, winRate: 1 });
+  });
+
   it('returns null brier/ece with no counted rows instead of fabricated values', async () => {
     mockedHistory.mockResolvedValue([
       mkRecord({ id: 'sim-only', isSimulated: true }),

--- a/apps/web/app/api/calibration/__tests__/route.test.ts
+++ b/apps/web/app/api/calibration/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The calibration API previously compared signal_history's 0-100 confidence
+ * against 0-1 bucket bounds: every bucket was empty, each fell back to
+ * winRate = midpoint, and the reliability chart rendered as perfectly
+ * calibrated — fabricated by construction. These tests pin the fix:
+ * 0-100 → 0-1 normalization, the canonical isCountedResolved population,
+ * and null (not midpoint) for empty buckets.
+ */
+
+jest.mock('@/lib/signal-history', () => {
+  const actual = jest.requireActual('@/lib/signal-history');
+  return {
+    ...actual,
+    readHistoryAsync: jest.fn(),
+  };
+});
+
+import { GET } from '../route';
+import { readHistoryAsync, type SignalHistoryRecord } from '@/lib/signal-history';
+
+const mockedHistory = readHistoryAsync as jest.MockedFunction<typeof readHistoryAsync>;
+
+function mkRecord(over: Partial<SignalHistoryRecord>): SignalHistoryRecord {
+  return {
+    id: Math.random().toString(36).slice(2),
+    pair: 'BTCUSD',
+    timeframe: 'H1',
+    direction: 'BUY',
+    confidence: 72,
+    entryPrice: 50000,
+    timestamp: Date.now() - 86_400_000,
+    tp1: 51000,
+    sl: 49500,
+    isSimulated: false,
+    gateBlocked: false,
+    outcomes: {
+      '4h': null,
+      '24h': { price: 51000, pnlPct: 2.0, hit: true, target: 'TP1' },
+    },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockedHistory.mockReset();
+});
+
+describe('GET /api/calibration', () => {
+  it('normalizes 0-100 confidence into the right buckets and excludes non-counted rows', async () => {
+    mockedHistory.mockResolvedValue([
+      // counted: conf 72 win → bucket 70-79%
+      mkRecord({ id: 'win72', confidence: 72 }),
+      // counted: conf 85 loss → bucket 80-89%
+      mkRecord({
+        id: 'loss85',
+        confidence: 85,
+        outcomes: { '4h': null, '24h': { price: 49500, pnlPct: -1.0, hit: false, target: 'SL' } },
+      }),
+      // excluded: auto-expired close
+      mkRecord({
+        id: 'expired',
+        confidence: 75,
+        outcomes: { '4h': null, '24h': { price: 50100, pnlPct: 0.2, hit: true, target: 'expired' } },
+      }),
+      // excluded: gate-blocked
+      mkRecord({ id: 'gated', confidence: 75, gateBlocked: true }),
+      // excluded: simulated
+      mkRecord({ id: 'sim', confidence: 75, isSimulated: true }),
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.totalSignals).toBe(2);
+
+    const byLabel = new Map(body.buckets.map((b: { label: string }) => [b.label, b]));
+    expect(byLabel.get('70-79%')).toMatchObject({ count: 1, wins: 1, winRate: 1 });
+    expect(byLabel.get('80-89%')).toMatchObject({ count: 1, wins: 0, winRate: 0 });
+
+    // Empty buckets report null, NOT the fake midpoint fallback.
+    expect(byLabel.get('50-59%')).toMatchObject({ count: 0, winRate: null, calibrationError: null });
+    expect(byLabel.get('90-99%')).toMatchObject({ count: 0, winRate: null, calibrationError: null });
+
+    // Brier on the 0-1 scale: ((0.72-1)^2 + (0.85-0)^2) / 2
+    const expectedBrier = (Math.pow(0.72 - 1, 2) + Math.pow(0.85 - 0, 2)) / 2;
+    expect(body.brier).toBeCloseTo(expectedBrier, 6);
+  });
+
+  it('returns null brier/ece with no counted rows instead of fabricated values', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord({ id: 'sim-only', isSimulated: true }),
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.totalSignals).toBe(0);
+    expect(body.brier).toBeNull();
+    expect(body.ece).toBeNull();
+    expect(body.isSimulated).toBe(true);
+    for (const b of body.buckets) {
+      expect(b.winRate).toBeNull();
+    }
+  });
+});

--- a/apps/web/app/api/calibration/route.ts
+++ b/apps/web/app/api/calibration/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { readHistoryAsync } from '@/lib/signal-history';
+import { readHistoryAsync, isCountedResolved } from '@/lib/signal-history';
 
 export const revalidate = 300; // 5-min cache
 
@@ -9,9 +9,10 @@ interface CalibrationBucket {
   confMax: number;
   count: number;
   wins: number;
-  winRate: number;
+  /** Null when the bucket is empty — the UI must not render a fake point. */
+  winRate: number | null;
   midpoint: number;
-  calibrationError: number;
+  calibrationError: number | null;
 }
 
 const BUCKETS = [
@@ -22,20 +23,35 @@ const BUCKETS = [
   { label: '90-99%', confMin: 0.90, confMax: 1.00, midpoint: 0.945 },
 ];
 
+/**
+ * signal_history stores confidence on the 0-100 scale (e.g. 72, 85 — see
+ * PRO_PREMIUM_MIN_CONFIDENCE = 85). Normalize to 0-1 for bucketing and Brier.
+ * Before this fix the route compared the raw 0-100 value against 0-1 bucket
+ * bounds: every bucket was empty, each fell back to winRate = midpoint, and
+ * the reliability chart rendered as perfectly calibrated — fabricated by
+ * construction. Defensive: values already <= 1 pass through unchanged.
+ */
+function normalizeConfidence(raw: number): number {
+  return raw > 1 ? raw / 100 : raw;
+}
+
 export async function GET() {
   try {
     const history = await readHistoryAsync();
-    // Only use resolved signals with 24h outcomes
-    const resolved = history.filter(
-      (s) => s.outcomes['24h'] !== null && s.confidence >= 0.5
-    );
+    // Canonical resolved filter: excludes simulated rows, gate-blocked rows,
+    // and auto-expired closes — same population as win-rate/equity, so the
+    // calibration chart measures the engine, not placeholder artifacts.
+    const resolved = history
+      .filter(isCountedResolved)
+      .map((s) => ({ ...s, confidence: normalizeConfidence(s.confidence) }))
+      .filter((s) => s.confidence >= 0.5);
 
     const buckets: CalibrationBucket[] = BUCKETS.map((b) => {
       const inBucket = resolved.filter(
         (s) => s.confidence >= b.confMin && s.confidence < b.confMax
       );
       const wins = inBucket.filter((s) => s.outcomes['24h']?.hit).length;
-      const winRate = inBucket.length > 0 ? wins / inBucket.length : b.midpoint;
+      const winRate = inBucket.length > 0 ? wins / inBucket.length : null;
       return {
         label: b.label,
         confMin: b.confMin,
@@ -44,7 +60,7 @@ export async function GET() {
         wins,
         winRate,
         midpoint: b.midpoint,
-        calibrationError: Math.abs(winRate - b.midpoint),
+        calibrationError: winRate !== null ? Math.abs(winRate - b.midpoint) : null,
       };
     });
 
@@ -52,26 +68,27 @@ export async function GET() {
     const totalWins = resolved.filter((s) => s.outcomes['24h']?.hit).length;
     const overallAccuracy = totalSignals > 0 ? totalWins / totalSignals : 0;
 
-    // Brier score: mean((conf - outcome)^2)
+    // Brier score: mean((conf - outcome)^2) on the 0-1 scale.
     const brier = totalSignals > 0
       ? resolved.reduce((sum, s) => {
           const outcome = s.outcomes['24h']?.hit ? 1 : 0;
           return sum + Math.pow(s.confidence - outcome, 2);
         }, 0) / totalSignals
-      : 0.21; // fallback demo value
+      : null;
 
-    // ECE: weighted mean calibration error
+    // ECE: weighted mean calibration error over non-empty buckets.
     const ece = totalSignals > 0
-      ? buckets.reduce((sum, b) => sum + (b.count / totalSignals) * b.calibrationError, 0)
-      : 0.038;
-
-    const isSimulated = resolved.every((s) => s.isSimulated);
+      ? buckets.reduce(
+          (sum, b) => sum + (b.calibrationError !== null ? (b.count / totalSignals) * b.calibrationError : 0),
+          0,
+        )
+      : null;
 
     return NextResponse.json({
       buckets,
       overallAccuracy,
       totalSignals,
-      isSimulated: isSimulated || totalSignals < 20,
+      isSimulated: totalSignals < 20,
       brier,
       ece,
       updatedAt: new Date().toISOString(),

--- a/apps/web/app/api/calibration/route.ts
+++ b/apps/web/app/api/calibration/route.ts
@@ -47,8 +47,12 @@ export async function GET() {
       .filter((s) => s.confidence >= 0.5);
 
     const buckets: CalibrationBucket[] = BUCKETS.map((b) => {
+      // Top bucket is inclusive so confidence exactly 100 (normalized 1.0)
+      // lands in 90-99% instead of falling out of every bucket while still
+      // counting in totalSignals/Brier.
+      const topInclusive = b.confMax === 1.0;
       const inBucket = resolved.filter(
-        (s) => s.confidence >= b.confMin && s.confidence < b.confMax
+        (s) => s.confidence >= b.confMin && (topInclusive ? s.confidence <= b.confMax : s.confidence < b.confMax)
       );
       const wins = inBucket.filter((s) => s.outcomes['24h']?.hit).length;
       const winRate = inBucket.length > 0 ? wins / inBucket.length : null;

--- a/apps/web/app/api/cron/signals/route.ts
+++ b/apps/web/app/api/cron/signals/route.ts
@@ -301,7 +301,26 @@ export async function GET(request: NextRequest): Promise<Response> {
     // unfiltered broadcast (Pro must not silently mute) — those rows record
     // NO decision (NULL) because the gate never actually ran.
     const broadcastInputs: NewlyRecordedSignal[] = [...candidates, ...catchupSignals];
-    const decisions = await computeBroadcastDecisions(broadcastInputs);
+    // computeBroadcastDecisions guards its internals (regime fetch + pipeline),
+    // but an unexpected throw here must not skip recording/resolution — fall
+    // back to "no decision computed": rows record NULL and broadcast
+    // unfiltered, mirroring the pipeline-outage philosophy.
+    let decisions: Awaited<ReturnType<typeof computeBroadcastDecisions>>;
+    try {
+      decisions = await computeBroadcastDecisions(broadcastInputs);
+    } catch (err) {
+      console.warn(
+        '[cron/signals] Broadcast decision computation failed entirely — recording without decisions, broadcasting unfiltered:',
+        err instanceof Error ? err.message : String(err),
+      );
+      decisions = new Map(
+        broadcastInputs.map((s) => [s.id, { id: s.id, blocked: false, recordable: false }]),
+      );
+    }
+    const outageCount = [...decisions.values()].filter((d) => !d.recordable).length;
+    if (outageCount > 0) {
+      console.warn(`[cron/signals] ${outageCount} signal(s) broadcast via outage fallback this tick — no gate decision recorded (rows stay NULL and are excluded from scope=broadcast)`);
+    }
 
     // Record new candidates with their decision inline.
     const newSignals: NewlyRecordedSignal[] = [];

--- a/apps/web/app/api/cron/signals/route.ts
+++ b/apps/web/app/api/cron/signals/route.ts
@@ -8,6 +8,7 @@ import {
   getRecentRecordForSymbolAsync,
   getPendingRecordsAsync,
   updateRecordsAsync,
+  updateBroadcastDecisionAsync,
   markTelegramPosted,
   resolveFromCandles,
   getOutcomeResolutionTimeframe,
@@ -16,9 +17,7 @@ import {
 } from '../../../../lib/signal-history';
 import { PUBLISHED_SIGNAL_MIN_CONFIDENCE } from '../../../../lib/signal-thresholds';
 import { broadcastSignalsToProGroup } from '../../../../lib/telegram-pro-broadcast';
-import { isWinningCell, getWinningCellsMode } from '../../../../lib/winning-cells';
-import { runRiskPipeline } from '../../../../lib/risk-pipeline';
-import { fetchRegimeMap } from '../../../../lib/regime-filter';
+import { computeBroadcastDecisions } from '../../../../lib/broadcast-decision';
 import { recordSignalRun } from '../../../../lib/signal-run-log';
 import { requireCronAuth } from '../../../../lib/cron-auth';
 import { precomputeSignals } from '../../../../lib/signal-worker';
@@ -43,7 +42,16 @@ type NewlyRecordedSignal = {
   timestamp: number;
 };
 
-async function recordNewSignals(strategyId: string): Promise<NewlyRecordedSignal[]> {
+/**
+ * Selects the candidate set to record this tick (best per symbol+direction,
+ * market open, no recent duplicate). Does NOT persist — Phase 1 re-sequenced
+ * the cron so the broadcast gate decision is computed BEFORE persistence and
+ * recorded on the row (docs/plans/2026-06-10-engine-makeover.md).
+ */
+async function collectNewSignals(strategyId: string): Promise<{
+  candidates: NewlyRecordedSignal[];
+  effectiveStrategyId: string;
+}> {
   let signals: Array<{
     id: string;
     symbol: string;
@@ -93,10 +101,10 @@ async function recordNewSignals(strategyId: string): Promise<NewlyRecordedSignal
       }));
   }
 
-  const recorded: NewlyRecordedSignal[] = [];
+  const candidates: NewlyRecordedSignal[] = [];
 
-  // Track symbols already recorded in this run to prevent dupes within a batch
-  const recordedThisRun = new Set<string>();
+  // Track symbols already selected in this run to prevent dupes within a batch
+  const selectedThisRun = new Set<string>();
 
   // Pick the best signal per symbol+direction (highest confidence)
   const bestBySymDir = new Map<string, (typeof signals)[number]>();
@@ -112,31 +120,18 @@ async function recordNewSignals(strategyId: string): Promise<NewlyRecordedSignal
     if (!isMarketOpen(sig.symbol)) continue;
 
     const dedupKey = `${sig.symbol}:${sig.direction}`;
-    if (recordedThisRun.has(dedupKey)) continue;
+    if (selectedThisRun.has(dedupKey)) continue;
 
     const existing = await getRecentRecordForSymbolAsync(sig.symbol, sig.direction, TWO_HOURS_MS);
     if (existing) continue;
 
-    const id = sig.id;
     const parsedCandleTs = Date.parse(sig.timestamp);
     const timestamp = Number.isFinite(parsedCandleTs) ? parsedCandleTs : Date.now();
-    await recordSignalAsync(
-      sig.symbol,
-      sig.timeframe,
-      sig.direction,
-      sig.confidence,
-      sig.entry,
-      id,
-      sig.takeProfit1,
-      sig.stopLoss,
-      timestamp,
-      strategyId,
-    );
 
-    recordedThisRun.add(dedupKey);
+    selectedThisRun.add(dedupKey);
 
-    recorded.push({
-      id,
+    candidates.push({
+      id: sig.id,
       symbol: sig.symbol,
       timeframe: sig.timeframe,
       direction: sig.direction,
@@ -148,12 +143,14 @@ async function recordNewSignals(strategyId: string): Promise<NewlyRecordedSignal
     });
   }
 
-  return recorded;
+  return { candidates, effectiveStrategyId: strategyId };
 }
 
 // ── Resolve logic ─────────────────────────────────────────────
-// Outcome math now lives in lib/signal-history.ts → resolveFromCandles. Cron
-// just discards the MAE field (only the request-path writer feeds calibration).
+// Outcome math lives in lib/signal-history.ts → resolveFromCandles. The cron
+// stamps resolution provenance (resolvedAt + OHLCV source) onto each outcome
+// and persists MAE alongside — re-resolution against a different provider is
+// detectable instead of silently rewriting history.
 
 async function resolveOldSignals(): Promise<{ resolved: number; pending: number; errors: string[] }> {
   const pending = await getPendingRecordsAsync();
@@ -169,18 +166,22 @@ async function resolveOldSignals(): Promise<{ resolved: number; pending: number;
     if (!record.tp1 || !record.sl) continue;
 
     let candles: Array<{ timestamp: number; high: number; low: number; close: number; open: number; volume: number }> = [];
+    let candleSource = 'unknown';
 
     try {
       const result = await getOHLCV(record.pair, getOutcomeResolutionTimeframe(record));
       candles = result.candles;
+      candleSource = result.source;
     } catch (err) {
       const msg = `OHLCV fetch failed for ${record.pair}: ${err instanceof Error ? err.message : String(err)}`;
       console.error(`[cron/signals] ${msg}`);
       errors.push(msg);
     }
 
+    const resolvedAt = new Date(now).toISOString();
     const newOutcomes = { ...record.outcomes };
     let changed = false;
+    let mae24h: number | null = null;
 
     if (needs4h) {
       const windowEnd = record.timestamp + FOUR_HOURS_MS;
@@ -190,10 +191,10 @@ async function resolveOldSignals(): Promise<{ resolved: number; pending: number;
       const windowComplete = age >= FOUR_HOURS_MS;
       const result = resolveFromCandles(record, window, windowComplete);
       if (result) {
-        newOutcomes['4h'] = result.outcome;
+        newOutcomes['4h'] = { ...result.outcome, resolvedAt, source: candleSource };
         changed = true;
       } else if (age >= FOUR_HOURS_MS * 2) {
-        newOutcomes['4h'] = { price: record.entryPrice, pnlPct: 0, hit: false, target: 'expired' };
+        newOutcomes['4h'] = { price: record.entryPrice, pnlPct: 0, hit: false, target: 'expired', resolvedAt, source: 'force-expired' };
         changed = true;
       }
     }
@@ -206,16 +207,24 @@ async function resolveOldSignals(): Promise<{ resolved: number; pending: number;
       const windowComplete = age >= TWENTY_FOUR_HOURS_MS;
       const result = resolveFromCandles(record, window, windowComplete);
       if (result) {
-        newOutcomes['24h'] = result.outcome;
+        newOutcomes['24h'] = { ...result.outcome, resolvedAt, source: candleSource };
+        mae24h = result.maxAdverseExcursion;
         changed = true;
       } else if (age >= TWENTY_FOUR_HOURS_MS * 2) {
-        newOutcomes['24h'] = { price: record.entryPrice, pnlPct: 0, hit: false, target: 'expired' };
+        newOutcomes['24h'] = { price: record.entryPrice, pnlPct: 0, hit: false, target: 'expired', resolvedAt, source: 'force-expired' };
         changed = true;
       }
     }
 
     if (changed) {
-      updates.push({ id: record.id, patch: { outcomes: newOutcomes, lastVerified: now } });
+      updates.push({
+        id: record.id,
+        patch: {
+          outcomes: newOutcomes,
+          lastVerified: now,
+          ...(mae24h !== null ? { maxAdverseExcursion: mae24h } : {}),
+        },
+      });
     }
   }
 
@@ -252,24 +261,8 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   try {
     const preset = getActivePreset();
-    const newSignals = await recordNewSignals(preset.id);
-    const { resolved, pending, errors } = await resolveOldSignals();
+    const { candidates, effectiveStrategyId } = await collectNewSignals(preset.id);
 
-    const taggedSignals = newSignals.map((s) => ({ ...s, strategyId: preset.id }));
-
-    // Pro Telegram broadcast — fire on the deterministic 5-min cron cadence.
-    // After the duplicate-spam audit (2026-05-03) this is the SINGLE source
-    // of Pro broadcasts: the request-side path in tracked-signals.ts was
-    // removed, and the dedup gate inside broadcastSignalsToProGroup catches
-    // any retries. Pipeline order:
-    //   winning-cells curation → risk pipeline (allocator + circuit breakers
-    //   + LLM advisory) → broadcast.
-    // Risk pipeline mirrors the free channel's safety filter so Pro buyers
-    // are not exposed to signals the system itself flagged as drawdown-risky.
-    // Pipeline failure falls back to unfiltered broadcast — Pro's value prop
-    // is real-time delivery, so a transient risk-state outage must not
-    // silently mute the channel.
-    //
     // Catch-up set: tracked-signals.ts still records via /api/signals when
     // free traffic hits, but only broadcasts when the caller is paid. Those
     // rows land in signal_history with telegram_pro_message_id NULL and
@@ -279,9 +272,9 @@ export async function GET(request: NextRequest): Promise<Response> {
     let catchupSignals: NewlyRecordedSignal[] = [];
     try {
       const catchupRecords = await getUnpostedProSignalsAsync(CATCHUP_WINDOW_MS);
-      const taggedIds = new Set(newSignals.map((s) => s.id));
+      const candidateIds = new Set(candidates.map((s) => s.id));
       catchupSignals = catchupRecords
-        .filter((r) => !taggedIds.has(r.id) && r.tp1 != null && r.sl != null)
+        .filter((r) => !candidateIds.has(r.id) && r.tp1 != null && r.sl != null)
         .map((r) => ({
           id: r.id,
           symbol: r.pair,
@@ -300,65 +293,88 @@ export async function GET(request: NextRequest): Promise<Response> {
       );
     }
 
-    const broadcastInputs: NewlyRecordedSignal[] = [...newSignals, ...catchupSignals];
-    let broadcastableCount = 0;
-    let curatedCount = 0;
-    if (broadcastInputs.length > 0) {
-      const winningCellsActive = getWinningCellsMode() === 'active';
-      const curated = broadcastInputs.filter((s) =>
-        !winningCellsActive || isWinningCell(s.symbol, s.direction),
+    // Phase 1 re-sequence: ONE gate decision per tick, computed BEFORE
+    // persistence, over the merged set (new candidates + catch-up). The
+    // decision (winning-cells curation → risk pipeline: circuit breakers +
+    // allocator + veto + LLM advisory) is recorded on each row so the
+    // Pro-broadcast subset is measurable. Pipeline failure falls back to
+    // unfiltered broadcast (Pro must not silently mute) — those rows record
+    // NO decision (NULL) because the gate never actually ran.
+    const broadcastInputs: NewlyRecordedSignal[] = [...candidates, ...catchupSignals];
+    const decisions = await computeBroadcastDecisions(broadcastInputs);
+
+    // Record new candidates with their decision inline.
+    const newSignals: NewlyRecordedSignal[] = [];
+    for (const sig of candidates) {
+      const d = decisions.get(sig.id);
+      await recordSignalAsync(
+        sig.symbol,
+        sig.timeframe,
+        sig.direction,
+        sig.confidence,
+        sig.entry,
+        sig.id,
+        sig.takeProfit1,
+        sig.stopLoss,
+        sig.timestamp,
+        effectiveStrategyId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        d && d.recordable
+          ? { regime: d.regime, blocked: d.blocked, blockReason: d.blockReason, allocationPct: d.allocationPct }
+          : undefined,
       );
-      curatedCount = curated.length;
+      newSignals.push(sig);
+    }
 
-      let approvedIds: Set<string> | null = null;
-      try {
-        const regimeMap = await fetchRegimeMap();
-        const riskResult = await runRiskPipeline(
-          curated.map((s) => ({
-            id: s.id,
-            symbol: s.symbol,
-            direction: s.direction,
-            confidence: s.confidence,
-            entry: s.entry,
-            stopLoss: s.stopLoss,
-            takeProfit1: s.takeProfit1,
-            takeProfit2: null,
-            takeProfit3: null,
-            timeframe: s.timeframe,
-          })),
-          regimeMap,
-        );
-        approvedIds = new Set(riskResult.approved.map((s) => s.id));
-        if (riskResult.vetoed.length > 0) {
-          console.warn(
-            `[cron/signals] Risk pipeline vetoed ${riskResult.vetoed.length} Pro signal(s):`,
-            riskResult.vetoed.map((v) => `${v.signal.symbol}:${v.reason}`).join('; '),
-          );
-        }
-      } catch (err) {
-        console.warn(
-          '[cron/signals] Risk pipeline failed, broadcasting curated signals unfiltered:',
-          err instanceof Error ? err.message : String(err),
-        );
-      }
+    // Late-stamp catch-up rows (recorded earlier by the request path with no
+    // broadcast decision). Only fills NULL — never overwrites.
+    const catchupDecisions = catchupSignals
+      .map((s) => decisions.get(s.id))
+      .filter((d): d is NonNullable<typeof d> => d !== undefined && d.recordable)
+      .map((d) => ({ id: d.id, regime: d.regime, blocked: d.blocked, blockReason: d.blockReason, allocationPct: d.allocationPct }));
+    try {
+      await updateBroadcastDecisionAsync(catchupDecisions);
+    } catch (err) {
+      console.warn(
+        '[cron/signals] Failed to stamp catch-up broadcast decisions:',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
 
-      const broadcastable = curated
-        .filter((s) => approvedIds === null || approvedIds.has(s.id))
-        .map((s) => ({
-          id: s.id,
-          symbol: s.symbol,
-          timeframe: s.timeframe,
-          direction: s.direction,
-          confidence: s.confidence,
-          entry: s.entry,
-          takeProfit1: s.takeProfit1,
-          stopLoss: s.stopLoss,
-          gateBlocked: false,
-        }));
-      broadcastableCount = broadcastable.length;
-      if (broadcastable.length > 0) {
-        broadcastSignalsToProGroup(broadcastable).catch(() => undefined);
-      }
+    const { resolved, pending, errors } = await resolveOldSignals();
+
+    const taggedSignals = newSignals.map((s) => ({ ...s, strategyId: preset.id }));
+
+    // Pro Telegram broadcast — fire on the deterministic 5-min cron cadence.
+    // After the duplicate-spam audit (2026-05-03) this is the SINGLE source
+    // of Pro broadcasts: the dedup gate inside broadcastSignalsToProGroup
+    // catches any retries. Broadcast set = rows the decision approved
+    // (blocked === false), identical to the pre-Phase-1 curated ∩ approved.
+    const vetoedCount = [...decisions.values()].filter((d) => d.blocked && !d.blockReason?.startsWith('winning_cells')).length;
+    if (vetoedCount > 0) {
+      console.warn(`[cron/signals] Risk pipeline vetoed ${vetoedCount} Pro signal(s) — decisions recorded on rows`);
+    }
+    const curatedCount = [...decisions.values()].filter((d) => !d.blockReason?.startsWith('winning_cells')).length;
+    const broadcastable = broadcastInputs
+      .filter((s) => decisions.get(s.id)?.blocked === false)
+      .map((s) => ({
+        id: s.id,
+        symbol: s.symbol,
+        timeframe: s.timeframe,
+        direction: s.direction,
+        confidence: s.confidence,
+        entry: s.entry,
+        takeProfit1: s.takeProfit1,
+        stopLoss: s.stopLoss,
+        gateBlocked: false,
+      }));
+    const broadcastableCount = broadcastable.length;
+    if (broadcastable.length > 0) {
+      broadcastSignalsToProGroup(broadcastable).catch(() => undefined);
     }
 
     const auditRowId = await recordSignalRun({

--- a/apps/web/app/api/leaderboard/__tests__/route.test.ts
+++ b/apps/web/app/api/leaderboard/__tests__/route.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../../lib/signal-history-cache', () => ({
 }));
 
 jest.mock('../../../../lib/signal-slice', () => ({
-  parseScope: jest.fn((raw: string | null | undefined) => raw === 'free' ? 'free' : 'pro'),
+  parseScope: jest.fn((raw: string | null | undefined) => raw === 'free' ? 'free' : raw === 'broadcast' ? 'broadcast' : 'pro'),
   getResolvedSlice: jest.fn(),
 }));
 
@@ -64,6 +64,27 @@ function makeReq(path: string): NextRequest {
 describe('GET /api/leaderboard category filtering', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('scope=broadcast recomputes from the broadcast slice instead of serving the Pro cache', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getResolvedSlice } = require('../../../../lib/signal-slice') as { getResolvedSlice: jest.Mock };
+    getResolvedSlice.mockResolvedValueOnce({
+      scopedRecords: [],
+      periodFiltered: [],
+      resolved: [],
+      cutoffTs: null,
+      earliestTimestamp: null,
+    });
+
+    const res = await GET(makeReq('/api/leaderboard?scope=broadcast'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // The Pro firehose cache must NOT be consulted for the gated subset.
+    expect(mockedGetLeaderboard).not.toHaveBeenCalled();
+    expect(getResolvedSlice).toHaveBeenCalledWith(expect.objectContaining({ scope: 'broadcast' }));
+    expect(body.assets).toEqual([]);
   });
 
   it('filters assets and recomputes overall for majors', async () => {

--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -39,10 +39,12 @@ export async function GET(request: NextRequest) {
 
     let detailHistory: SignalHistoryRecord[] | null = null;
 
-    // Strategy-filtered and free-scope variants recompute from history; the
-    // unfiltered Pro path still uses the precomputed period:sort cache.
+    // Strategy-filtered, free-scope, and broadcast-scope variants recompute
+    // from history; the unfiltered Pro path still uses the precomputed
+    // period:sort cache. The broadcast scope MUST NOT fall through to the
+    // Pro cache — it would silently serve firehose stats as the gated subset.
     const data = await (async () => {
-      if (scope === 'free') {
+      if (scope === 'free' || scope === 'broadcast') {
         const slice = await getResolvedSlice({ scope, period });
         detailHistory = slice.periodFiltered;
         return computeLeaderboard(slice.periodFiltered, 'all', sortBy, strategyFilter);

--- a/apps/web/app/api/signals/equity/route.test.ts
+++ b/apps/web/app/api/signals/equity/route.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../../../lib/signal-history', () => {
 });
 
 jest.mock('../../../../lib/signal-slice', () => ({
-  parseScope: jest.fn((raw: string | null | undefined) => raw === 'free' ? 'free' : 'pro'),
+  parseScope: jest.fn((raw: string | null | undefined) => raw === 'free' ? 'free' : raw === 'broadcast' ? 'broadcast' : 'pro'),
   getResolvedSlice: jest.fn(),
 }));
 

--- a/apps/web/app/api/signals/history/__tests__/route.test.ts
+++ b/apps/web/app/api/signals/history/__tests__/route.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../../../../lib/signal-history', () => {
 });
 
 jest.mock('../../../../../lib/signal-slice', () => ({
-  parseScope: jest.fn((raw: string | null | undefined) => raw === 'free' ? 'free' : 'pro'),
+  parseScope: jest.fn((raw: string | null | undefined) => raw === 'free' ? 'free' : raw === 'broadcast' ? 'broadcast' : 'pro'),
   getResolvedSlice: jest.fn(),
 }));
 

--- a/apps/web/app/calibration/CalibrationClient.tsx
+++ b/apps/web/app/calibration/CalibrationClient.tsx
@@ -9,9 +9,9 @@ interface CalibrationBucket {
   confMax: number;
   count: number;
   wins: number;
-  winRate: number;         // actual win rate
-  midpoint: number;        // expected win rate (midpoint of bucket)
-  calibrationError: number; // abs(winRate - midpoint)
+  winRate: number | null;         // actual win rate; null when the bucket is empty
+  midpoint: number;               // expected win rate (midpoint of bucket)
+  calibrationError: number | null; // abs(winRate - midpoint); null when empty
 }
 
 interface CalibrationData {
@@ -19,8 +19,8 @@ interface CalibrationData {
   overallAccuracy: number;
   totalSignals: number;
   isSimulated: boolean;
-  brier: number;           // Brier score (lower is better, 0.25 = random)
-  ece: number;             // Expected Calibration Error
+  brier: number | null;    // Brier score (lower is better, 0.25 = random); null with no data
+  ece: number | null;      // Expected Calibration Error; null with no data
   updatedAt: string;
 }
 
@@ -79,26 +79,30 @@ function CalibrationChart({ buckets }: { buckets: CalibrationBucket[] }) {
     const barW = (chartW / buckets.length) * 0.6;
     buckets.forEach((b, i) => {
       const x = pad.left + (i + 0.5) * (chartW / buckets.length) - barW / 2;
-      const actualH = chartH * b.winRate;
       const expectedH = chartH * b.midpoint;
-      const y = pad.top + chartH - actualH;
 
-      // Actual bar
-      const isOverConfident = b.winRate < b.midpoint - 0.05;
-      const isUnderConfident = b.winRate > b.midpoint + 0.05;
-      const barColor = isOverConfident
-        ? 'rgba(239,68,68,0.7)'
-        : isUnderConfident
-        ? 'rgba(251,191,36,0.7)'
-        : 'rgba(0,212,163,0.7)';
+      // Actual bar — only when the bucket has data. An empty bucket renders
+      // no bar (previously the API faked winRate = midpoint for empty
+      // buckets, which drew a perfectly calibrated chart out of nothing).
+      if (b.winRate !== null) {
+        const actualH = chartH * b.winRate;
+        const y = pad.top + chartH - actualH;
+        const isOverConfident = b.winRate < b.midpoint - 0.05;
+        const isUnderConfident = b.winRate > b.midpoint + 0.05;
+        const barColor = isOverConfident
+          ? 'rgba(239,68,68,0.7)'
+          : isUnderConfident
+          ? 'rgba(251,191,36,0.7)'
+          : 'rgba(0,212,163,0.7)';
 
-      const grad = ctx.createLinearGradient(0, y, 0, pad.top + chartH);
-      grad.addColorStop(0, barColor);
-      grad.addColorStop(1, barColor.replace('0.7', '0.3'));
-      ctx.fillStyle = grad;
-      ctx.beginPath();
-      ctx.roundRect(x, y, barW, actualH, [4, 4, 0, 0]);
-      ctx.fill();
+        const grad = ctx.createLinearGradient(0, y, 0, pad.top + chartH);
+        grad.addColorStop(0, barColor);
+        grad.addColorStop(1, barColor.replace('0.7', '0.3'));
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.roundRect(x, y, barW, actualH, [4, 4, 0, 0]);
+        ctx.fill();
+      }
 
       // Expected line
       ctx.strokeStyle = 'rgba(255,255,255,0.4)';
@@ -109,11 +113,12 @@ function CalibrationChart({ buckets }: { buckets: CalibrationBucket[] }) {
       ctx.stroke();
 
       // Count label
-      if (b.count > 0) {
+      if (b.count > 0 && b.winRate !== null) {
+        const labelY = pad.top + chartH - chartH * b.winRate - 6;
         ctx.fillStyle = 'rgba(255,255,255,0.5)';
         ctx.font = '10px system-ui';
         ctx.textAlign = 'center';
-        ctx.fillText(String(b.count), x + barW / 2, y - 6);
+        ctx.fillText(String(b.count), x + barW / 2, labelY);
       }
 
       // X label
@@ -197,8 +202,8 @@ export function CalibrationClient() {
 
   if (!data) return null;
 
-  const wellCalibrated = data.ece < 0.05;
-  const briferScore = data.brier < 0.20 ? 'Excellent' : data.brier < 0.25 ? 'Good' : 'Fair';
+  const wellCalibrated = data.ece !== null && data.ece < 0.05;
+  const briferScore = data.brier === null ? '—' : data.brier < 0.20 ? 'Excellent' : data.brier < 0.25 ? 'Good' : 'Fair';
 
   return (
     <div className="min-h-screen bg-zinc-950 text-white pb-24 md:pb-8">
@@ -257,13 +262,13 @@ export function CalibrationClient() {
           </div>
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
             <div className="text-xs text-zinc-400 mb-1">Brier Score</div>
-            <div className="text-2xl font-bold text-white">{data.brier.toFixed(3)}</div>
+            <div className="text-2xl font-bold text-white">{data.brier !== null ? data.brier.toFixed(3) : '—'}</div>
             <div className="text-xs text-zinc-500 mt-0.5">{briferScore} · lower is better</div>
           </div>
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
             <div className="text-xs text-zinc-400 mb-1">Calibration Error</div>
             <div className={`text-2xl font-bold ${wellCalibrated ? 'text-emerald-400' : 'text-zinc-400'}`}>
-              {(data.ece * 100).toFixed(1)}%
+              {data.ece !== null ? `${(data.ece * 100).toFixed(1)}%` : '—'}
             </div>
             <div className="text-xs text-zinc-500 mt-0.5">ECE · {wellCalibrated ? 'well calibrated' : 'needs tuning'}</div>
           </div>
@@ -320,7 +325,7 @@ export function CalibrationClient() {
               </thead>
               <tbody>
                 {data.buckets.map((b) => {
-                  const diff = b.winRate - b.midpoint;
+                  const diff = (b.winRate ?? b.midpoint) - b.midpoint;
                   const isGood = Math.abs(diff) < 0.05;
                   const isOver = diff < -0.05;
                   return (
@@ -330,7 +335,7 @@ export function CalibrationClient() {
                       <td className="px-4 py-3 text-right text-zinc-400">{b.wins}</td>
                       <td className="px-4 py-3 text-right text-zinc-300">{(b.midpoint * 100).toFixed(0)}%</td>
                       <td className={`px-4 py-3 text-right font-semibold ${isGood ? 'text-emerald-400' : isOver ? 'text-red-400' : 'text-zinc-400'}`}>
-                        {b.count > 0 ? `${(b.winRate * 100).toFixed(1)}%` : '—'}
+                        {b.winRate !== null ? `${(b.winRate * 100).toFixed(1)}%` : '—'}
                       </td>
                       <td className="px-4 py-3 text-right text-zinc-400 font-mono text-xs">
                         {b.count > 0 ? `${diff >= 0 ? '+' : ''}${(diff * 100).toFixed(1)}%` : '—'}

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -368,11 +368,12 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
     : HYPOTHETICAL_START;
 
   const isPro = scope === 'pro';
+  const isBroadcast = scope === 'broadcast';
 
   return (
     <section
       className={`glass-card rounded-2xl p-5 mb-6 border-l-2 ${
-        isPro ? 'border-emerald-500/50' : 'border-white/10'
+        isPro ? 'border-emerald-500/50' : isBroadcast ? 'border-cyan-500/50' : 'border-white/10'
       }`}
     >
       {/* Header */}
@@ -384,11 +385,13 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
               className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[10px] font-mono font-semibold uppercase tracking-wider ${
                 isPro
                   ? 'bg-emerald-500/15 text-emerald-400'
-                  : 'bg-white/[0.06] text-zinc-400'
+                  : isBroadcast
+                    ? 'bg-cyan-500/15 text-cyan-400'
+                    : 'bg-white/[0.06] text-zinc-400'
               }`}
             >
               <Lock className="h-3 w-3" aria-hidden="true" />
-              {isPro ? 'Pro' : 'Free'} view
+              {isPro ? 'Pro' : isBroadcast ? 'Broadcast' : 'Free'} view
             </span>
           </h2>
           <p className="text-[11px] text-zinc-600 mt-0.5">
@@ -396,9 +399,13 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
               ? summary
                 ? `Full Pro track record. ${summary.riskPerTradePct}% risk per trade, fixed-fractional${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R per trade` : ''}, after ${summary.roundTripCostPct}% round-trip costs. Verified against real market data.`
                 : 'Full Pro track record. Verified against real market data.'
-              : summary
-                ? `Free-tier slice — last ${FREE_HISTORY_DAYS} days on free symbols only. Subset of what Pro subscribers see. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after costs.`
-                : `Free-tier slice — last ${FREE_HISTORY_DAYS} days on free symbols only. Subset of what Pro subscribers see.`}
+              : isBroadcast
+                ? summary
+                  ? `Gate-approved broadcast subset — decisions recorded since 2026-06-10. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after ${summary.roundTripCostPct}% round-trip costs.`
+                  : 'Gate-approved broadcast subset — decisions recorded since 2026-06-10.'
+                : summary
+                  ? `Free-tier slice — last ${FREE_HISTORY_DAYS} days on free symbols only. Subset of what Pro subscribers see. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after costs.`
+                  : `Free-tier slice — last ${FREE_HISTORY_DAYS} days on free symbols only. Subset of what Pro subscribers see.`}
           </p>
           {summary && summary.sizedTrades !== undefined && summary.sizedTrades > 0 && (
             <p className="text-[10px] text-zinc-600 mt-1">

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -291,7 +291,7 @@ function drawChart(
   };
 }
 
-type EquityScope = 'pro' | 'free';
+type EquityScope = 'pro' | 'free' | 'broadcast';
 type EquityBand = 'all' | 'premium' | 'standard';
 
 interface EquityCurveProps {

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -232,7 +232,7 @@ function formatOutcomeCell(
 
 
 type DirectionFilter = 'ALL' | 'BUY' | 'SELL';
-type Scope = 'pro' | 'free';
+type Scope = 'pro' | 'free' | 'broadcast';
 type EquityBand = 'premium' | 'standard' | 'all';
 
 function parseEquityBand(raw: string | null): EquityBand {
@@ -690,12 +690,15 @@ export function TrackRecordClient() {
           })}
         </div>
 
-        {/* Scope tabs — default Pro, Free is a comparison view */}
+        {/* Scope tabs — default Pro (full firehose), Free is a comparison
+            view, Broadcast is the risk-gated subset actually sent to the Pro
+            group (decision recorded per row since migration 048). */}
         <div className="mb-3 flex items-center gap-1 p-1 rounded-lg bg-white/[0.04] w-fit">
           {(
             [
               { value: 'pro', label: 'Pro track record' },
               { value: 'free', label: 'Free track record' },
+              { value: 'broadcast', label: 'Pro broadcast (gated)' },
             ] as const
           ).map(({ value, label }) => (
             <button
@@ -706,7 +709,9 @@ export function TrackRecordClient() {
                 scope === value
                   ? value === 'pro'
                     ? 'bg-emerald-500/15 text-emerald-400'
-                    : 'bg-white/[0.08] text-[var(--foreground)]'
+                    : value === 'broadcast'
+                      ? 'bg-cyan-500/15 text-cyan-400'
+                      : 'bg-white/[0.08] text-[var(--foreground)]'
                   : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
               }`}
             >
@@ -714,6 +719,14 @@ export function TrackRecordClient() {
             </button>
           ))}
         </div>
+        {scope === 'broadcast' && (
+          <p className="mb-3 text-[11px] text-[var(--text-secondary)] max-w-xl">
+            Only signals the live gate (regime + curation + risk pipeline) approved
+            for the Pro Telegram broadcast. Gate decisions are recorded per row
+            since 2026-06-10 — earlier signals carry no decision and are excluded
+            from this view entirely.
+          </p>
+        )}
 
         {/* Category tabs — display-only segmentation over the same signal history */}
         <div className="mb-2 flex items-center gap-1 p-1 rounded-lg bg-white/[0.04] w-fit overflow-x-auto max-w-full">

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -513,9 +513,9 @@ export function TrackRecordClient() {
     if (category === 'thematic') {
       return `${symbolsForCategory('thematic').length} narrative-driven symbols. Wider coverage, more noise — useful for breadth, not for headline win rate.`;
     }
-    return scope === 'free'
-      ? `Every free-tier symbol in the last ${FREE_HISTORY_DAYS} days.`
-      : 'Every tracked symbol, full archive.';
+    if (scope === 'free') return `Every free-tier symbol in the last ${FREE_HISTORY_DAYS} days.`;
+    if (scope === 'broadcast') return 'Gate-approved signals only — decisions recorded since 2026-06-10.';
+    return 'Every tracked symbol, full archive.';
   }, [category, scope]);
   const noFreeSymbolsInCategory = scope === 'free' && category !== 'all' && !freeCategoryHasSymbols;
 
@@ -691,8 +691,9 @@ export function TrackRecordClient() {
         </div>
 
         {/* Scope tabs — default Pro (full firehose), Free is a comparison
-            view, Broadcast is the risk-gated subset actually sent to the Pro
-            group (decision recorded per row since migration 048). */}
+            view, Broadcast is the subset the risk gate APPROVED for the Pro
+            group (decision recorded per row since migration 048; approval is
+            not delivery — outage fallbacks and failed sends differ). */}
         <div className="mb-3 flex items-center gap-1 p-1 rounded-lg bg-white/[0.04] w-fit">
           {(
             [
@@ -778,6 +779,21 @@ export function TrackRecordClient() {
                 Get these signals live
               </Link>
             )}
+          </div>
+        ) : scope === 'broadcast' ? (
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm">
+            <div className="flex items-center gap-2 text-cyan-300">
+              <Lock className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>
+                Pro broadcast view — only signals the live risk gate approved for the Pro Telegram group. Decisions are recorded per row since 2026-06-10; older signals are excluded.
+              </span>
+            </div>
+            <button
+              onClick={() => setScope('pro')}
+              className="shrink-0 rounded-md border border-emerald-500/30 px-3 py-1 text-xs font-semibold text-emerald-400 transition-colors hover:bg-emerald-500/10"
+            >
+              Switch to full record
+            </button>
           </div>
         ) : (
           <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm">

--- a/apps/web/lib/__tests__/broadcast-decision.test.ts
+++ b/apps/web/lib/__tests__/broadcast-decision.test.ts
@@ -1,0 +1,132 @@
+jest.mock('../winning-cells', () => ({
+  isWinningCell: jest.fn(() => true),
+  getWinningCellsMode: jest.fn(() => 'shadow'),
+}));
+
+jest.mock('../risk-pipeline', () => ({
+  runRiskPipeline: jest.fn(),
+}));
+
+jest.mock('../regime-filter', () => ({
+  fetchRegimeMap: jest.fn(() => Promise.resolve(new Map())),
+  getDominantRegime: jest.fn(() => 'neutral'),
+}));
+
+import { computeBroadcastDecisions, type BroadcastCandidate } from '../broadcast-decision';
+import { isWinningCell, getWinningCellsMode } from '../winning-cells';
+import { runRiskPipeline } from '../risk-pipeline';
+import { fetchRegimeMap } from '../regime-filter';
+
+const mockedIsWinningCell = isWinningCell as jest.MockedFunction<typeof isWinningCell>;
+const mockedCellsMode = getWinningCellsMode as jest.MockedFunction<typeof getWinningCellsMode>;
+const mockedPipeline = runRiskPipeline as jest.MockedFunction<typeof runRiskPipeline>;
+const mockedRegimeMap = fetchRegimeMap as jest.MockedFunction<typeof fetchRegimeMap>;
+
+function candidate(id: string, symbol: string): BroadcastCandidate {
+  return {
+    id,
+    symbol,
+    timeframe: 'H1',
+    direction: 'BUY',
+    confidence: 80,
+    entry: 100,
+    takeProfit1: 104,
+    stopLoss: 98,
+  };
+}
+
+function pipelineResult(approved: Array<{ id: string; symbol: string }>, vetoed: Array<{ id: string; symbol: string; reason: string; vetoedBy: string }>, allocations: Array<{ symbol: string; positionSizePct: number }>) {
+  return {
+    approved: approved.map(({ id, symbol }) => ({ id, symbol, direction: 'BUY', confidence: 80, entry: 100, stopLoss: 98, takeProfit1: 104, takeProfit2: null, takeProfit3: null, timeframe: 'H1' })),
+    vetoed: vetoed.map((v) => ({
+      signal: { id: v.id, symbol: v.symbol, direction: 'BUY', confidence: 80, entry: 100, stopLoss: 98, takeProfit1: 104, takeProfit2: null, takeProfit3: null, timeframe: 'H1' },
+      reason: v.reason,
+      vetoedBy: v.vetoedBy,
+    })),
+    report: {
+      regime: 'neutral',
+      riskState: {},
+      activeBreakers: [],
+      canTrade: true,
+      llmVerification: null,
+      allocations: allocations.map((a) => ({ ...a, approved: true, reason: '' })),
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedRegimeMap.mockResolvedValue(new Map() as never);
+  mockedCellsMode.mockReturnValue('shadow' as never);
+  mockedIsWinningCell.mockReturnValue(true as never);
+});
+
+describe('computeBroadcastDecisions', () => {
+  it('returns empty map and runs nothing for an empty candidate list', async () => {
+    const decisions = await computeBroadcastDecisions([]);
+    expect(decisions.size).toBe(0);
+    expect(mockedPipeline).not.toHaveBeenCalled();
+    expect(mockedRegimeMap).not.toHaveBeenCalled();
+  });
+
+  it('records approved and vetoed decisions with regime + allocation', async () => {
+    const a = candidate('a', 'BTCUSD');
+    const b = candidate('b', 'ETHUSD');
+    mockedRegimeMap.mockResolvedValue(new Map([['BTCUSD', 'bull']]) as never);
+    mockedPipeline.mockResolvedValue(pipelineResult(
+      [{ id: 'a', symbol: 'BTCUSD' }],
+      [{ id: 'b', symbol: 'ETHUSD', reason: 'streak blocked', vetoedBy: 'circuit_breaker' }],
+      [{ symbol: 'BTCUSD', positionSizePct: 7.5 }, { symbol: 'ETHUSD', positionSizePct: 0 }],
+    ) as never);
+
+    const decisions = await computeBroadcastDecisions([a, b]);
+
+    const da = decisions.get('a')!;
+    expect(da).toMatchObject({ blocked: false, recordable: true, regime: 'bull', allocationPct: 7.5 });
+    const db = decisions.get('b')!;
+    expect(db.blocked).toBe(true);
+    expect(db.recordable).toBe(true);
+    expect(db.blockReason).toBe('circuit_breaker: streak blocked');
+    // ETHUSD not in regime map → dominant fallback
+    expect(db.regime).toBe('neutral');
+  });
+
+  it('blocks non-winning cells deterministically when curation is active, without sending them to the pipeline', async () => {
+    const a = candidate('a', 'BTCUSD');
+    const b = candidate('b', 'DOGEUSD');
+    mockedCellsMode.mockReturnValue('active' as never);
+    mockedIsWinningCell.mockImplementation(((symbol: string) => symbol === 'BTCUSD') as never);
+    mockedPipeline.mockResolvedValue(pipelineResult([{ id: 'a', symbol: 'BTCUSD' }], [], [{ symbol: 'BTCUSD', positionSizePct: 5 }]) as never);
+
+    const decisions = await computeBroadcastDecisions([a, b]);
+
+    expect(decisions.get('b')).toMatchObject({
+      blocked: true,
+      recordable: true,
+      blockReason: expect.stringContaining('winning_cells'),
+    });
+    expect(decisions.get('a')).toMatchObject({ blocked: false });
+    const pipelineInput = mockedPipeline.mock.calls[0][0] as Array<{ id: string }>;
+    expect(pipelineInput.map((s) => s.id)).toEqual(['a']);
+  });
+
+  it('marks pipeline-outage fallbacks blocked=false and NOT recordable', async () => {
+    const a = candidate('a', 'BTCUSD');
+    mockedPipeline.mockRejectedValue(new Error('risk-state db down'));
+
+    const decisions = await computeBroadcastDecisions([a]);
+
+    expect(decisions.get('a')).toMatchObject({ blocked: false, recordable: false });
+  });
+
+  it('survives a regime-map fetch failure (decisions still computed, neutral regime)', async () => {
+    const a = candidate('a', 'BTCUSD');
+    mockedRegimeMap.mockRejectedValue(new Error('db down'));
+    mockedPipeline.mockResolvedValue(pipelineResult([{ id: 'a', symbol: 'BTCUSD' }], [], []) as never);
+
+    const decisions = await computeBroadcastDecisions([a]);
+
+    expect(decisions.get('a')).toMatchObject({ blocked: false, recordable: true, regime: 'neutral' });
+  });
+});

--- a/apps/web/lib/__tests__/signal-history-broadcast.test.ts
+++ b/apps/web/lib/__tests__/signal-history-broadcast.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Migration-048 broadcast-scope persistence: Tier-0 INSERT, graceful fallback
+ * when the migration is unapplied, tri-state row mapping, and the catch-up
+ * late-stamp that must never overwrite an existing decision.
+ */
+
+jest.mock('../db-pool', () => ({
+  query: jest.fn(),
+  queryOne: jest.fn(),
+  execute: jest.fn(() => Promise.resolve()),
+}));
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+beforeAll(() => {
+  process.env.DATABASE_URL = 'postgres://test/test';
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+});
+
+type SignalHistoryModule = typeof import('../signal-history');
+
+function freshModule(): { mod: SignalHistoryModule; query: jest.Mock } {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const dbPool = require('../db-pool') as { query: jest.Mock };
+  dbPool.query.mockReset();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require('../signal-history') as SignalHistoryModule;
+  return { mod, query: dbPool.query };
+}
+
+const baseRow = {
+  id: 'sig-1',
+  pair: 'BTCUSD',
+  timeframe: 'H1',
+  direction: 'BUY',
+  confidence: 80,
+  entry_price: 50000,
+  tp1: 51000,
+  sl: 49500,
+  is_simulated: false,
+  outcome_4h: null,
+  outcome_24h: null,
+  telegram_posted_at: null,
+  telegram_message_id: null,
+  created_at: new Date().toISOString(),
+  last_verified: null,
+  strategy_id: 'hmm-top3',
+  mode: 'swing',
+  entry_atr: null,
+  atr_multiplier: null,
+  max_adverse_excursion: null,
+  gate_blocked: false,
+  gate_reason: null,
+};
+
+describe('recordSignalAsync with a broadcast decision (Tier 0)', () => {
+  it('inserts the regime / broadcast_blocked / reason / allocation columns', async () => {
+    const { mod, query } = freshModule();
+    query.mockResolvedValue([{ id: 'sig-1' }]);
+
+    await mod.recordSignalAsync(
+      'BTCUSD', 'H1', 'BUY', 80, 50000, 'sig-1', 51000, 49500, Date.now(), 'hmm-top3',
+      undefined, undefined, undefined, undefined, undefined,
+      { regime: 'bull', blocked: true, blockReason: 'circuit_breaker: streak', allocationPct: 7.5 },
+    );
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('broadcast_blocked');
+    expect(sql).toContain('broadcast_block_reason');
+    expect(sql).toContain('allocation_pct');
+    expect(sql).toContain('regime');
+    expect(params).toEqual(expect.arrayContaining(['bull', true, 'circuit_breaker: streak', 7.5]));
+  });
+
+  it('falls back to the pre-048 INSERT when the broadcast columns are missing, and skips Tier 0 afterwards', async () => {
+    const { mod, query } = freshModule();
+    const missingErr = Object.assign(new Error('column "broadcast_blocked" of relation "signal_history" does not exist'), { code: '42703' });
+    query
+      .mockRejectedValueOnce(missingErr)        // Tier 0 probe fails
+      .mockResolvedValue([{ id: 'sig-1' }]);    // Tier 1 succeeds
+
+    await mod.recordSignalAsync(
+      'BTCUSD', 'H1', 'BUY', 80, 50000, 'sig-1', 51000, 49500, Date.now(), 'hmm-top3',
+      undefined, undefined, undefined, undefined, undefined,
+      { blocked: false },
+    );
+
+    expect(query).toHaveBeenCalledTimes(2);
+    const tier1Sql = query.mock.calls[1][0] as string;
+    expect(tier1Sql).not.toContain('broadcast_blocked');
+    expect(tier1Sql).toContain('gate_blocked');
+
+    // Second record: Tier 0 is not probed again.
+    query.mockClear();
+    query.mockResolvedValue([{ id: 'sig-2' }]);
+    await mod.recordSignalAsync(
+      'ETHUSD', 'H1', 'BUY', 80, 3000, 'sig-2', 3100, 2950, Date.now(), 'hmm-top3',
+      undefined, undefined, undefined, undefined, undefined,
+      { blocked: false },
+    );
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0] as string).not.toContain('broadcast_blocked');
+  });
+
+  it('skips the Tier-0 probe entirely when no broadcast decision is supplied', async () => {
+    const { mod, query } = freshModule();
+    query.mockResolvedValue([{ id: 'sig-1' }]);
+
+    await mod.recordSignalAsync('BTCUSD', 'H1', 'BUY', 80, 50000, 'sig-1', 51000, 49500, Date.now(), 'hmm-top3');
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0] as string).not.toContain('broadcast_blocked');
+  });
+});
+
+describe('rowToRecord tri-state mapping (via readHistoryAsync)', () => {
+  it('maps NULL broadcast_blocked to undefined, never to false', async () => {
+    const { mod, query } = freshModule();
+    query.mockResolvedValue([
+      { ...baseRow, id: 'null-row', broadcast_blocked: null, regime: null },
+      { ...baseRow, id: 'approved-row', broadcast_blocked: false, regime: 'bull', allocation_pct: '7.5' },
+      { ...baseRow, id: 'blocked-row', broadcast_blocked: true, broadcast_block_reason: 'risk_veto: halt', regime: 'bear' },
+    ]);
+
+    const records = await mod.readHistoryAsync();
+
+    const byId = new Map(records.map((r) => [r.id, r]));
+    expect(byId.get('null-row')!.broadcastBlocked).toBeUndefined();
+    expect(byId.get('approved-row')!.broadcastBlocked).toBe(false);
+    expect(byId.get('approved-row')!.allocationPct).toBe(7.5);
+    expect(byId.get('approved-row')!.regime).toBe('bull');
+    expect(byId.get('blocked-row')!.broadcastBlocked).toBe(true);
+    expect(byId.get('blocked-row')!.broadcastBlockReason).toBe('risk_veto: halt');
+  });
+});
+
+describe('updateBroadcastDecisionAsync (catch-up late-stamp)', () => {
+  it('only fills rows whose decision is NULL', async () => {
+    const { mod, query } = freshModule();
+    query.mockResolvedValue([{ id: 'sig-1' }]);
+
+    const stamped = await mod.updateBroadcastDecisionAsync([
+      { id: 'sig-1', regime: 'neutral', blocked: false, allocationPct: 5 },
+    ]);
+
+    expect(stamped).toBe(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('broadcast_blocked IS NULL');
+    expect(params).toEqual(['sig-1', 'neutral', false, null, 5]);
+  });
+
+  it('no-ops gracefully when migration 048 is missing', async () => {
+    const { mod, query } = freshModule();
+    const missingErr = Object.assign(new Error('column "broadcast_blocked" does not exist'), { code: '42703' });
+    query.mockRejectedValue(missingErr);
+
+    const stamped = await mod.updateBroadcastDecisionAsync([
+      { id: 'sig-1', blocked: false },
+    ]);
+
+    expect(stamped).toBe(0);
+  });
+});

--- a/apps/web/lib/__tests__/signal-slice-broadcast.test.ts
+++ b/apps/web/lib/__tests__/signal-slice-broadcast.test.ts
@@ -1,0 +1,71 @@
+jest.mock('../signal-history-cache', () => ({
+  getCachedHistory: jest.fn(),
+}));
+
+import { getResolvedSlice, parseScope } from '../signal-slice';
+import { getCachedHistory } from '../signal-history-cache';
+import type { SignalHistoryRecord } from '../signal-history';
+
+const mockedHistory = getCachedHistory as jest.MockedFunction<typeof getCachedHistory>;
+
+function mkRecord(id: string, broadcastBlocked: boolean | undefined): SignalHistoryRecord {
+  return {
+    id,
+    pair: 'BTCUSD',
+    timeframe: 'H1',
+    direction: 'BUY',
+    confidence: 80,
+    entryPrice: 50000,
+    timestamp: Date.now() - 60_000,
+    tp1: 51000,
+    sl: 49500,
+    isSimulated: false,
+    gateBlocked: false,
+    broadcastBlocked,
+    outcomes: {
+      '4h': null,
+      '24h': { price: 51000, pnlPct: 2.0, hit: true, target: 'TP1' },
+    },
+  };
+}
+
+beforeEach(() => {
+  mockedHistory.mockReset();
+});
+
+describe('parseScope', () => {
+  it('accepts broadcast and defaults unknown values to pro', () => {
+    expect(parseScope('broadcast')).toBe('broadcast');
+    expect(parseScope('free')).toBe('free');
+    expect(parseScope('pro')).toBe('pro');
+    expect(parseScope('nonsense')).toBe('pro');
+    expect(parseScope(null)).toBe('pro');
+  });
+});
+
+describe('getResolvedSlice scope=broadcast', () => {
+  it('includes ONLY rows whose decision ran and approved (strict === false)', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('approved', false),
+      mkRecord('blocked', true),
+      mkRecord('not-recorded', undefined),
+    ]);
+
+    const slice = await getResolvedSlice({ scope: 'broadcast' });
+
+    expect(slice.scopedRecords.map((r) => r.id)).toEqual(['approved']);
+    expect(slice.resolved.map((r) => r.id)).toEqual(['approved']);
+  });
+
+  it('scope=pro still returns the full firehose including undecided rows', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('approved', false),
+      mkRecord('blocked', true),
+      mkRecord('not-recorded', undefined),
+    ]);
+
+    const slice = await getResolvedSlice({ scope: 'pro' });
+
+    expect(slice.scopedRecords).toHaveLength(3);
+  });
+});

--- a/apps/web/lib/broadcast-decision.ts
+++ b/apps/web/lib/broadcast-decision.ts
@@ -1,0 +1,132 @@
+/**
+ * Pro-broadcast gate decision, computed BEFORE persistence (engine-makeover
+ * Phase 1). One pipeline run per cron tick decides, per signal: does this row
+ * reach the Pro broadcast, and why not if it doesn't. The cron records the
+ * decision on the row (migration 048) so the broadcast-filtered subset is
+ * measurable — previously the decision was computed after recording and only
+ * console-warned.
+ *
+ * Decision semantics:
+ * - winning-cells curation (when active) blocks deterministically.
+ * - risk pipeline (circuit breakers → allocator → veto) blocks with a reason.
+ * - pipeline OUTAGE falls back to unfiltered broadcast (Pro must not silently
+ *   mute) — those rows are marked `recordable: false` and their decision is
+ *   NOT persisted: the gate never actually ran, so NULL ("decision not
+ *   recorded") is the truthful state even though the row was broadcast.
+ */
+
+import { isWinningCell, getWinningCellsMode } from './winning-cells';
+import { runRiskPipeline } from './risk-pipeline';
+import { fetchRegimeMap, getDominantRegime } from './regime-filter';
+import type { BroadcastDecisionFields } from './signal-history';
+import type { MarketRegime } from '@tradeclaw/signals';
+
+export interface BroadcastCandidate {
+  id: string;
+  symbol: string;
+  timeframe: string;
+  direction: 'BUY' | 'SELL';
+  confidence: number;
+  entry: number;
+  takeProfit1: number;
+  stopLoss: number;
+}
+
+export interface BroadcastDecision extends BroadcastDecisionFields {
+  id: string;
+  /** True when a real gate decision ran (winning-cells or risk pipeline). False = pipeline outage fallback: row broadcasts unfiltered and the decision must NOT be persisted. */
+  recordable: boolean;
+}
+
+export async function computeBroadcastDecisions(
+  candidates: BroadcastCandidate[],
+): Promise<Map<string, BroadcastDecision>> {
+  const decisions = new Map<string, BroadcastDecision>();
+  if (candidates.length === 0) return decisions;
+
+  let regimeMap = new Map<string, MarketRegime>();
+  try {
+    regimeMap = await fetchRegimeMap();
+  } catch {
+    // Empty map → everything resolves 'neutral', same as the filter layer.
+  }
+  const dominant = getDominantRegime(regimeMap);
+  const regimeOf = (symbol: string): string =>
+    regimeMap.get(symbol.toUpperCase()) ?? dominant;
+
+  const winningCellsActive = getWinningCellsMode() === 'active';
+  const curated: BroadcastCandidate[] = [];
+  for (const c of candidates) {
+    if (winningCellsActive && !isWinningCell(c.symbol, c.direction)) {
+      decisions.set(c.id, {
+        id: c.id,
+        regime: regimeOf(c.symbol),
+        blocked: true,
+        blockReason: 'winning_cells: not in current winning set',
+        recordable: true,
+      });
+    } else {
+      curated.push(c);
+    }
+  }
+
+  if (curated.length === 0) return decisions;
+
+  try {
+    const result = await runRiskPipeline(
+      curated.map((s) => ({
+        id: s.id,
+        symbol: s.symbol,
+        direction: s.direction,
+        confidence: s.confidence,
+        entry: s.entry,
+        stopLoss: s.stopLoss,
+        takeProfit1: s.takeProfit1,
+        takeProfit2: null,
+        takeProfit3: null,
+        timeframe: s.timeframe,
+      })),
+      regimeMap,
+    );
+    const allocBySymbol = new Map(
+      result.report.allocations.map((a) => [a.symbol, a.positionSizePct]),
+    );
+    for (const s of result.approved) {
+      decisions.set(s.id, {
+        id: s.id,
+        regime: regimeOf(s.symbol),
+        blocked: false,
+        allocationPct: allocBySymbol.get(s.symbol),
+        recordable: true,
+      });
+    }
+    for (const v of result.vetoed) {
+      decisions.set(v.signal.id, {
+        id: v.signal.id,
+        regime: regimeOf(v.signal.symbol),
+        blocked: true,
+        blockReason: `${v.vetoedBy}: ${v.reason}`,
+        allocationPct: allocBySymbol.get(v.signal.symbol),
+        recordable: true,
+      });
+    }
+  } catch (err) {
+    // Mirror the long-standing broadcast fallback: a transient risk-state
+    // outage must not mute the Pro channel. These rows broadcast unfiltered;
+    // their gate decision never ran, so they are not recordable.
+    console.warn(
+      '[broadcast-decision] Risk pipeline failed, falling back to unfiltered broadcast:',
+      err instanceof Error ? err.message : String(err),
+    );
+    for (const c of curated) {
+      decisions.set(c.id, {
+        id: c.id,
+        regime: regimeOf(c.symbol),
+        blocked: false,
+        recordable: false,
+      });
+    }
+  }
+
+  return decisions;
+}

--- a/apps/web/lib/broadcast-decision.ts
+++ b/apps/web/lib/broadcast-decision.ts
@@ -88,15 +88,21 @@ export async function computeBroadcastDecisions(
       })),
       regimeMap,
     );
-    const allocBySymbol = new Map(
-      result.report.allocations.map((a) => [a.symbol, a.positionSizePct]),
-    );
+    // report.allocations is pushed one entry per input signal IN INPUT ORDER
+    // (risk-pipeline.ts signal loop) but keyed only by symbol — a symbol with
+    // both BUY and SELL in the same tick would collide in a symbol-keyed map
+    // and persist the wrong positionSizePct. Zip by index instead.
+    const allocByIndex = result.report.allocations;
+    const allocOf = (id: string): number | undefined => {
+      const idx = curated.findIndex((c) => c.id === id);
+      return idx >= 0 ? allocByIndex[idx]?.positionSizePct : undefined;
+    };
     for (const s of result.approved) {
       decisions.set(s.id, {
         id: s.id,
         regime: regimeOf(s.symbol),
         blocked: false,
-        allocationPct: allocBySymbol.get(s.symbol),
+        allocationPct: allocOf(s.id),
         recordable: true,
       });
     }
@@ -106,7 +112,7 @@ export async function computeBroadcastDecisions(
         regime: regimeOf(v.signal.symbol),
         blocked: true,
         blockReason: `${v.vetoedBy}: ${v.reason}`,
-        allocationPct: allocBySymbol.get(v.signal.symbol),
+        allocationPct: allocOf(v.signal.id),
         recordable: true,
       });
     }

--- a/apps/web/lib/signal-history.ts
+++ b/apps/web/lib/signal-history.ts
@@ -16,6 +16,10 @@ export interface SignalOutcome {
   pnlPct: number;
   hit: boolean;
   target?: 'TP1' | 'TP2' | 'TP3' | 'SL' | 'expired';
+  /** Resolution provenance: wall-clock ISO timestamp when this outcome was written. Absent on legacy rows. */
+  resolvedAt?: string;
+  /** Resolution provenance: OHLCV provider that supplied the resolving candles (e.g. 'binance', 'stooq'), or 'force-expired'. Absent on legacy rows. */
+  source?: string;
 }
 
 // Auto-expire writes `{ pnlPct: 0, hit: false, target: 'expired' }` when a signal window elapses
@@ -75,6 +79,16 @@ export interface SignalHistoryRecord {
   gateBlocked?: boolean;
   /** Human-readable gate.reason at the moment of blocking. NULL unless gateBlocked is TRUE. */
   gateReason?: string;
+  /** Market regime resolved for this symbol at emission (migration 048). Undefined on pre-048 rows. */
+  regime?: string;
+  /** Pro-broadcast gate decision at emission: false = approved for broadcast, true = blocked. Undefined = decision not recorded (pre-048 rows). Tri-state is load-bearing — do NOT default to false. */
+  broadcastBlocked?: boolean;
+  /** Why the broadcast gate blocked this row (winning-cells / risk veto). Undefined unless broadcastBlocked is true. */
+  broadcastBlockReason?: string;
+  /** Allocator position size (% of equity) computed at emission. Undefined on pre-048 rows or when the pipeline did not run. */
+  allocationPct?: number;
+  /** Wall-clock publish stamp (DB-defaulted NOW() on insert), distinct from bar-time `timestamp`. Undefined on pre-048 rows. */
+  publishedAt?: number;
   outcomes: {
     '4h': SignalOutcome | null;
     '24h': SignalOutcome | null;
@@ -240,6 +254,11 @@ interface HistoryRow {
   max_adverse_excursion: string | number | null;
   gate_blocked: boolean | null;
   gate_reason: string | null;
+  regime?: string | null;
+  broadcast_blocked?: boolean | null;
+  broadcast_block_reason?: string | null;
+  allocation_pct?: string | number | null;
+  published_at?: string | null;
 }
 
 function rowToRecord(row: HistoryRow): SignalHistoryRecord {
@@ -264,6 +283,14 @@ function rowToRecord(row: HistoryRow): SignalHistoryRecord {
     maxAdverseExcursion: row.max_adverse_excursion != null ? Number(row.max_adverse_excursion) : undefined,
     gateBlocked: row.gate_blocked ?? false,
     gateReason: row.gate_reason ?? undefined,
+    regime: row.regime ?? undefined,
+    // Tri-state: NULL (pre-048 / decision not recorded) maps to undefined,
+    // NOT false — the broadcast scope must only include rows whose decision
+    // actually ran and approved.
+    broadcastBlocked: row.broadcast_blocked ?? undefined,
+    broadcastBlockReason: row.broadcast_block_reason ?? undefined,
+    allocationPct: row.allocation_pct != null ? Number(row.allocation_pct) : undefined,
+    publishedAt: row.published_at ? new Date(row.published_at).getTime() : undefined,
     outcomes: {
       '4h': row.outcome_4h ?? null,
       '24h': row.outcome_24h ?? null,
@@ -329,6 +356,17 @@ export async function readHistoryAsync(
 
 // ── Record single signal ─────────────────────────────────────
 
+/**
+ * Pro-broadcast gate decision computed at emission (migration 048). Recorded
+ * alongside the row so the broadcast-filtered subset is measurable.
+ */
+export interface BroadcastDecisionFields {
+  regime?: string;
+  blocked: boolean;
+  blockReason?: string;
+  allocationPct?: number;
+}
+
 export async function recordSignalAsync(
   pair: string,
   timeframe: string,
@@ -345,6 +383,7 @@ export async function recordSignalAsync(
   atrMultiplier?: number,
   gateBlocked?: boolean,
   gateReason?: string,
+  broadcast?: BroadcastDecisionFields,
 ): Promise<void> {
   const sigId = id ?? `${pair}-${timeframe}-${direction}-${Date.now()}`;
   const ts = timestamp ?? Date.now();
@@ -367,12 +406,16 @@ export async function recordSignalAsync(
       atrMultiplier,
       gateBlocked,
       gateReason,
+      regime: broadcast?.regime,
+      broadcastBlocked: broadcast?.blocked,
+      broadcastBlockReason: broadcast?.blockReason,
+      allocationPct: broadcast?.allocationPct,
     });
     return;
   }
 
   // File fallback
-  recordSignal(pair, timeframe, direction, confidence, entryPrice, sigId, tp1, sl, ts, strategyId, resolvedMode, entryAtr, atrMultiplier, gateBlocked, gateReason);
+  recordSignal(pair, timeframe, direction, confidence, entryPrice, sigId, tp1, sl, ts, strategyId, resolvedMode, entryAtr, atrMultiplier, gateBlocked, gateReason, broadcast);
 }
 
 /**
@@ -399,12 +442,49 @@ interface InsertRowArgs {
   atrMultiplier?: number;
   gateBlocked?: boolean;
   gateReason?: string;
+  regime?: string;
+  broadcastBlocked?: boolean;
+  broadcastBlockReason?: string;
+  allocationPct?: number;
 }
 
 let atrColumnsKnownMissing = false;
 let gateColumnsKnownMissing = false;
+let broadcastColumnsKnownMissing = false;
 
 async function insertSignalHistoryRow(args: InsertRowArgs): Promise<boolean> {
+  // Tier 0: full schema incl. 048 broadcast-scope cols. Only attempted when
+  // the caller actually has a broadcast decision to persist — otherwise the
+  // Tier 1 INSERT is identical in effect and skips a failure probe.
+  if (
+    !broadcastColumnsKnownMissing && !atrColumnsKnownMissing && !gateColumnsKnownMissing &&
+    args.broadcastBlocked !== undefined
+  ) {
+    try {
+      const result = await query<{ id: string }>(
+        `INSERT INTO signal_history (id, pair, timeframe, direction, confidence, entry_price, tp1, sl, created_at, strategy_id, mode, entry_atr, atr_multiplier, gate_blocked, gate_reason, regime, broadcast_blocked, broadcast_block_reason, allocation_pct)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+         ON CONFLICT (id) DO UPDATE SET strategy_id = EXCLUDED.strategy_id
+           WHERE signal_history.strategy_id IS NULL AND EXCLUDED.strategy_id IS NOT NULL
+         RETURNING id`,
+        [args.id, args.pair, args.timeframe, args.direction, args.confidence, args.entryPrice, args.tp1 ?? null, args.sl ?? null, args.createdAt, args.strategyId ?? null, args.mode, args.entryAtr ?? null, args.atrMultiplier ?? null, args.gateBlocked ?? false, args.gateReason ?? null, args.regime ?? null, args.broadcastBlocked, args.broadcastBlockReason ?? null, args.allocationPct ?? null],
+      );
+      return result.length > 0;
+    } catch (err: unknown) {
+      const code = (err as { code?: string } | null)?.code;
+      const msg = err instanceof Error ? err.message : String(err);
+      if (code === '42703' && /regime|broadcast_blocked|broadcast_block_reason|allocation_pct/.test(msg)) {
+        console.warn('[signal-history] migration 048 not applied — falling back to pre-048 INSERT (broadcast decision dropped). Run psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql to record broadcast-scope decisions.');
+        broadcastColumnsKnownMissing = true;
+      } else if (code === '42703') {
+        // Older migration missing too — let the existing tiers diagnose.
+        broadcastColumnsKnownMissing = true;
+      } else {
+        throw err;
+      }
+    }
+  }
+
   // Tier 1: full schema (012 ATR + 017 gate cols).
   if (!atrColumnsKnownMissing && !gateColumnsKnownMissing) {
     try {
@@ -486,6 +566,7 @@ export function recordSignal(
   atrMultiplier?: number,
   gateBlocked?: boolean,
   gateReason?: string,
+  broadcast?: BroadcastDecisionFields,
 ): void {
   const records = readHistoryFile();
   const sigId = id ?? `${pair}-${timeframe}-${direction}-${Date.now()}`;
@@ -500,10 +581,74 @@ export function recordSignal(
     atrMultiplier,
     gateBlocked: gateBlocked ?? false,
     gateReason,
+    regime: broadcast?.regime,
+    broadcastBlocked: broadcast?.blocked,
+    broadcastBlockReason: broadcast?.blockReason,
+    allocationPct: broadcast?.allocationPct,
+    publishedAt: broadcast !== undefined ? Date.now() : undefined,
     outcomes: { '4h': null, '24h': null },
   });
   if (records.length > MAX_RECORDS) records.splice(MAX_RECORDS);
   writeHistoryFile(records);
+}
+
+// ── Broadcast decision late-stamp (catch-up rows) ────────────
+
+/**
+ * Stamps the Pro-broadcast gate decision onto rows that were recorded by the
+ * request-path writer BEFORE the cron's broadcast tick evaluated them (the
+ * catch-up set). Only fills rows whose decision is still NULL — a decision
+ * recorded at emission is never overwritten.
+ */
+export async function updateBroadcastDecisionAsync(
+  decisions: Array<{ id: string } & BroadcastDecisionFields>,
+): Promise<number> {
+  if (decisions.length === 0) return 0;
+
+  if (isDbEnabled()) {
+    if (broadcastColumnsKnownMissing) return 0;
+    let stamped = 0;
+    for (const d of decisions) {
+      try {
+        const result = await query<{ id: string }>(
+          `UPDATE signal_history
+              SET regime = COALESCE($2, regime),
+                  broadcast_blocked = $3,
+                  broadcast_block_reason = $4,
+                  allocation_pct = $5
+            WHERE id = $1 AND broadcast_blocked IS NULL
+            RETURNING id`,
+          [d.id, d.regime ?? null, d.blocked, d.blockReason ?? null, d.allocationPct ?? null],
+        );
+        stamped += result.length;
+      } catch (err: unknown) {
+        const code = (err as { code?: string } | null)?.code;
+        if (code === '42703') {
+          console.warn('[signal-history] migration 048 not applied — broadcast decisions not stamped. Run psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql.');
+          broadcastColumnsKnownMissing = true;
+          return stamped;
+        }
+        throw err;
+      }
+    }
+    return stamped;
+  }
+
+  // File fallback
+  const records = readHistoryFile();
+  const byId = new Map(decisions.map(d => [d.id, d]));
+  let stamped = 0;
+  for (const r of records) {
+    const d = byId.get(r.id);
+    if (!d || r.broadcastBlocked !== undefined) continue;
+    r.regime = d.regime ?? r.regime;
+    r.broadcastBlocked = d.blocked;
+    r.broadcastBlockReason = d.blockReason;
+    r.allocationPct = d.allocationPct;
+    stamped++;
+  }
+  if (stamped > 0) writeHistoryFile(records);
+  return stamped;
 }
 
 // ── Bulk record ──────────────────────────────────────────────
@@ -1108,9 +1253,30 @@ export async function updateRecordsAsync(
         sets.push(`last_verified = $${idx++}`);
         params.push(new Date(patch.lastVerified).toISOString());
       }
+      // MAE rides along with outcome resolution (cron path). COALESCE keeps
+      // the first-written value; skip entirely when migration 012 is absent.
+      if (patch.maxAdverseExcursion !== undefined && !atrColumnsKnownMissing) {
+        sets.push(`max_adverse_excursion = COALESCE(max_adverse_excursion, $${idx++})`);
+        params.push(patch.maxAdverseExcursion);
+      }
 
       if (sets.length === 0) continue;
-      await execute(`UPDATE signal_history SET ${sets.join(', ')} WHERE id = $1`, params);
+      try {
+        await execute(`UPDATE signal_history SET ${sets.join(', ')} WHERE id = $1`, params);
+      } catch (err: unknown) {
+        const code = (err as { code?: string } | null)?.code;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (code === '42703' && /max_adverse_excursion/.test(msg)) {
+          atrColumnsKnownMissing = true;
+          const maeIdx = sets.findIndex(s => s.includes('max_adverse_excursion'));
+          sets.splice(maeIdx, 1);
+          params.splice(maeIdx + 1, 1);
+          if (sets.length === 0) continue;
+          await execute(`UPDATE signal_history SET ${sets.join(', ')} WHERE id = $1`, params);
+        } else {
+          throw err;
+        }
+      }
       changed++;
     }
     return changed;

--- a/apps/web/lib/signal-history.ts
+++ b/apps/web/lib/signal-history.ts
@@ -474,7 +474,7 @@ async function insertSignalHistoryRow(args: InsertRowArgs): Promise<boolean> {
       const code = (err as { code?: string } | null)?.code;
       const msg = err instanceof Error ? err.message : String(err);
       if (code === '42703' && /regime|broadcast_blocked|broadcast_block_reason|allocation_pct/.test(msg)) {
-        console.warn('[signal-history] migration 048 not applied — falling back to pre-048 INSERT (broadcast decision dropped). Run psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql to record broadcast-scope decisions.');
+        console.warn('[signal-history] migration 048 not applied — falling back to pre-048 INSERT (broadcast decision dropped). Run psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql THEN RESTART the service — this flag sticks for the process lifetime.');
         broadcastColumnsKnownMissing = true;
       } else if (code === '42703') {
         // Older migration missing too — let the existing tiers diagnose.
@@ -599,6 +599,12 @@ export function recordSignal(
  * request-path writer BEFORE the cron's broadcast tick evaluated them (the
  * catch-up set). Only fills rows whose decision is still NULL — a decision
  * recorded at emission is never overwritten.
+ *
+ * Semantics: broadcast_blocked is the FIRST RECORDED gate decision, not the
+ * delivery outcome. A row stamped blocked=TRUE can still be re-evaluated and
+ * broadcast on a later tick while it remains in the catch-up window (the
+ * stamp no-ops), and a row stamped FALSE can fail its fire-and-forget send.
+ * Join against telegram_pro_message_id for actual-delivery analytics.
  */
 export async function updateBroadcastDecisionAsync(
   decisions: Array<{ id: string } & BroadcastDecisionFields>,
@@ -624,7 +630,7 @@ export async function updateBroadcastDecisionAsync(
       } catch (err: unknown) {
         const code = (err as { code?: string } | null)?.code;
         if (code === '42703') {
-          console.warn('[signal-history] migration 048 not applied — broadcast decisions not stamped. Run psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql.');
+          console.warn('[signal-history] migration 048 not applied — broadcast decisions not stamped. Run psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql THEN RESTART the service — this flag sticks for the process lifetime.');
           broadcastColumnsKnownMissing = true;
           return stamped;
         }
@@ -849,14 +855,20 @@ export async function resolveRealOutcomes(): Promise<void> {
       if (!needs4h && !needs24h) continue;
 
       let candles: import('../app/lib/ohlcv').OHLCV[] = [];
+      let candleSource = 'unknown';
 
       try {
         const result = await getOHLCV(r.pair, getOutcomeResolutionTimeframe(r));
         candles = result.candles;
+        candleSource = result.source;
       } catch (err) {
         console.error(`[signal-history] OHLCV fetch failed for ${r.pair}: ${err instanceof Error ? err.message : String(err)}`);
       }
 
+      // Resolution provenance — both writers (this request-path resolver and
+      // the cron) must stamp it or the detection property doesn't hold:
+      // whichever writer wins the race owns the row.
+      const resolvedAt = new Date(now).toISOString();
       let outcome4h = r.outcomes['4h'];
       let outcome24h = r.outcomes['24h'];
       let mae24h: number | null = null;
@@ -865,19 +877,19 @@ export async function resolveRealOutcomes(): Promise<void> {
         const windowEnd = r.timestamp + FOUR_H;
         const window = candles.filter(c => c.timestamp > r.timestamp && c.timestamp <= windowEnd);
         const resolved = resolveFromCandles(r, window, age >= FOUR_H);
-        outcome4h = resolved?.outcome ?? outcome4h;
+        outcome4h = resolved ? { ...resolved.outcome, resolvedAt, source: candleSource } : outcome4h;
         if (!outcome4h && age >= FOUR_H * 2) {
-          outcome4h = { price: r.entryPrice, pnlPct: 0, hit: false, target: 'expired' };
+          outcome4h = { price: r.entryPrice, pnlPct: 0, hit: false, target: 'expired', resolvedAt, source: 'force-expired' };
         }
       }
       if (needs24h) {
         const windowEnd = r.timestamp + TWENTY_FOUR_H;
         const window = candles.filter(c => c.timestamp > r.timestamp && c.timestamp <= windowEnd);
         const resolved = resolveFromCandles(r, window, age >= TWENTY_FOUR_H);
-        outcome24h = resolved?.outcome ?? outcome24h;
+        outcome24h = resolved ? { ...resolved.outcome, resolvedAt, source: candleSource } : outcome24h;
         mae24h = resolved?.maxAdverseExcursion ?? null;
         if (!outcome24h && age >= TWENTY_FOUR_H * 2) {
-          outcome24h = { price: r.entryPrice, pnlPct: 0, hit: false, target: 'expired' };
+          outcome24h = { price: r.entryPrice, pnlPct: 0, hit: false, target: 'expired', resolvedAt, source: 'force-expired' };
         }
       }
 
@@ -1122,7 +1134,13 @@ export async function recordTradeOutcomeToHistory(
 ): Promise<void> {
   if (!isDbEnabled()) return;
 
-  const outcome: SignalOutcome = { price: exitPrice, pnlPct, hit: isHit };
+  const outcome: SignalOutcome = {
+    price: exitPrice,
+    pnlPct,
+    hit: isHit,
+    resolvedAt: new Date().toISOString(),
+    source: 'trade-close',
+  };
 
   await execute(
     `UPDATE signal_history
@@ -1255,6 +1273,9 @@ export async function updateRecordsAsync(
       }
       // MAE rides along with outcome resolution (cron path). COALESCE keeps
       // the first-written value; skip entirely when migration 012 is absent.
+      // INVARIANT: this MUST stay the LAST pushed SET — the 42703 retry below
+      // splices it off the end, which only preserves $-placeholder numbering
+      // for a trailing element.
       if (patch.maxAdverseExcursion !== undefined && !atrColumnsKnownMissing) {
         sets.push(`max_adverse_excursion = COALESCE(max_adverse_excursion, $${idx++})`);
         params.push(patch.maxAdverseExcursion);
@@ -1269,8 +1290,10 @@ export async function updateRecordsAsync(
         if (code === '42703' && /max_adverse_excursion/.test(msg)) {
           atrColumnsKnownMissing = true;
           const maeIdx = sets.findIndex(s => s.includes('max_adverse_excursion'));
-          sets.splice(maeIdx, 1);
-          params.splice(maeIdx + 1, 1);
+          if (maeIdx >= 0) {
+            sets.splice(maeIdx, 1);
+            params.splice(maeIdx + 1, 1);
+          }
           if (sets.length === 0) continue;
           await execute(`UPDATE signal_history SET ${sets.join(', ')} WHERE id = $1`, params);
         } else {

--- a/apps/web/lib/signal-slice.ts
+++ b/apps/web/lib/signal-slice.ts
@@ -2,7 +2,7 @@ import { getCachedHistory } from './signal-history-cache';
 import { isCountedResolved, type SignalHistoryRecord } from './signal-history';
 import { TIER_SYMBOLS, TIER_HISTORY_DAYS } from './tier';
 
-export type SignalScope = 'pro' | 'free';
+export type SignalScope = 'pro' | 'free' | 'broadcast';
 
 const PERIOD_DAYS: Record<string, number> = {
   '7d': 7,
@@ -28,7 +28,9 @@ export interface ResolvedSlice {
 }
 
 export function parseScope(raw: string | null | undefined): SignalScope {
-  return raw === 'free' ? 'free' : 'pro';
+  if (raw === 'free') return 'free';
+  if (raw === 'broadcast') return 'broadcast';
+  return 'pro';
 }
 
 /**
@@ -57,6 +59,12 @@ export async function getResolvedSlice(opts: {
       const cutoff = now - days * 86_400_000;
       scopedRecords = scopedRecords.filter(r => r.timestamp >= cutoff);
     }
+  } else if (opts.scope === 'broadcast') {
+    // Pro-broadcast subset: rows whose gate decision (regime + winning-cells
+    // + risk pipeline) ran at emission AND approved. Strict === false — NULL
+    // (pre-048 rows, or pipeline-outage fallbacks where the gate never ran)
+    // is "decision not recorded" and must not be counted either way.
+    scopedRecords = scopedRecords.filter(r => r.broadcastBlocked === false);
   }
 
   const earliestTimestamp = scopedRecords.length > 0

--- a/apps/web/migrations/048_broadcast_scope.sql
+++ b/apps/web/migrations/048_broadcast_scope.sql
@@ -17,9 +17,11 @@ ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS broadcast_block_reason TEXT;
 ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS allocation_pct REAL;
 
 -- Wall-clock publish stamp, distinct from the writer-supplied bar-time
--- created_at. Added WITHOUT a default first: a volatile DEFAULT on ADD COLUMN
--- would rewrite the table and stamp migration-time NOW() onto historical rows
--- — falsifying history. The default applies to future inserts only.
+-- created_at. Added WITHOUT a default first: ADD COLUMN ... DEFAULT NOW()
+-- (now() is STABLE in PG>=11, no rewrite) would take the attmissingval fast
+-- path and stamp the single migration-time value onto ALL existing rows —
+-- falsifying history. Split this way, existing rows stay NULL and the
+-- catalog-only SET DEFAULT applies to future inserts only.
 ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ;
 ALTER TABLE signal_history ALTER COLUMN published_at SET DEFAULT NOW();
 

--- a/apps/web/migrations/048_broadcast_scope.sql
+++ b/apps/web/migrations/048_broadcast_scope.sql
@@ -1,0 +1,28 @@
+-- 048: Broadcast-scope recording (engine-makeover Phase 1).
+--
+-- Records the regime + winning-cells + risk-pipeline decision that shapes the
+-- Pro broadcast AT EMISSION TIME, so the broadcast-filtered subset becomes
+-- measurable. Until now the cron recorded the raw firehose and only
+-- console-warned the gate decision — the Pro-deployed strategy's performance
+-- was never recorded (docs/plans/2026-06-10-engine-makeover.md, Phase 1;
+-- PR #110 deferred item 1).
+--
+-- All columns nullable, no backfill: NULL = "decision not recorded at
+-- emission" (pre-migration rows). FALSE = decision ran and approved for
+-- broadcast. TRUE = decision ran and blocked.
+
+ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS regime VARCHAR(16);
+ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS broadcast_blocked BOOLEAN;
+ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS broadcast_block_reason TEXT;
+ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS allocation_pct REAL;
+
+-- Wall-clock publish stamp, distinct from the writer-supplied bar-time
+-- created_at. Added WITHOUT a default first: a volatile DEFAULT on ADD COLUMN
+-- would rewrite the table and stamp migration-time NOW() onto historical rows
+-- — falsifying history. The default applies to future inserts only.
+ALTER TABLE signal_history ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ;
+ALTER TABLE signal_history ALTER COLUMN published_at SET DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS idx_signal_history_broadcast
+  ON signal_history (broadcast_blocked, created_at DESC)
+  WHERE broadcast_blocked IS NOT NULL;


### PR DESCRIPTION
## What this is

Phase 1 of the approved engine-makeover plan (`docs/plans/2026-06-10-engine-makeover.md`): the cron now computes the regime + winning-cells + risk-pipeline decision **before** persistence and records it per row, so the Pro-broadcast subset — the strategy you actually sell — becomes measurable for the first time. This is PR #110's deferred item 1.

## What changes

**Recording (migration 048 + writer)**
- New nullable columns: `regime`, `broadcast_blocked`, `broadcast_block_reason`, `allocation_pct`, `published_at` (wall-clock, DB-defaulted for new rows only — historical rows stay NULL, no falsified backfill)
- Tri-state semantics are load-bearing: NULL = decision not recorded (pre-048 rows, pipeline-outage fallbacks), FALSE = gate ran and approved, TRUE = gate ran and blocked
- Cron re-sequenced: collect → decide once over new + catch-up signals → record with decision inline → late-stamp catch-up rows (NULL-only, never overwrites) → resolve → broadcast. The broadcast set is byte-identical to the old curated ∩ approved behavior, including the unfiltered outage fallback
- Resolution provenance (`resolvedAt` + OHLCV `source`) stamped into outcome JSON by **all three** outcome writers; cron path now persists MAE (previously discarded)

**Surfaces**
- `scope=broadcast` on /api/signals/history, /api/signals/equity, **and** /api/leaderboard (review caught the leaderboard falling through to the Pro cache — firehose stats would have rendered labeled as the gated subset)
- /track-record gains a 'Pro broadcast (gated)' tab with its own disclaimer and equity captions

**Calibration honesty fix (bonus catch)**
- The calibration API compared 0-100 stored confidence against 0-1 bucket bounds: every bucket was empty and fell back to `winRate = midpoint` — the public reliability chart rendered as **perfectly calibrated by construction**, and Brier was computed on nonsense units. Fixed: normalization, canonical `isCountedResolved` population, null (no bar) for empty buckets, nullable Brier/ECE

## Review pass (pre-push, two reviewers)

All findings fixed in the last two commits, including: allocation_pct mis-attribution when a symbol has BUY+SELL in one tick (symbol-keyed map → input-index zip), fleet-wide provenance (was cron-only), an unguarded decision-compute call that could have skipped recording entirely, conf-100 falling out of every calibration bucket, and stale parseScope test mocks that shielded the leaderboard leak.

## ⚠️ Operator actions after merge

1. Apply the migration to prod: `psql "$DATABASE_URL" -f apps/web/migrations/048_broadcast_scope.sql`
2. **Restart/redeploy the service afterward** — the columns-missing fallback flag sticks for the process lifetime; without a restart, decisions keep being dropped silently
3. ~2 weeks of data accrual before the broadcast tab shows a meaningful curve (plan gate)

## Verification

- `tsc --noEmit` clean; full suite **1117 passed, 0 failed** (18 new tests)
- Broadcast set parity with old behavior verified by review; decision lib unit-tested across approve/veto/curation/outage/regime-miss
- Known, documented limitations: `broadcast_blocked` = first recorded decision (not delivery outcome — join `telegram_pro_message_id` for that); outage-fallback rows stay NULL and are excluded from the scope (logged per tick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)