### PR TITLE
Phase 6a: honesty sweep — every public metric declares provenance + sample size

### DIFF
--- a/apps/web/app/ab-stats/ABStatsClient.tsx
+++ b/apps/web/app/ab-stats/ABStatsClient.tsx
@@ -18,32 +18,48 @@ const VARIANT_COLORS: Record<Variant, string> = {
   c: "yellow",
 };
 
+// Minimum impressions PER VARIANT before a CTR is meaningful enough to show a
+// "leading" marker. A single click on N=1 is noise, not a result; this is a
+// sample-size floor, not a statistical significance test (single-browser
+// localStorage data can never support one).
+const MIN_IMPRESSIONS = 30;
+
 export function ABStatsClient() {
   const [impressions, setImpressions] = useState<Record<Variant, number>>({ a: 0, b: 0, c: 0 });
   const [clicks, setClicks] = useState<Record<Variant, number>>({ a: 0, b: 0, c: 0 });
   const [myVariant, setMyVariant] = useState<Variant | null>(null);
+  const [since, setSince] = useState<string | null>(null);
 
   useEffect(() => {
     const imp = JSON.parse(localStorage.getItem("tc_ab_impressions") || '{"a":0,"b":0,"c":0}');
     const clk = JSON.parse(localStorage.getItem("tc_ab_clicks") || '{"a":0,"b":0,"c":0}');
     const v = localStorage.getItem("tc_ab_variant") as Variant | null;
+    const sinceRaw = localStorage.getItem("tc_ab_since");
     setTimeout(() => {
       setImpressions(imp);
       setClicks(clk);
       setMyVariant(v);
+      setSince(sinceRaw);
     }, 0);
   }, []);
 
   const totalImpressions = VARIANTS.reduce((s, v) => s + (impressions[v] || 0), 0);
   const totalClicks = VARIANTS.reduce((s, v) => s + (clicks[v] || 0), 0);
+  const sinceLabel = since
+    ? new Date(since).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+    : null;
+  // Overall CTR is only meaningful once enough impressions have accrued.
+  const overallSufficient = totalImpressions >= MIN_IMPRESSIONS;
 
   function resetStats() {
     localStorage.removeItem("tc_ab_impressions");
     localStorage.removeItem("tc_ab_clicks");
     localStorage.removeItem("tc_ab_variant");
+    localStorage.removeItem("tc_ab_since");
     setImpressions({ a: 0, b: 0, c: 0 });
     setClicks({ a: 0, b: 0, c: 0 });
     setMyVariant(null);
+    setSince(null);
   }
 
   function forceVariant(v: Variant) {
@@ -58,13 +74,20 @@ export function ABStatsClient() {
           A/B Test Dashboard
         </div>
         <h1 className="mb-2 text-3xl font-bold">Hero Variant Stats</h1>
-        <p className="mb-10 text-sm text-zinc-500">
-          Tracking impressions and GitHub CTA clicks per hero variant (localStorage only — single browser).
+        <p className="mb-3 text-sm text-zinc-500">
+          Tracking impressions and GitHub CTA clicks per hero variant
+          {sinceLabel ? <> since <span className="text-zinc-300">{sinceLabel}</span></> : null}
+          {" "}(localStorage only — single browser).
           {myVariant && (
             <span className="ml-2 text-emerald-400">
               Your variant: <strong>{myVariant.toUpperCase()}</strong>
             </span>
           )}
+        </p>
+        <p className="mb-10 inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] text-amber-400 bg-amber-500/10 border border-amber-500/25">
+          Single-browser sample, not a controlled experiment. No statistical
+          significance test — a &ldquo;leading&rdquo; marker requires only{" "}
+          {MIN_IMPRESSIONS}+ impressions on each variant and does not prove a real difference.
         </p>
 
         {/* Summary */}
@@ -79,9 +102,23 @@ export function ABStatsClient() {
           </div>
           <div className="rounded-xl border border-white/8 bg-white/3 p-4">
             <div className="text-xs text-zinc-500 mb-1">Overall CTR</div>
-            <div className="text-2xl font-bold">
-              {totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(1) : "0.0"}%
-            </div>
+            {overallSufficient ? (
+              <>
+                <div className="text-2xl font-bold">
+                  {((totalClicks / totalImpressions) * 100).toFixed(1)}%
+                </div>
+                <div className="text-[10px] font-mono text-zinc-600 mt-0.5">
+                  {totalClicks}/{totalImpressions} clicks/impr
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="text-2xl font-bold text-zinc-600">—</div>
+                <div className="text-[10px] font-mono text-amber-400/80 mt-0.5">
+                  n={totalImpressions} &lt; {MIN_IMPRESSIONS} · too few impressions
+                </div>
+              </>
+            )}
           </div>
         </div>
 
@@ -90,12 +127,23 @@ export function ABStatsClient() {
           {VARIANTS.map((v) => {
             const imp = impressions[v] || 0;
             const clk = clicks[v] || 0;
-            const ctr = imp > 0 ? ((clk / imp) * 100).toFixed(1) : "0.0";
+            const ctrSufficient = imp >= MIN_IMPRESSIONS;
+            const ctrNum = imp > 0 ? (clk / imp) * 100 : 0;
+            const ctr = ctrNum.toFixed(1);
             const color = VARIANT_COLORS[v];
-            const isWinner =
-              totalClicks > 0 &&
-              clk === Math.max(...VARIANTS.map((x) => clicks[x] || 0)) &&
-              clk > 0;
+            // "Leading" — not "winning". Only mark a leader once EVERY variant
+            // has cleared the impression floor (so the comparison is on
+            // comparable samples) and this variant has the strictly highest
+            // CTR. Ties and thin samples get no marker. This is not a
+            // significance test.
+            const allCleared = VARIANTS.every((x) => (impressions[x] || 0) >= MIN_IMPRESSIONS);
+            const variantCtr = (x: Variant) =>
+              (impressions[x] || 0) > 0 ? (clicks[x] || 0) / (impressions[x] || 0) : 0;
+            const myCtr = variantCtr(v);
+            const bestCtr = Math.max(...VARIANTS.map(variantCtr));
+            const isUniqueBest =
+              VARIANTS.filter((x) => variantCtr(x) === bestCtr).length === 1;
+            const isLeading = allCleared && myCtr > 0 && myCtr === bestCtr && isUniqueBest;
 
             return (
               <div
@@ -114,9 +162,12 @@ export function ABStatsClient() {
                       >
                         Variant {v.toUpperCase()}
                       </span>
-                      {isWinner && (
-                        <span className="rounded bg-zinc-500/20 px-1.5 py-0.5 text-[10px] font-bold text-zinc-400">
-                          WINNING
+                      {isLeading && (
+                        <span
+                          className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-bold text-amber-400 border border-amber-500/25"
+                          title={`Highest CTR with every variant past ${MIN_IMPRESSIONS}+ impressions. Not a significance test.`}
+                        >
+                          LEADING
                         </span>
                       )}
                       {myVariant === v && (
@@ -143,20 +194,32 @@ export function ABStatsClient() {
                   <div>
                     <div className="text-[10px] text-zinc-600 mb-0.5">GitHub Clicks</div>
                     <div className="text-lg font-semibold">{clk}</div>
+                    <div className="text-[10px] font-mono text-zinc-600 mt-0.5">{clk}/{imp}</div>
                   </div>
                   <div>
                     <div className="text-[10px] text-zinc-600 mb-0.5">CTR</div>
-                    <div className={`text-lg font-semibold text-${color}-400`}>{ctr}%</div>
+                    {ctrSufficient ? (
+                      <div className={`text-lg font-semibold text-${color}-400`}>{ctr}%</div>
+                    ) : (
+                      <>
+                        <div className="text-lg font-semibold text-zinc-600">—</div>
+                        <div className="text-[10px] font-mono text-amber-400/80 mt-0.5">
+                          n={imp} &lt; {MIN_IMPRESSIONS}
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
 
-                {/* CTR bar */}
-                <div className="mt-3 h-1 w-full rounded-full bg-white/5">
-                  <div
-                    className={`h-full rounded-full bg-${color}-400 transition-all duration-700`}
-                    style={{ width: `${Math.min(parseFloat(ctr) * 5, 100)}%` }}
-                  />
-                </div>
+                {/* CTR bar — only drawn once the variant clears the floor */}
+                {ctrSufficient && (
+                  <div className="mt-3 h-1 w-full rounded-full bg-white/5">
+                    <div
+                      className={`h-full rounded-full bg-${color}-400 transition-all duration-700`}
+                      style={{ width: `${Math.min(ctrNum * 5, 100)}%` }}
+                    />
+                  </div>
+                )}
               </div>
             );
           })}

--- a/apps/web/app/accuracy/AccuracyClient.tsx
+++ b/apps/web/app/accuracy/AccuracyClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Search, Check, X, Clock } from 'lucide-react';
-import { DataProvenanceBadge, getDataProvenance } from '@/components/data-provenance-badge';
+import { DataProvenanceBadge, getDataProvenanceFromCounts } from '@/components/data-provenance-badge';
 import { MetricMeta } from '@/components/metric-meta';
 import {
   isExpiredHistoricalSignal,
@@ -35,12 +35,19 @@ interface SignalRecord {
 interface Stats {
   totalSignals: number;
   resolved: number;
+  /** Live (non-simulated) row count across full filtered history. */
+  live: number;
+  /** Simulated seed-row count across full filtered history. */
+  simulated: number;
   wins: number;
   losses: number;
   winRate: number;
   totalPnlPct: number;
   avgPnlPct: number;
+  /** Avg confidence over ALL filtered records (resolved + open + simulated). */
   avgConfidence: number;
+  /** Avg confidence over the same resolved population the win-rate uses. */
+  avgConfidenceResolved: number;
 }
 
 interface APIResponse {
@@ -48,6 +55,8 @@ interface APIResponse {
   total: number;
   offset: number;
   limit: number;
+  earliestTimestamp: number | null;
+  latestTimestamp: number | null;
   stats: Stats;
 }
 
@@ -74,11 +83,25 @@ function formatPrice(price: number, pair: string): string {
   return price.toFixed(2);
 }
 
+function formatDateShort(ts: number): string {
+  return new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/** "Mar 4, 2026 – Jun 13, 2026" window label for the stat cards. */
+function formatWindow(earliest: number | null, latest: number | null): string | null {
+  if (!earliest || !latest) return null;
+  const a = formatDateShort(earliest);
+  const b = formatDateShort(latest);
+  return a === b ? a : `${a} – ${b}`;
+}
+
 /* ── Component ── */
 export function AccuracyClient() {
   const [records, setRecords] = useState<SignalRecord[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
   const [total, setTotal] = useState(0);
+  const [earliestTs, setEarliestTs] = useState<number | null>(null);
+  const [latestTs, setLatestTs] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pair, setPair] = useState('ALL');
@@ -106,6 +129,8 @@ export function AccuracyClient() {
       setRecords(data.records);
       setStats(data.stats);
       setTotal(data.total);
+      setEarliestTs(data.earliestTimestamp ?? null);
+      setLatestTs(data.latestTimestamp ?? null);
       setError(null);
     } catch (err) {
       if (id === fetchRef.current) setError(err instanceof Error ? err.message : 'Failed to load signal history');
@@ -118,9 +143,12 @@ export function AccuracyClient() {
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
+  // Provenance must reflect the FULL filtered history (live vs simulated
+  // counts from stats), not the 25-row page in `records`. A page can be
+  // all-live while the whole track record is mixed.
   const provenance = useMemo(
-    () => getDataProvenance({ records, ...(stats ?? {}) }),
-    [records, stats],
+    () => getDataProvenanceFromCounts({ live: stats?.live, simulated: stats?.simulated }),
+    [stats],
   );
 
   const openCount = useMemo(
@@ -193,27 +221,40 @@ export function AccuracyClient() {
 
       {/* Stats Cards */}
       {stats && stats.totalSignals > 0 && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <StatCard label="Total Signals" value={stats.totalSignals.toString()} />
-          <StatCard
-            label="Win Rate"
-            value={`${stats.winRate}%`}
-            color={stats.winRate >= 60 ? 'text-emerald-400' : stats.winRate >= 50 ? 'text-zinc-400' : 'text-rose-400'}
-          />
-          <StatCard
-            label="Avg P&L"
-            value={`${stats.avgPnlPct >= 0 ? '+' : ''}${stats.avgPnlPct}%`}
-            color={stats.avgPnlPct >= 0 ? 'text-emerald-400' : 'text-rose-400'}
-          />
-          <StatCard label="Avg Confidence" value={`${stats.avgConfidence}%`} />
-          <StatCard label="Wins" value={stats.wins.toString()} color="text-emerald-400" />
-          <StatCard label="Losses" value={stats.losses.toString()} color="text-rose-400" />
-          <StatCard
-            label="Total P&L"
-            value={`${stats.totalPnlPct >= 0 ? '+' : ''}${stats.totalPnlPct}%`}
-            color={stats.totalPnlPct >= 0 ? 'text-emerald-400' : 'text-rose-400'}
-          />
-          <StatCard label="Resolved" value={`${stats.resolved}/${stats.totalSignals}`} />
+        <div className="space-y-2">
+          {(() => {
+            const win = formatWindow(earliestTs, latestTs);
+            return win ? (
+              <p className="text-[10px] font-mono uppercase tracking-wider text-zinc-500">
+                Win rate, Avg P&amp;L and Total P&amp;L cover {win} · n={stats.resolved} resolved
+              </p>
+            ) : null;
+          })()}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <StatCard label="Total Signals" value={stats.totalSignals.toString()} />
+            <StatCard
+              label="Win Rate"
+              value={`${stats.winRate}%`}
+              color={stats.winRate >= 60 ? 'text-emerald-400' : stats.winRate >= 50 ? 'text-zinc-400' : 'text-rose-400'}
+            />
+            <StatCard
+              label="Avg P&L"
+              value={`${stats.avgPnlPct >= 0 ? '+' : ''}${stats.avgPnlPct}%`}
+              color={stats.avgPnlPct >= 0 ? 'text-emerald-400' : 'text-rose-400'}
+            />
+            <StatCard
+              label="Avg Confidence (resolved)"
+              value={`${stats.avgConfidenceResolved}%`}
+            />
+            <StatCard label="Wins" value={stats.wins.toString()} color="text-emerald-400" />
+            <StatCard label="Losses" value={stats.losses.toString()} color="text-rose-400" />
+            <StatCard
+              label="Total P&L"
+              value={`${stats.totalPnlPct >= 0 ? '+' : ''}${stats.totalPnlPct}%`}
+              color={stats.totalPnlPct >= 0 ? 'text-emerald-400' : 'text-rose-400'}
+            />
+            <StatCard label="Resolved" value={`${stats.resolved}/${stats.totalSignals}`} />
+          </div>
         </div>
       )}
 
@@ -325,7 +366,11 @@ export function AccuracyClient() {
           </div>
           <div className="flex justify-between mt-1">
             <span className="text-[10px] text-emerald-500 font-mono">{stats.winRate}% WIN</span>
-            <span className="text-[10px] text-rose-500 font-mono">{(100 - stats.winRate).toFixed(1)}% LOSS</span>
+            {/* Loss% from losses/resolved (not 100−winRate) so pending/expired
+                rows are not silently folded into the loss share. */}
+            <span className="text-[10px] text-rose-500 font-mono">
+              {stats.resolved > 0 ? +(stats.losses / stats.resolved * 100).toFixed(1) : 0}% LOSS
+            </span>
           </div>
         </div>
       )}
@@ -503,7 +548,10 @@ export function AccuracyClient() {
         <p className="text-xs text-zinc-500 leading-relaxed">
           Every signal is recorded at generation time with its entry price and confidence score.
           Outcomes are evaluated at 4-hour and 24-hour windows against actual price movement.
-          No cherry-picking, no hindsight edits. Self-hosted users can verify all data in{' '}
+          No cherry-picking, no hindsight edits. The hosted deployment stores this history in{' '}
+          <code className="text-emerald-500/80 bg-emerald-500/5 px-1 rounded">Postgres</code> (the{' '}
+          <code className="text-emerald-500/80 bg-emerald-500/5 px-1 rounded">signal_history</code> table);
+          self-hosted users without <code className="text-emerald-500/80 bg-emerald-500/5 px-1 rounded">DATABASE_URL</code> can verify all data in{' '}
           <code className="text-emerald-500/80 bg-emerald-500/5 px-1 rounded">data/signal-history.json</code>.
         </p>
       </div>

--- a/apps/web/app/allocation/AllocationClient.tsx
+++ b/apps/web/app/allocation/AllocationClient.tsx
@@ -123,6 +123,21 @@ export function AllocationClient() {
   const currentExposure = portfolioSnapshot?.grossExposurePct ?? null;
   const headroom = currentExposure !== null ? +(maxExposureNum - currentExposure).toFixed(1) : null;
 
+  // Regime freshness — most recent classification timestamp across symbols and
+  // how many symbols were classified, so the "Active Regime" figure shows when
+  // and over how many symbols it was detected rather than reading as live.
+  const classifiedCount = regimeData.length;
+  const latestDetectedAt = regimeData.reduce<string | null>((latest, e) => {
+    if (!e.detectedAt) return latest;
+    if (!latest || e.detectedAt > latest) return e.detectedAt;
+    return latest;
+  }, null);
+  const detectedAtLabel = latestDetectedAt
+    ? new Date(latestDetectedAt).toLocaleString('en-US', {
+        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+      })
+    : null;
+
   return (
     <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)] pb-20 md:pb-8">
       <div className="max-w-6xl mx-auto px-4 pt-24 pb-6">
@@ -157,11 +172,21 @@ export function AllocationClient() {
               <p className="text-2xl font-bold" style={{ color: REGIME_COLORS[dominant].color }}>
                 {dominant.charAt(0).toUpperCase() + dominant.slice(1)}
               </p>
+              <p className="text-[10px] text-[var(--text-secondary)] mt-1 font-mono">
+                {classifiedCount} symbol{classifiedCount === 1 ? '' : 's'} classified
+                {detectedAtLabel ? ` · detected ${detectedAtLabel}` : ''}
+              </p>
             </div>
             <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-card)] p-5">
-              <div className="flex items-center gap-2 mb-2">
+              <div className="flex flex-wrap items-center gap-2 mb-2">
                 <ShieldCheck className="w-4 h-4 text-[var(--text-secondary)]" />
                 <span className="text-xs font-medium text-[var(--text-secondary)] uppercase tracking-wider">Current Exposure</span>
+                <span
+                  className="inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-400 bg-amber-500/10 border border-amber-500/25"
+                  title="These exposure figures come from a paper-trading demo account, not real capital."
+                >
+                  Paper / demo account
+                </span>
               </div>
               <p className="text-2xl font-bold text-[var(--foreground)]">
                 {currentExposure === null ? 'N/A' : `${currentExposure.toFixed(1)}%`}
@@ -180,9 +205,15 @@ export function AllocationClient() {
               </p>
             </div>
             <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-card)] p-5">
-              <div className="flex items-center gap-2 mb-2">
+              <div className="flex flex-wrap items-center gap-2 mb-2">
                 <TrendingUp className="w-4 h-4 text-[var(--text-secondary)]" />
                 <span className="text-xs font-medium text-[var(--text-secondary)] uppercase tracking-wider">Headroom</span>
+                <span
+                  className="inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-400 bg-amber-500/10 border border-amber-500/25"
+                  title="Headroom is derived from the paper-trading demo account exposure, not real capital."
+                >
+                  Paper / demo account
+                </span>
               </div>
               <p className={`text-2xl font-bold ${headroom === null ? 'text-[var(--foreground)]' : headroom > 0 ? 'text-emerald-400' : 'text-rose-400'}`}>
                 {headroom === null ? 'N/A' : `${headroom.toFixed(1)}%`}
@@ -199,7 +230,15 @@ export function AllocationClient() {
         {/* Allocation rules table */}
         <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-card)] overflow-hidden mb-8">
           <div className="px-5 py-4 border-b border-[var(--border)]">
-            <h2 className="text-sm font-semibold text-[var(--foreground)] uppercase tracking-wider">Allocation Rules by Regime</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-sm font-semibold text-[var(--foreground)] uppercase tracking-wider">Allocation Rules by Regime</h2>
+              <span
+                className="inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-400 bg-amber-500/10 border border-amber-500/25"
+                title="Static display mirror of the engine's REGIME_ALLOCATION_RULES (packages/signals/src/allocation/regime-rules.ts). Not fetched live — kept in sync manually."
+              >
+                Policy rules — not fetched live from the engine
+              </span>
+            </div>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -261,7 +300,14 @@ export function AllocationClient() {
         {/* Per-symbol allocation */}
         {!loading && regimeData.length > 0 && (
           <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-card)] p-5">
-            <h2 className="text-sm font-semibold text-[var(--foreground)] mb-4 uppercase tracking-wider">Per-Symbol Regime Allocation</h2>
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+              <h2 className="text-sm font-semibold text-[var(--foreground)] uppercase tracking-wider">Per-Symbol Regime Allocation</h2>
+              <span className="text-[10px] font-mono text-[var(--text-secondary)]">
+                {classifiedCount} symbol{classifiedCount === 1 ? '' : 's'} classified
+                {detectedAtLabel ? ` · detected ${detectedAtLabel}` : ''}
+                {' · Max pos / Dir are policy rules, not live engine values'}
+              </span>
+            </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
               {regimeData.map((entry) => {
                 const regime = normalizeRegime(entry.regime);

--- a/apps/web/app/api/calibration/__tests__/route.test.ts
+++ b/apps/web/app/api/calibration/__tests__/route.test.ts
@@ -110,10 +110,54 @@ describe('GET /api/calibration', () => {
     expect(body.totalSignals).toBe(0);
     expect(body.brier).toBeNull();
     expect(body.ece).toBeNull();
-    expect(body.isSimulated).toBe(true);
+    // The route filters out simulated rows, so it NEVER serves a simulated
+    // population — isSimulated is always false here. An empty/thin real
+    // population is flagged insufficientData, not mislabeled as simulated.
+    expect(body.isSimulated).toBe(false);
+    expect(body.insufficientData).toBe(true);
     for (const b of body.buckets) {
       expect(b.winRate).toBeNull();
     }
+  });
+
+  it('flags real-but-thin data as insufficient (not simulated) and surfaces the window', async () => {
+    // 2 real counted rows — below the 20-signal stability floor.
+    const t0 = 1_700_000_000_000;
+    mockedHistory.mockResolvedValue([
+      mkRecord({ id: 'a', confidence: 72, timestamp: t0 }),
+      mkRecord({
+        id: 'b',
+        confidence: 85,
+        timestamp: t0 + 3_600_000,
+        outcomes: { '4h': null, '24h': { price: 49500, pnlPct: -1.0, hit: false, target: 'SL' } },
+      }),
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.totalSignals).toBe(2);
+    expect(body.isSimulated).toBe(false);
+    expect(body.insufficientData).toBe(true);
+    expect(body.minStableSignals).toBe(20);
+    // Date range covering the resolved population.
+    expect(body.windowStart).toBe(t0);
+    expect(body.windowEnd).toBe(t0 + 3_600_000);
+  });
+
+  it('does not flag insufficientData once the population reaches the stability floor', async () => {
+    const base = 1_700_000_000_000;
+    const rows = Array.from({ length: 20 }, (_, i) =>
+      mkRecord({ id: `row-${i}`, confidence: 72, timestamp: base + i * 60_000 }),
+    );
+    mockedHistory.mockResolvedValue(rows);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.totalSignals).toBe(20);
+    expect(body.isSimulated).toBe(false);
+    expect(body.insufficientData).toBe(false);
   });
 
   // ── Phase 4 D7 — additive reported calibration curves ──────────────

--- a/apps/web/app/api/calibration/route.ts
+++ b/apps/web/app/api/calibration/route.ts
@@ -21,6 +21,11 @@ interface CalibrationBucket {
   calibrationError: number | null;
 }
 
+// Below this many counted-resolved signals the per-bucket win-rates are too
+// noisy to read as a stable calibration. Real data under this floor is
+// "insufficient", not "simulated" — the distinction the UI surfaces.
+const MIN_STABLE_CALIBRATION_SIGNALS = 20;
+
 const BUCKETS = [
   { label: '50-59%', confMin: 0.50, confMax: 0.60, midpoint: 0.545 },
   { label: '60-69%', confMin: 0.60, confMax: 0.70, midpoint: 0.645 },
@@ -73,6 +78,12 @@ export async function GET() {
     const totalWins = resolved.filter((s) => s.outcomes['24h']?.hit).length;
     const overallAccuracy = totalSignals > 0 ? totalWins / totalSignals : 0;
 
+    // Date range of the resolved population the metrics cover. Null when empty
+    // so the UI can omit the window rather than render an invalid range.
+    const timestamps = resolved.map((s) => s.timestamp);
+    const windowStart = timestamps.length ? Math.min(...timestamps) : null;
+    const windowEnd = timestamps.length ? Math.max(...timestamps) : null;
+
     // Brier score: mean((conf - outcome)^2) on the 0-1 scale.
     const brier = totalSignals > 0
       ? resolved.reduce((sum, s) => {
@@ -105,11 +116,21 @@ export async function GET() {
       })),
     );
 
+    // This route NEVER serves simulated rows — isCountedResolved already
+    // excludes `isSimulated` history. So server-side isSimulated is always
+    // false; the genuine simulated/demo case lives only in the client
+    // catch-block fallback. A real-but-thin population (1–19 counted, or 0)
+    // is flagged `insufficientData`, NOT mislabeled as simulated, so the UI
+    // can say "insufficient live data (N=n)" instead of "demo data".
     return NextResponse.json({
       buckets,
       overallAccuracy,
       totalSignals,
-      isSimulated: totalSignals < 20,
+      isSimulated: false,
+      insufficientData: totalSignals < MIN_STABLE_CALIBRATION_SIGNALS,
+      minStableSignals: MIN_STABLE_CALIBRATION_SIGNALS,
+      windowStart,
+      windowEnd,
       brier,
       ece,
       calibration,

--- a/apps/web/app/api/consensus/route.ts
+++ b/apps/web/app/api/consensus/route.ts
@@ -17,7 +17,7 @@ export interface ConsensusEntry {
   dominantDirection: 'BUY' | 'SELL' | 'NEUTRAL';
   avgBuyConfidence: number;
   avgSellConfidence: number;
-  trend24h: 'UP' | 'DOWN' | 'FLAT'; // vs 24h prior snapshot
+  trend24h: 'UP' | 'DOWN' | 'FLAT'; // ESTIMATED — derived from pair + current hour + buyRatio, NOT a measured 24h price change. Rendered with an "est." marker on the client.
   source: 'live' | 'synthetic'; // whether data comes from real signals or is algorithmically generated
 }
 
@@ -38,7 +38,9 @@ const CONSENSUS_PAIRS = [
   'GBPUSD', 'USDJPY', 'GBPJPY', 'AUDUSD', 'USDCAD',
 ];
 
-// Simulate 24h trend with deterministic logic based on current hour
+// ESTIMATED indicator — NOT a measured 24h price change. Deterministically
+// derived from the pair's char codes, the current hour, and the live buyRatio.
+// The client renders this with a visible "est." marker (honesty contract rule 7).
 function getTrend24h(pair: string, buyRatio: number): 'UP' | 'DOWN' | 'FLAT' {
   const hourSeed = new Date().getHours();
   const hash = (pair.charCodeAt(0) * 7 + pair.charCodeAt(1) * 13 + hourSeed) % 3;

--- a/apps/web/app/api/og/track-record/route.tsx
+++ b/apps/web/app/api/og/track-record/route.tsx
@@ -66,7 +66,7 @@ export async function GET() {
         </div>
 
         <div style={{ fontSize: '22px', color: '#10b981', letterSpacing: '0.12em', marginBottom: '40px' }}>
-          VERIFIED TRACK RECORD — 30 DAYS
+          RECORDED TRACK RECORD — 30 DAYS
         </div>
 
         {/* Stats row */}
@@ -89,7 +89,7 @@ export async function GET() {
 
         {/* Footer */}
         <div style={{ color: '#3f3f46', fontSize: '14px', letterSpacing: '0.05em' }}>
-          tradeclaw.win/track-record — open-source, transparent, verifiable
+          tradeclaw.win/track-record — open-source, transparent, resolved against Binance/Yahoo OHLCV
         </div>
       </div>
     ),

--- a/apps/web/app/api/og/track-record/route.tsx
+++ b/apps/web/app/api/og/track-record/route.tsx
@@ -1,25 +1,23 @@
 import { ImageResponse } from 'next/og';
-import { query } from '../../../../lib/db-pool';
+import { computeTrackRecordStats } from '../../../../lib/track-record-stats';
 
 export const runtime = 'nodejs';
 
 export async function GET() {
-  const rows = await query<{ total: string; wins: string; win_rate: string; total_pnl: string }>(`
-    SELECT
-      COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL)::text AS total,
-      COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::text AS wins,
-      CASE WHEN COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) > 0
-        THEN ROUND(COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::numeric
-          / COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) * 100, 1)::text
-        ELSE '0' END AS win_rate,
-      COALESCE(ROUND(SUM((outcome_24h->>'pnlPct')::numeric) FILTER (WHERE outcome_24h IS NOT NULL), 2)::text, '0') AS total_pnl
-    FROM signal_history
-    WHERE is_simulated = false AND created_at >= NOW() - INTERVAL '30 days'
-  `);
-
-  const s = rows[0] ?? { total: '0', wins: '0', win_rate: '0', total_pnl: '0' };
-  const pnl = Number(s.total_pnl);
+  // Same resolved-signal logic the page body + /api/signals/equity use:
+  // excludes auto-expired, gate-blocked, and simulated rows. The prior raw
+  // `outcome_24h IS NOT NULL` SQL folded those in, so the card showed a lower
+  // win-rate and different P&L than the page under the same banner. Honesty
+  // contract: surfaces sharing a metric for the same window must compute it
+  // the same way.
+  const stats = await computeTrackRecordStats('all');
+  const pnl = stats.totalPnl;
   const pnlColor = pnl >= 0 ? '#10b981' : '#f43f5e';
+  const s = {
+    total: stats.total.toString(),
+    win_rate: stats.winRate.toString(),
+    total_pnl: stats.totalPnl.toFixed(2),
+  };
 
   return new ImageResponse(
     (

--- a/apps/web/app/api/signals/history/__tests__/route.test.ts
+++ b/apps/web/app/api/signals/history/__tests__/route.test.ts
@@ -129,6 +129,26 @@ describe('GET /api/signals/history category filtering', () => {
     expect(body.stats.resolved).toBe(0);
   });
 
+  it('splits live vs simulated over full history, not the page slice', async () => {
+    primeSlice([
+      record({ id: 'live-1', pair: 'BTCUSD', isSimulated: false }),
+      record({ id: 'live-2', pair: 'ETHUSD', isSimulated: false }),
+      record({ id: 'seed-1', pair: 'SOLUSD', isSimulated: true }),
+    ]);
+
+    // limit=1 paginates so only one row is on the page; provenance counts must
+    // still reflect all three rows (the bug this fixes mislabeled a clean page).
+    const res = await GET(makeReq('/api/signals/history?limit=1'));
+    const body = await res.json();
+
+    expect(body.records).toHaveLength(1);
+    expect(body.stats.totalSignals).toBe(3);
+    expect(body.stats.live).toBe(2);
+    expect(body.stats.simulated).toBe(1);
+    expect(typeof body.latestTimestamp).toBe('number');
+    expect(typeof body.stats.avgConfidenceResolved).toBe('number');
+  });
+
   it('returns only thematic records for category=thematic', async () => {
     primeSlice([
       record({ id: 'btc-1', pair: 'BTCUSD' }),

--- a/apps/web/app/api/signals/history/route.ts
+++ b/apps/web/app/api/signals/history/route.ts
@@ -153,9 +153,28 @@ export async function GET(request: NextRequest) {
       : slice.resolved;
     const wins = resolved.filter(r => r.outcomes['24h']!.hit);
     const totalPnl = resolved.reduce((sum, r) => sum + (r.outcomes['24h']?.pnlPct ?? 0), 0);
+    // avgConfidence is over ALL filtered records; avgConfidenceResolved is over
+    // the same resolved population the win-rate uses, so the UI can state which
+    // denominator a confidence figure is on instead of silently mixing them.
     const avgConfidence = records.length > 0
       ? records.reduce((sum, r) => sum + r.confidence, 0) / records.length
       : 0;
+    const avgConfidenceResolved = resolved.length > 0
+      ? resolved.reduce((sum, r) => sum + r.confidence, 0) / resolved.length
+      : 0;
+
+    // Full-history provenance split (live vs simulated seed rows) over the
+    // entire filtered set — NOT the paginated page — so the data-provenance
+    // badge reflects the whole track record, not whichever 25 rows are visible.
+    const simulatedCount = records.filter(r => r.isSimulated).length;
+    const liveCount = records.length - simulatedCount;
+
+    // Window the stat cards cover: earliest comes from the scope-level slice
+    // (pre-period) so it matches the disabled-period UI; latest is the newest
+    // row in the filtered view.
+    const latestTimestamp = records.length > 0
+      ? records.reduce((max, r) => (r.timestamp > max ? r.timestamp : max), records[0].timestamp)
+      : null;
 
     // Excluded buckets — surfaced for transparency, not folded into win-rate.
     // Pending is intentionally age-aware: once a trade has crossed the 24h
@@ -216,9 +235,12 @@ export async function GET(request: NextRequest) {
       scope,
       category,
       earliestTimestamp: slice.earliestTimestamp,
+      latestTimestamp,
       stats: {
         totalSignals: records.length,
         resolved: resolved.length,
+        simulated: simulatedCount,
+        live: liveCount,
         expired,
         gateBlocked,
         pending,
@@ -228,6 +250,7 @@ export async function GET(request: NextRequest) {
         totalPnlPct: +totalPnl.toFixed(2),
         avgPnlPct: resolved.length > 0 ? +(totalPnl / resolved.length).toFixed(2) : 0,
         avgConfidence: +avgConfidence.toFixed(1),
+        avgConfidenceResolved: +avgConfidenceResolved.toFixed(1),
         bestSignal,
         streak,
       },

--- a/apps/web/app/benchmark/BenchmarkClient.tsx
+++ b/apps/web/app/benchmark/BenchmarkClient.tsx
@@ -19,6 +19,7 @@ import {
   Copy,
   Check,
 } from 'lucide-react';
+import { StarsWidget } from '../../components/stars-widget';
 
 /* ------------------------------------------------------------------ */
 /*  Data                                                               */
@@ -46,6 +47,11 @@ const VPS_OPTIONS = [
 ];
 
 const MAX_MONTHLY = Math.max(...SAAS_OPTIONS.map((s) => s.monthlyUSD));
+
+// Competitor SaaS / VPS prices are hand-collected list prices that vendors
+// change frequently. Date-stamp them so the page never asserts a stale figure
+// as current fact (Phase 6a honesty contract §5/§6).
+const PRICES_AS_OF = 'June 2026';
 
 type Support = true | false | 'partial';
 
@@ -184,9 +190,9 @@ export default function BenchmarkClient() {
   const savings = saasAnnual;
   const freeVPSMonths = savings > 0 ? Math.round(savings / 4) : 0;
 
-  const tweetText = `I just found out I can replace my $${saas.monthlyUSD}/mo ${saas.name} subscription with TradeClaw — free, open-source, self-hosted on a $4/mo VPS.\n\nThat saves me $${Math.round(saasAnnual)}/year.\n\nhttps://github.com/naimkatiman/tradeclaw\n\n#selfhosted #algotrading #opensource`;
+  const tweetText = `TradeClaw is a free, open-source, self-hosted alternative to ${saas.name} — it runs on a $4/mo VPS.\n\nBased on ${saas.name}'s listed $${saas.monthlyUSD}/mo plan, that's about $${Math.round(saasAnnual)}/year you could keep.\n\nhttps://github.com/naimkatiman/tradeclaw\n\n#selfhosted #algotrading #opensource`;
 
-  const redditText = `I just replaced my $${saas.monthlyUSD}/mo ${saas.name} subscription with TradeClaw — a free, open-source, self-hosted trading platform.\n\nIt runs on a $4/mo VPS (Hetzner) or even Oracle Cloud Free Tier. Saves me $${Math.round(saasAnnual)}/year.\n\nFeatures: live signals, backtesting, custom indicators, Telegram bot, Docker deploy.\n\ngithub.com/naimkatiman/tradeclaw`;
+  const redditText = `TradeClaw is a free, open-source, self-hosted trading platform — an alternative to ${saas.name}.\n\nIt runs on a $4/mo VPS (Hetzner) or even Oracle Cloud Free Tier. Based on ${saas.name}'s listed $${saas.monthlyUSD}/mo plan, that's roughly $${Math.round(saasAnnual)}/year of subscription you could avoid.\n\nFeatures: live signals, backtesting, custom indicators, Telegram bot, Docker deploy.\n\ngithub.com/naimkatiman/tradeclaw`;
 
   const handleShare = useCallback(() => {
     const tweet = encodeURIComponent(tweetText);
@@ -202,7 +208,7 @@ export default function BenchmarkClient() {
           Self-hosting cost analysis
         </div>
         <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
-          Stop Paying <span className="text-rose-400">$200/mo</span> for Trading Tools
+          Stop Paying <span className="text-rose-400">up to ~$108/mo</span> for Trading Tools
         </h1>
         <p className="text-[var(--text-secondary)] text-lg max-w-2xl mx-auto mb-8">
           TradeClaw is free, open-source, and runs on a <span className="text-emerald-400 font-semibold">$4/mo VPS</span>.
@@ -217,16 +223,23 @@ export default function BenchmarkClient() {
           <div className="glass rounded-2xl px-6 py-4 border border-rose-500/20 bg-gradient-to-br from-rose-500/5 to-transparent text-center">
             <div className="text-3xl font-black text-rose-400">${avgSaaS}</div>
             <div className="text-xs text-[var(--text-secondary)]">Average SaaS / mo</div>
+            <div className="text-[10px] text-[var(--text-secondary)]/70 mt-0.5">mean of {SAAS_OPTIONS.length} curated plans</div>
           </div>
         </div>
+        <p className="mt-4 text-[11px] text-[var(--text-secondary)]/70">
+          Highest single plan shown below is ${MAX_MONTHLY}/mo. Competitor prices are list prices as of {PRICES_AS_OF} — verify current pricing on each vendor&apos;s site.
+        </p>
       </section>
 
       {/* ── Animated Cost Comparison ── */}
       <section ref={barsRef} className="glass rounded-3xl p-6 md:p-8 border border-[var(--border)] mb-8">
-        <h2 className="text-lg font-semibold mb-6 flex items-center gap-2">
+        <h2 className="text-lg font-semibold mb-2 flex items-center gap-2">
           <TrendingDown className="w-4 h-4 text-rose-400" />
           Monthly Cost Comparison
         </h2>
+        <p className="text-[11px] text-[var(--text-secondary)]/70 mb-5">
+          List prices as of {PRICES_AS_OF}. Plans and pricing change often — verify current rates with each vendor.
+        </p>
         <div className="space-y-4">
           {SAAS_OPTIONS.map((s, i) => (
             <div key={s.id}>
@@ -340,10 +353,13 @@ export default function BenchmarkClient() {
 
       {/* ── VPS Options Table ── */}
       <section className="glass rounded-2xl p-6 border border-[var(--border)] mb-8 overflow-x-auto">
-        <h2 className="text-sm font-semibold mb-4 flex items-center gap-2">
+        <h2 className="text-sm font-semibold mb-1 flex items-center gap-2">
           <Server className="w-4 h-4 text-emerald-400" />
           Recommended VPS Providers
         </h2>
+        <p className="text-[11px] text-[var(--text-secondary)]/70 mb-4">
+          Provider pricing and free-tier terms as of {PRICES_AS_OF} — verify current plans before signing up.
+        </p>
         <table className="w-full text-sm min-w-[520px]">
           <thead>
             <tr className="border-b border-[var(--border)]">
@@ -381,10 +397,13 @@ export default function BenchmarkClient() {
 
       {/* ── Feature Comparison Table ── */}
       <section className="glass rounded-2xl p-6 border border-[var(--border)] mb-8 overflow-x-auto">
-        <h2 className="text-sm font-semibold mb-4 flex items-center gap-2">
+        <h2 className="text-sm font-semibold mb-1 flex items-center gap-2">
           <Zap className="w-4 h-4 text-emerald-400" />
           Feature Comparison
         </h2>
+        <p className="text-[11px] text-[var(--text-secondary)]/70 mb-4">
+          Feature availability is plan-dependent and reflects a point-in-time snapshot as of {PRICES_AS_OF}. Monthly costs are list prices for the plans named above — verify current tiers with each vendor.
+        </p>
         <table className="w-full text-sm min-w-[640px]">
           <thead>
             <tr className="border-b border-[var(--border)]">
@@ -419,10 +438,13 @@ export default function BenchmarkClient() {
 
       {/* ── Social Proof Kit ── */}
       <section className="glass rounded-3xl p-6 md:p-8 border border-emerald-500/20 bg-gradient-to-br from-emerald-500/5 via-transparent to-zinc-500/5 mb-8">
-        <h2 className="text-lg font-semibold mb-6 flex items-center justify-center gap-2">
+        <h2 className="text-lg font-semibold mb-2 flex items-center justify-center gap-2">
           <Share2 className="w-4 h-4 text-emerald-400" />
           Social Proof Kit
         </h2>
+        <p className="text-center text-[11px] text-[var(--text-secondary)]/70 mb-6">
+          Savings figures are based on the selected vendor&apos;s listed plan price ({PRICES_AS_OF}), not an audited personal claim. Edit before posting.
+        </p>
 
         <div className="grid md:grid-cols-2 gap-4 mb-6">
           {/* Pre-written tweet */}
@@ -536,11 +558,14 @@ export default function BenchmarkClient() {
         <div className="glass rounded-2xl p-6 border border-zinc-500/20 bg-gradient-to-br from-zinc-500/5 to-transparent">
           <h3 className="font-semibold mb-2 flex items-center gap-2">
             <Star className="w-4 h-4 text-zinc-400 fill-zinc-400" />
-            Join 1,000-star mission
+            Help us grow on GitHub
           </h3>
-          <p className="text-xs text-[var(--text-secondary)] mb-4">
+          <p className="text-xs text-[var(--text-secondary)] mb-3">
             Free, open-source, self-hostable. A GitHub star costs nothing and helps more developers find TradeClaw.
           </p>
+          <div className="mb-4">
+            <StarsWidget />
+          </div>
           <Link
             href="https://github.com/naimkatiman/tradeclaw"
             target="_blank"

--- a/apps/web/app/calibration/CalibrationClient.tsx
+++ b/apps/web/app/calibration/CalibrationClient.tsx
@@ -18,10 +18,48 @@ interface CalibrationData {
   buckets: CalibrationBucket[];
   overallAccuracy: number;
   totalSignals: number;
+  /** True ONLY for the synthetic catch-block fallback (live fetch failed). */
   isSimulated: boolean;
+  /** Real but below the stability floor (1–19 counted, or 0). NOT simulated. */
+  insufficientData?: boolean;
+  /** Signal count needed before calibration is treated as stable. */
+  minStableSignals?: number;
+  /** Epoch ms of the earliest / latest resolved signal in the window. */
+  windowStart?: number | null;
+  windowEnd?: number | null;
   brier: number | null;    // Brier score (lower is better, 0.25 = random); null with no data
   ece: number | null;      // Expected Calibration Error; null with no data
   updatedAt: string;
+}
+
+/** "Mon D, YYYY – Mon D, YYYY" window stamp, or null when no range exists. */
+function formatWindow(start?: number | null, end?: number | null): string | null {
+  if (start == null || end == null) return null;
+  const fmt = (ts: number) =>
+    new Date(ts).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  const s = fmt(start);
+  const e = fmt(end);
+  return s === e ? s : `${s} – ${e}`;
+}
+
+/** Prominent per-card "DEMO" badge for the synthetic-fallback case. */
+function DemoBadge({ show }: { show: boolean }) {
+  if (!show) return null;
+  return (
+    <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-300">
+      Demo
+    </span>
+  );
+}
+
+/** Window footer under each stat card: the date range the metric covers, or
+ * a "simulated" marker when the values are the demo fallback (no real range). */
+function CardWindow({ label, simulated }: { label: string | null; simulated: boolean }) {
+  if (simulated) {
+    return <div className="text-[10px] text-amber-400/70 mt-1">simulated — no real window</div>;
+  }
+  if (!label) return null;
+  return <div className="text-[10px] text-zinc-600 mt-1">{label}</div>;
 }
 
 function CalibrationChart({ buckets }: { buckets: CalibrationBucket[] }) {
@@ -181,7 +219,10 @@ export function CalibrationClient() {
         buckets,
         overallAccuracy: 0.700,
         totalSignals: 100,
+        // Genuine synthetic fallback: the live fetch failed, these are
+        // hand-authored demo values — NOT thin real data.
         isSimulated: true,
+        insufficientData: false,
         brier: 0.21,
         ece: 0.038,
         updatedAt: new Date().toISOString(),
@@ -204,6 +245,13 @@ export function CalibrationClient() {
 
   const wellCalibrated = data.ece !== null && data.ece < 0.05;
   const briferScore = data.brier === null ? '—' : data.brier < 0.20 ? 'Excellent' : data.brier < 0.25 ? 'Good' : 'Fair';
+  // Two distinct provenance states, never conflated:
+  //  - isSimulated: hand-authored demo values (live fetch failed)
+  //  - insufficientData: REAL data, but below the stability floor (1–19 or 0)
+  const isSimulated = data.isSimulated;
+  const insufficientData = !isSimulated && (data.insufficientData ?? false);
+  const minStableSignals = data.minStableSignals ?? 20;
+  const windowLabel = formatWindow(data.windowStart, data.windowEnd);
 
   return (
     <div className="min-h-screen bg-zinc-950 text-white pb-24 md:pb-8">
@@ -239,38 +287,71 @@ export function CalibrationClient() {
           </div>
         </div>
 
-        {/* Simulated warning */}
-        {data.isSimulated && (
-          <div className="bg-zinc-500/10 border border-zinc-500/30 rounded-xl p-4 flex gap-3 text-sm">
-            <AlertCircle className="w-5 h-5 text-zinc-400 shrink-0 mt-0.5" />
+        {/* Genuine simulated fallback — live data unavailable, values are demo. */}
+        {isSimulated && (
+          <div className="bg-amber-500/10 border border-amber-500/40 rounded-xl p-4 flex gap-3 text-sm">
+            <AlertCircle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
             <div>
-              <p className="text-zinc-300 font-medium">Demo data</p>
-              <p className="text-zinc-400/80 mt-0.5">These results are based on simulated signal history. As live signals accumulate, this page will reflect real forward-performance data.</p>
+              <p className="text-amber-300 font-semibold">Simulated / demo data — not measured</p>
+              <p className="text-amber-200/80 mt-0.5">Live calibration data is unavailable, so these are hand-authored demo values. They do not reflect real signal outcomes.</p>
             </div>
           </div>
         )}
 
-        {/* Stats row */}
+        {/* Real-but-thin data — NOT simulated, just below the stability floor. */}
+        {insufficientData && (
+          <div className="bg-zinc-500/10 border border-zinc-500/30 rounded-xl p-4 flex gap-3 text-sm">
+            <AlertCircle className="w-5 h-5 text-zinc-400 shrink-0 mt-0.5" />
+            <div>
+              <p className="text-zinc-300 font-medium">
+                Insufficient live data (N={data.totalSignals}) — needs ≥{minStableSignals} for stable calibration
+              </p>
+              <p className="text-zinc-400/80 mt-0.5">
+                These are real tracked-signal outcomes, but the sample is still too small for the per-bucket win-rates to be stable. The numbers will firm up as more signals resolve.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Stats row. Each card carries a prominent DEMO badge when the values
+            are the synthetic fallback (so a card seen out of context is never
+            mistaken for measured data), plus the window the metrics cover. */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-            <div className="text-xs text-zinc-400 mb-1">Total Signals</div>
+            <div className="flex items-center justify-between mb-1">
+              <div className="text-xs text-zinc-400">Total Signals</div>
+              <DemoBadge show={isSimulated} />
+            </div>
             <div className="text-2xl font-bold text-white">{data.totalSignals}</div>
+            <CardWindow label={windowLabel} simulated={isSimulated} />
           </div>
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-            <div className="text-xs text-zinc-400 mb-1">Overall Win Rate</div>
+            <div className="flex items-center justify-between mb-1">
+              <div className="text-xs text-zinc-400">Overall Win Rate</div>
+              <DemoBadge show={isSimulated} />
+            </div>
             <div className="text-2xl font-bold text-emerald-400">{(data.overallAccuracy * 100).toFixed(1)}%</div>
+            <CardWindow label={windowLabel} simulated={isSimulated} />
           </div>
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-            <div className="text-xs text-zinc-400 mb-1">Brier Score</div>
+            <div className="flex items-center justify-between mb-1">
+              <div className="text-xs text-zinc-400">Brier Score</div>
+              <DemoBadge show={isSimulated} />
+            </div>
             <div className="text-2xl font-bold text-white">{data.brier !== null ? data.brier.toFixed(3) : '—'}</div>
             <div className="text-xs text-zinc-500 mt-0.5">{briferScore} · lower is better</div>
+            <CardWindow label={windowLabel} simulated={isSimulated} />
           </div>
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-            <div className="text-xs text-zinc-400 mb-1">Calibration Error</div>
+            <div className="flex items-center justify-between mb-1">
+              <div className="text-xs text-zinc-400">Calibration Error</div>
+              <DemoBadge show={isSimulated} />
+            </div>
             <div className={`text-2xl font-bold ${wellCalibrated ? 'text-emerald-400' : 'text-zinc-400'}`}>
               {data.ece !== null ? `${(data.ece * 100).toFixed(1)}%` : '—'}
             </div>
             <div className="text-xs text-zinc-500 mt-0.5">ECE · {wellCalibrated ? 'well calibrated' : 'needs tuning'}</div>
+            <CardWindow label={windowLabel} simulated={isSimulated} />
           </div>
         </div>
 
@@ -304,11 +385,14 @@ export function CalibrationClient() {
 
         {/* Bucket breakdown table */}
         <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-zinc-800">
+          <div className="px-5 py-4 border-b border-zinc-800 flex items-center justify-between gap-2">
             <h2 className="text-sm font-semibold flex items-center gap-2">
               <TrendingUp className="w-4 h-4 text-emerald-400" />
               Bucket Breakdown
             </h2>
+            <span className="text-[11px] text-zinc-500">
+              {isSimulated ? 'simulated — no real window' : windowLabel ?? 'no resolved signals yet'}
+            </span>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -375,7 +459,13 @@ export function CalibrationClient() {
             <p><strong className="text-zinc-300">Outcome definition:</strong> A signal is a &quot;win&quot; if price hits Take Profit 1 before Stop Loss within 24 hours of signal generation.</p>
             <p><strong className="text-zinc-300">Brier Score:</strong> Mean squared error between confidence (0-1) and outcome (0 or 1). Score of 0 = perfect, 0.25 = random, 1.0 = perfectly wrong.</p>
             <p><strong className="text-zinc-300">ECE (Expected Calibration Error):</strong> Weighted average of the difference between predicted confidence and actual win rate across buckets. Below 5% is considered well-calibrated.</p>
-            <p><strong className="text-zinc-300">Data source:</strong> {data.isSimulated ? 'Simulated seed data until sufficient live signals accumulate.' : 'Live tracked signals from the TradeClaw signal engine.'}</p>
+            <p><strong className="text-zinc-300">Data source:</strong> {
+              isSimulated
+                ? 'Simulated demo values — live calibration data is currently unavailable.'
+                : insufficientData
+                  ? `Live tracked signals from the TradeClaw signal engine (N=${data.totalSignals} — below the ${minStableSignals}-signal floor for stable calibration).`
+                  : 'Live tracked signals from the TradeClaw signal engine.'
+            }</p>
           </div>
         </div>
 

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -101,7 +101,7 @@ function drawChart(
     ctx.font = '12px monospace';
     ctx.textAlign = 'center';
     ctx.fillText(
-      'Performance tracking will begin once signals are recorded and verified',
+      'Performance tracking will begin once signals are recorded and resolved',
       w / 2,
       midY + 24,
     );
@@ -397,8 +397,8 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
           <p className="text-[11px] text-zinc-600 mt-0.5">
             {isPro
               ? summary
-                ? `Full Pro track record. ${summary.riskPerTradePct}% risk per trade, fixed-fractional${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R per trade` : ''}, after ${summary.roundTripCostPct}% round-trip costs. Verified against real market data.`
-                : 'Full Pro track record. Verified against real market data.'
+                ? `Full Pro track record. ${summary.riskPerTradePct}% risk per trade, fixed-fractional${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R per trade` : ''}, after ${summary.roundTripCostPct}% round-trip costs. Resolved against Binance/Yahoo OHLCV.`
+                : 'Full Pro track record. Resolved against Binance/Yahoo OHLCV.'
               : isBroadcast
                 ? summary
                   ? `Gate-approved broadcast subset — decisions recorded since 2026-06-10. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after ${summary.roundTripCostPct}% round-trip costs.`

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -367,6 +367,19 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
     ? +(HYPOTHETICAL_START * (1 + summary.totalReturn / 100)).toFixed(0)
     : HYPOTHETICAL_START;
 
+  // Distinct UTC calendar days the Sharpe is computed over. Each point is one
+  // sized trade; Sharpe buckets these by day, so the honest N for a daily-
+  // bucketed annualized Sharpe is the day count, not the trade count. A 5-day
+  // Sharpe must not read like a 500-day one.
+  const sharpeDays = points.length
+    ? new Set(points.map(p => new Date(p.timestamp).toISOString().slice(0, 10))).size
+    : 0;
+
+  // Date range the window actually covers — first→last sized trade.
+  const rangeLabel = points.length
+    ? `${formatDate(points[0].timestamp)} – ${formatDate(points[points.length - 1].timestamp)}`
+    : null;
+
   const isPro = scope === 'pro';
   const isBroadcast = scope === 'broadcast';
 
@@ -462,6 +475,23 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
         </div>
       </div>
 
+      {/* Persistent smoothed-curve banner — when the P95 clip is ACTIVE the
+         curve is NOT the raw paper-trade path. The tiny toggle label alone is
+         easy to miss in a shared or embedded screenshot, so surface a visible
+         amber banner whenever smooth mode is on, regardless of whether a cap
+         was computed. */}
+      {smooth && (
+        <div className="mb-3 flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-300">
+          <span aria-hidden="true" className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-amber-400" />
+          <span>
+            Outlier-smoothed view (P95-clipped) — this is <strong>not</strong> the raw equity path.
+            The top and bottom 5% of trade outcomes are clamped
+            {smoothMeta?.capR != null ? ` to ±${smoothMeta.capR}R` : ''}; raw drawdown is larger.
+            Turn off &ldquo;Smoothed&rdquo; for the unmodified curve.
+          </span>
+        </div>
+      )}
+
       {/* Stats overlay — Total Return and Max Drawdown are presented as a
          barbell, equal weight. Win-rate-only or return-only framing hides
          the path. A +308% return with -67% drawdown is not a flat ride. */}
@@ -539,6 +569,11 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
               <div className="text-xs font-mono font-semibold text-zinc-300 tabular-nums">
                 {summary.sharpeRatio !== null ? summary.sharpeRatio.toFixed(2) : '—'}
               </div>
+              <div className="text-[9px] text-zinc-600 mt-0.5 font-mono">
+                {summary.sharpeRatio !== null
+                  ? `over ${sharpeDays} trading day${sharpeDays === 1 ? '' : 's'}`
+                  : `needs ≥5 days (have ${sharpeDays})`}
+              </div>
             </div>
           </div>
           <div className="grid grid-cols-3 gap-3 mb-4">
@@ -578,6 +613,19 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
               </div>
             </div>
           </div>
+          {/* R-stat denominator note — avg R per win/loss, expectancy and the
+             break-even win-rate come from the SIZED-TRADE subset (rows with an
+             SL so R is defined), which can differ from resolved signals. Show
+             that N so a thin R-stat isn't mistaken for a deep one. */}
+          {summary.sizedTrades !== undefined && (
+            <p className="text-[10px] text-zinc-600 -mt-2 mb-4 font-mono">
+              R-stats over {summary.sizedTrades.toLocaleString()} sized trade{summary.sizedTrades === 1 ? '' : 's'}
+              {summary.sizedTrades !== summary.totalSignals
+                ? ` (of ${summary.totalSignals.toLocaleString()} resolved — legacy rows without a stop are excluded)`
+                : ''}
+              {rangeLabel ? ` · ${rangeLabel}` : ''}
+            </p>
+          )}
         </>
       )}
 

--- a/apps/web/app/components/trailing-week-band-callout.tsx
+++ b/apps/web/app/components/trailing-week-band-callout.tsx
@@ -10,6 +10,7 @@ interface BandSummary {
   expectancyR: number | null;
   avgRWin: number | null;
   avgRLoss: number | null;
+  breakEvenWinRate: number | null;
 }
 
 interface BandResponse {
@@ -126,7 +127,17 @@ function BandCard({ label, data, accent }: BandCardProps) {
       <div className="mt-1.5 grid grid-cols-3 gap-2 text-[10px] font-mono text-zinc-500">
         <div>
           <div className="text-[8px] uppercase tracking-wider text-zinc-600">Win</div>
-          <div className="text-zinc-300">{data.winRate.toFixed(1)}%</div>
+          <div
+            className={
+              data.breakEvenWinRate !== null
+                ? data.winRate >= data.breakEvenWinRate
+                  ? 'text-emerald-400'
+                  : 'text-red-400'
+                : 'text-zinc-300'
+            }
+          >
+            {data.winRate.toFixed(1)}%
+          </div>
         </div>
         <div>
           <div className="text-[8px] uppercase tracking-wider text-zinc-600">Trades</div>
@@ -140,6 +151,13 @@ function BandCard({ label, data, accent }: BandCardProps) {
               : '—'}
           </div>
         </div>
+      </div>
+      {/* Break-even context: a sub-50% win-rate with asymmetric R:R can still
+         be profitable. Show the bar the win-rate is being judged against. */}
+      <div className="mt-1.5 text-[9px] font-mono text-zinc-600">
+        {data.breakEvenWinRate !== null
+          ? `break-even ${data.breakEvenWinRate}% · 7d window`
+          : 'break-even n/a · 7d window'}
       </div>
     </div>
   );

--- a/apps/web/app/confidence/ConfidenceClient.tsx
+++ b/apps/web/app/confidence/ConfidenceClient.tsx
@@ -144,16 +144,19 @@ function getSliderAccentClass(color: string): string {
 }
 
 /* ── code snippet ─────────────────────────────────────────────────────── */
-const CODE_SNIPPET = `// TradeClaw Confidence Scoring Formula (matches signal-generator.ts)
-// 5 indicators scored 0–max points, total raw max = 90
+const CODE_SNIPPET = `// TradeClaw confidence scoring — weights match this calculator's INDICATORS.
+// 6 indicators, each scored 0–100, weighted to a 0–100 confidence.
 const WEIGHTS = {
-  RSI: 20,   MACD: 25,  EMA: 20,
-  STOCH: 15, BB: 10,    // total = 90
+  RSI: 0.20, MACD: 0.20, EMA: 0.20,
+  BB:  0.15, STOCH: 0.15, VOLUME: 0.10, // total = 1.00
 };
 
-// Raw score → confidence % (scaled to 48–95 range)
-function scaleConfidence(rawScore: number): number {
-  return Math.min(95, Math.max(48, Math.round(42 + rawScore * 0.62)));
+// Confidence = weighted sum of the per-indicator 0–100 scores.
+function confidence(scores: Record<string, number>): number {
+  const raw =
+    scores.rsi   * 0.20 + scores.macd  * 0.20 + scores.ema    * 0.20 +
+    scores.bb    * 0.15 + scores.stoch * 0.15 + scores.volume * 0.10;
+  return Math.round(raw); // 0–100
 }
 
 // Thresholds (granular tiers):
@@ -162,7 +165,8 @@ function scaleConfidence(rawScore: number): number {
 //  58–64 → published (marginal)
 //  65–72 → published (moderate)
 //  73+   → auto-broadcast to Telegram & webhooks
-//  75+   → capped at 70 unless multi-TF confluence confirms`;
+//  75+   → capped at 70 unless multi-TF confluence (H1+H4+D1) confirms;
+//          with confluence, +confluence bonus, capped at 95`;
 
 /* ── main component ───────────────────────────────────────────────────── */
 export default function ConfidenceClient() {
@@ -220,6 +224,10 @@ export default function ConfidenceClient() {
         {/* ── Live Score Display ── */}
         <div className={`rounded-2xl border p-8 text-center transition-all duration-300 ${getScoreBg(confidence)}`}>
           <div className="flex flex-col items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/30">
+              <Calculator className="w-3 h-3" />
+              Interactive demo — not a live signal
+            </span>
             <span className="text-xs uppercase tracking-widest text-[var(--text-secondary)] font-semibold">
               Confidence Score
             </span>
@@ -251,8 +259,11 @@ export default function ConfidenceClient() {
 
         {/* ── Presets ── */}
         <div>
-          <p className="text-xs uppercase tracking-widest text-[var(--text-secondary)] font-semibold mb-3">
+          <p className="text-xs uppercase tracking-widest text-[var(--text-secondary)] font-semibold mb-1">
             Load a Preset
+          </p>
+          <p className="text-xs text-[var(--text-secondary)] mb-3">
+            Illustrative examples to explore the formula — not historical signals.
           </p>
           <div className="flex flex-wrap gap-3">
             {PRESETS.map((preset) => (
@@ -428,7 +439,7 @@ export default function ConfidenceClient() {
               <div className="w-3 h-3 rounded-full bg-zinc-500/60" />
               <div className="w-3 h-3 rounded-full bg-emerald-500/60" />
               <span className="ml-2 text-xs text-[var(--text-secondary)] font-mono">
-                signal-generator.ts
+                confidence formula (simplified)
               </span>
             </div>
             <button

--- a/apps/web/app/consensus/ConsensusClient.tsx
+++ b/apps/web/app/consensus/ConsensusClient.tsx
@@ -36,9 +36,21 @@ function BullBearGauge({ bullish }: { bullish: number }) {
 }
 
 function TrendIcon({ trend }: { trend: ConsensusEntry['trend24h'] }) {
-  if (trend === 'UP') return <TrendingUp className="w-4 h-4 text-emerald-400" />;
-  if (trend === 'DOWN') return <TrendingDown className="w-4 h-4 text-rose-400" />;
-  return <Minus className="w-4 h-4 text-zinc-500" />;
+  // trend24h is algorithmically derived (not a measured 24h price change),
+  // so it is marked "est." per the honesty contract (rule 7).
+  const icon =
+    trend === 'UP' ? <TrendingUp className="w-4 h-4 text-emerald-400" />
+    : trend === 'DOWN' ? <TrendingDown className="w-4 h-4 text-rose-400" />
+    : <Minus className="w-4 h-4 text-zinc-500" />;
+  return (
+    <span
+      className="inline-flex items-center gap-0.5"
+      title="estimated — not a measured 24h price change"
+    >
+      {icon}
+      <span className="text-[10px] font-medium text-zinc-500 leading-none">est.</span>
+    </span>
+  );
 }
 
 function ConsensusRow({ entry }: { entry: ConsensusEntry }) {
@@ -52,7 +64,12 @@ function ConsensusRow({ entry }: { entry: ConsensusEntry }) {
           <span className="font-mono font-bold text-white">{entry.pair}</span>
           <span className="text-xs text-zinc-500">{entry.name}</span>
           {entry.source === 'synthetic' && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-500/10 text-zinc-400 border border-zinc-500/20">ESTIMATED</span>
+            <span
+              className="text-xs font-semibold px-2 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30"
+              title="estimated — no live signals available for this pair yet"
+            >
+              ESTIMATED
+            </span>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -174,13 +191,14 @@ export default function ConsensusClient() {
             Market Consensus
           </h1>
           <p className="text-zinc-400 mb-6 max-w-xl mx-auto">
-            Aggregate buy/sell signal distribution across all tracked assets — updated every 60 seconds from live signal engine.
+            Aggregate buy/sell signal distribution from H1 + H4 signals across all tracked assets — updated every 60 seconds from the live signal engine, or estimated data when live signals are unavailable.
           </p>
 
           {/* Overall gauge */}
           {data && (
             <div className="max-w-md mx-auto mb-6">
               <BullBearGauge bullish={data.overallBullish} />
+              <p className="text-[11px] text-zinc-500 mt-1">across current H1 + H4 signals</p>
             </div>
           )}
 
@@ -204,12 +222,15 @@ export default function ConsensusClient() {
 
           {/* Total signals */}
           {data && (
-            <div className="flex items-center justify-center gap-4 text-sm text-zinc-400 mb-4">
-              <span className="text-emerald-400 font-semibold">{data.totalBuySignals} BUY signals</span>
-              <span className="text-zinc-600">·</span>
-              <span className="text-rose-400 font-semibold">{data.totalSellSignals} SELL signals</span>
-              <span className="text-zinc-600">·</span>
-              <span>Bias: <span className={`font-semibold ${bias === 'Bullish' ? 'text-emerald-400' : bias === 'Bearish' ? 'text-rose-400' : 'text-zinc-300'}`}>{bias}</span></span>
+            <div className="mb-4">
+              <div className="flex items-center justify-center gap-4 text-sm text-zinc-400">
+                <span className="text-emerald-400 font-semibold">{data.totalBuySignals} BUY signals</span>
+                <span className="text-zinc-600">·</span>
+                <span className="text-rose-400 font-semibold">{data.totalSellSignals} SELL signals</span>
+                <span className="text-zinc-600">·</span>
+                <span>Bias: <span className={`font-semibold ${bias === 'Bullish' ? 'text-emerald-400' : bias === 'Bearish' ? 'text-rose-400' : 'text-zinc-300'}`}>{bias}</span></span>
+              </div>
+              <p className="text-[11px] text-zinc-500 mt-1">counts current open H1 + H4 signals (not a 24h history)</p>
             </div>
           )}
 
@@ -254,7 +275,8 @@ export default function ConsensusClient() {
 
       {/* Per-asset grid */}
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <h2 className="text-lg font-semibold mb-4 text-zinc-300">Per-Asset Breakdown</h2>
+        <h2 className="text-lg font-semibold mb-1 text-zinc-300">Per-Asset Breakdown</h2>
+        <p className="text-xs text-zinc-500 mb-4">Buy/sell counts and average confidence reflect currently open H1 + H4 signals per pair.</p>
         <div className="grid md:grid-cols-2 gap-4">
           {data?.entries.map(entry => (
             <ConsensusRow key={entry.pair} entry={entry} />

--- a/apps/web/app/embed/track-record/page.tsx
+++ b/apps/web/app/embed/track-record/page.tsx
@@ -34,7 +34,7 @@ export default async function TrackRecordEmbedPage({ searchParams }: { searchPar
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
         <div style={{ fontSize: '12px', letterSpacing: '0.08em', textTransform: 'uppercase', opacity: 0.7 }}>
-          {`TradeClaw — verified track record (30d, ${bandLabel})`}
+          {`TradeClaw — recorded track record (30d, ${bandLabel})`}
         </div>
         <a href="https://tradeclaw.win/track-record" target="_blank" rel="noopener" style={{ fontSize: '11px', color: '#10b981', textDecoration: 'none' }}>
           tradeclaw.win →

--- a/apps/web/app/embed/track-record/page.tsx
+++ b/apps/web/app/embed/track-record/page.tsx
@@ -1,46 +1,19 @@
-import { query } from '../../../lib/db-pool';
-import { PRO_PREMIUM_MIN_CONFIDENCE } from '../../../lib/tier';
+import { computeTrackRecordStats, parseBand, type TrackRecordBand } from '../../../lib/track-record-stats';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;
 
-type Band = 'all' | 'premium' | 'standard';
-
-interface Stats { total: number; wins: number; winRate: number; totalPnl: number }
-
-function parseBand(raw: string | undefined): Band {
-  if (raw === 'premium' || raw === 'standard' || raw === 'all') return raw;
-  return 'all';
-}
-
-async function loadStats(band: Band): Promise<Stats> {
-  const bandClause = band === 'premium'
-    ? `AND confidence >= ${PRO_PREMIUM_MIN_CONFIDENCE}`
-    : band === 'standard'
-      ? `AND confidence < ${PRO_PREMIUM_MIN_CONFIDENCE}`
-      : '';
-  const rows = await query<{ total: string; wins: string; win_rate: string; total_pnl: string }>(`
-    SELECT
-      COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL)::text AS total,
-      COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::text AS wins,
-      CASE WHEN COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) > 0
-        THEN ROUND(COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::numeric
-          / COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) * 100, 1)::text
-        ELSE '0' END AS win_rate,
-      COALESCE(ROUND(SUM((outcome_24h->>'pnlPct')::numeric) FILTER (WHERE outcome_24h IS NOT NULL), 2)::text, '0') AS total_pnl
-    FROM signal_history
-    WHERE is_simulated = false AND created_at >= NOW() - INTERVAL '30 days' ${bandClause}
-  `);
-  const r = rows[0] ?? { total: '0', wins: '0', win_rate: '0', total_pnl: '0' };
-  return { total: +r.total, wins: +r.wins, winRate: +r.win_rate, totalPnl: +r.total_pnl };
-}
+type Band = TrackRecordBand;
 
 export default async function TrackRecordEmbedPage({ searchParams }: { searchParams: Promise<{ theme?: string; band?: string }> }) {
   const { theme, band: rawBand } = await searchParams;
   const band = parseBand(rawBand);
   const dark = theme !== 'light';
-  const s = await loadStats(band);
+  // Same resolved-signal logic as the page body + OG card: excludes
+  // auto-expired, gate-blocked, and simulated rows. Replaces the raw
+  // `outcome_24h IS NOT NULL` SQL that disagreed with the page numbers.
+  const s = await computeTrackRecordStats(band);
   const pnlColor = s.totalPnl >= 0 ? '#10b981' : '#f43f5e';
   const borderColor = dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
   const bandLabel = band === 'premium' ? 'premium band' : band === 'standard' ? 'standard band' : 'all signals';

--- a/apps/web/app/results/ResultsClient.tsx
+++ b/apps/web/app/results/ResultsClient.tsx
@@ -136,15 +136,27 @@ function EquityCurveChart({ data }: { data: number[] }) {
     ctx.lineWidth = 1.5;
     ctx.stroke();
 
-    // X-axis labels
+    // X-axis labels — relative window markers, NOT calendar months
+    // (the curve is a seeded-PRNG illustration, so a Mar/Jun/Sep calendar
+    //  axis would falsely imply real dated data — see honesty contract §3)
     ctx.fillStyle = 'rgba(255,255,255,0.3)';
     ctx.font = '10px monospace';
     ctx.textAlign = 'center';
-    const xLabels = ['Mar', 'Jun', 'Sep', 'Dec', 'Feb'];
+    const xLabels = ['Start', '25%', '50%', '75%', 'End'];
     xLabels.forEach((label, i) => {
       const x = pad.left + (i / (xLabels.length - 1)) * cw;
       ctx.fillText(label, x, h - 6);
     });
+
+    // Watermark — make it unmistakable on the chart body that this is
+    // not measured data, for a skim reader who lands mid-page.
+    ctx.save();
+    ctx.fillStyle = 'rgba(251,191,36,0.16)'; // amber-400, low alpha
+    ctx.font = 'bold 18px monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('ILLUSTRATIVE — NOT REAL DATA', pad.left + cw / 2, pad.top + ch / 2);
+    ctx.restore();
   }, [data]);
 
   useEffect(() => {
@@ -155,8 +167,14 @@ function EquityCurveChart({ data }: { data: number[] }) {
   }, [draw]);
 
   return (
-    <div ref={containerRef} className="w-full">
+    <div ref={containerRef} className="relative w-full">
+      <span className="absolute right-2 top-2 z-10 text-[9px] uppercase tracking-wider text-amber-400/80 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+        Illustrative — not real data
+      </span>
       <canvas ref={canvasRef} className="w-full" />
+      <p className="mt-1 text-center text-[10px] text-zinc-500">
+        Seeded-PRNG example path · x-axis is window progress, not calendar dates
+      </p>
     </div>
   );
 }
@@ -172,9 +190,12 @@ function MetricCard({ label, value, suffix, icon: Icon, positive }: {
 }) {
   return (
     <div className="bg-white/[0.02] rounded-lg py-3 px-4 border border-white/5">
-      <div className="flex items-center gap-1.5 mb-1">
-        <Icon className="w-3.5 h-3.5 text-zinc-500" />
-        <span className="text-[10px] uppercase tracking-wider text-zinc-500">{label}</span>
+      <div className="flex items-center justify-between gap-1.5 mb-1">
+        <div className="flex items-center gap-1.5">
+          <Icon className="w-3.5 h-3.5 text-zinc-500" />
+          <span className="text-[10px] uppercase tracking-wider text-zinc-500">{label}</span>
+        </div>
+        <span className="text-[9px] uppercase tracking-wider text-amber-400/80 bg-amber-500/10 border border-amber-500/20 rounded px-1 py-0.5" title="Hand-authored example — not a real or backtested figure">illus.</span>
       </div>
       <span className={`font-mono tabular-nums text-lg font-semibold ${positive === undefined ? 'text-white' : positive ? 'text-emerald-400' : 'text-red-400'}`}>
         {value}{suffix && <span className="text-xs text-zinc-500 ml-0.5">{suffix}</span>}
@@ -246,7 +267,10 @@ export function ResultsClient() {
               <div className="mt-1 text-[11px] text-zinc-500">Across {VALIDATION_SUMMARY.assetCount} assets · hand-authored examples</div>
             </div>
             <div className="rounded-xl border border-white/5 bg-white/[0.02] px-4 py-3 text-left">
-              <div className="text-[10px] uppercase tracking-wider text-zinc-500">Example snapshot</div>
+              <div className="flex items-center justify-between gap-1.5">
+                <div className="text-[10px] uppercase tracking-wider text-zinc-500">Example snapshot</div>
+                <span className="text-[9px] uppercase tracking-wider text-amber-400/80 bg-amber-500/10 border border-amber-500/20 rounded px-1 py-0.5">illus.</span>
+              </div>
               <div className="mt-1 font-mono text-sm font-semibold text-white">
                 {VALIDATION_SUMMARY.weightedWinRate.toFixed(1)}% win rate · Sharpe {VALIDATION_SUMMARY.averageSharpe.toFixed(2)}
               </div>
@@ -365,7 +389,12 @@ export function ResultsClient() {
 
             {/* ─── Monthly Returns Heatmap ─────────────────── */}
             <div className="glass-card rounded-2xl p-5 mb-6">
-              <span className="text-sm font-semibold mb-3 block">Monthly Returns <span className="text-[10px] font-normal text-amber-400/80">(illustrative)</span></span>
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-sm font-semibold">Monthly Returns <span className="text-[10px] font-normal text-amber-400/80">(illustrative)</span></span>
+                <span className="text-[9px] uppercase tracking-wider text-amber-400/80 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+                  Hand-authored — each cell is an example, not a measured month
+                </span>
+              </div>
               <div className="grid grid-cols-12 gap-1.5">
                 {result.monthlyReturns.map((m) => (
                   <div
@@ -384,9 +413,12 @@ export function ResultsClient() {
             {/* ─── Avg Holding + Period ────────────────────── */}
             <div className="grid grid-cols-2 gap-3 mb-6">
               <div className="bg-white/[0.02] rounded-lg py-3 px-4 border border-white/5">
-                <div className="flex items-center gap-1.5 mb-1">
-                  <Clock className="w-3.5 h-3.5 text-zinc-500" />
-                  <span className="text-[10px] uppercase tracking-wider text-zinc-500">Avg Hold Time</span>
+                <div className="flex items-center justify-between gap-1.5 mb-1">
+                  <div className="flex items-center gap-1.5">
+                    <Clock className="w-3.5 h-3.5 text-zinc-500" />
+                    <span className="text-[10px] uppercase tracking-wider text-zinc-500">Avg Hold Time</span>
+                  </div>
+                  <span className="text-[9px] uppercase tracking-wider text-amber-400/80 bg-amber-500/10 border border-amber-500/20 rounded px-1 py-0.5" title="Hand-authored example — not a real or backtested figure">illus.</span>
                 </div>
                 <span className="font-mono tabular-nums text-lg font-semibold text-white">
                   {result.metrics.avgHoldingHours}<span className="text-xs text-zinc-500 ml-0.5">hrs</span>
@@ -407,8 +439,8 @@ export function ResultsClient() {
 
         {/* ─── Comparison Table ────────────────────────── */}
         <div className="glass-card rounded-2xl p-5 mb-8">
-          <div className="flex items-center justify-between mb-4">
-            <span className="text-sm font-semibold">Strategy Comparison &mdash; {ASSETS.find(a => a.id === activeAsset)?.name}</span>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-semibold">Strategy Comparison &mdash; {ASSETS.find(a => a.id === activeAsset)?.name} <span className="text-[10px] font-normal text-amber-400/80">(illustrative)</span></span>
             <div className="flex gap-1">
               {([['sharpe', 'Sharpe'], ['return', 'Return'], ['winRate', 'Win %']] as const).map(([key, label]) => (
                 <button
@@ -425,16 +457,19 @@ export function ResultsClient() {
               ))}
             </div>
           </div>
+          <p className="mb-3 text-[10px] text-amber-400/80">
+            All figures below are hand-authored examples — not real, backtested, or live results.
+          </p>
           <div className="overflow-x-auto">
             <table className="w-full text-xs">
               <thead>
                 <tr className="text-zinc-500 text-[10px] uppercase tracking-wider border-b border-white/5">
                   <th className="text-left py-2 pr-4">Strategy</th>
-                  <th className="text-right py-2 px-3">Return</th>
-                  <th className="text-right py-2 px-3">Win Rate</th>
-                  <th className="text-right py-2 px-3">Sharpe</th>
-                  <th className="text-right py-2 px-3">Max DD</th>
-                  <th className="text-right py-2 pl-3">Trades</th>
+                  <th className="text-right py-2 px-3">Return <span className="text-amber-400/70">(illus.)</span></th>
+                  <th className="text-right py-2 px-3">Win Rate <span className="text-amber-400/70">(illus.)</span></th>
+                  <th className="text-right py-2 px-3">Sharpe <span className="text-amber-400/70">(illus.)</span></th>
+                  <th className="text-right py-2 px-3">Max DD <span className="text-amber-400/70">(illus.)</span></th>
+                  <th className="text-right py-2 pl-3">Trades <span className="text-amber-400/70">(illus.)</span></th>
                 </tr>
               </thead>
               <tbody>

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -549,7 +549,7 @@ export function TrackRecordClient() {
            70% WR with giant losers. We show both so the reader can judge. */}
         <div className="mb-6">
           <div className="text-[11px] uppercase tracking-wider text-[var(--text-secondary)] font-mono font-semibold mb-2">
-            Verified Track Record
+            Recorded Track Record
           </div>
           <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2 mb-2">
             <div className="flex items-baseline gap-2">
@@ -1252,8 +1252,8 @@ export function TrackRecordClient() {
         <div className="glass-card rounded-2xl p-5 border-l-2 border-emerald-500/50 mb-8">
           <h3 className="text-sm font-semibold mb-1">Full Transparency</h3>
           <p className="text-xs text-[var(--text-secondary)] leading-relaxed">
-            Every signal is recorded the moment it&apos;s generated. Outcomes are verified against real OHLCV market
-            data from Binance and Yahoo Finance.
+            Every signal is recorded the moment it&apos;s generated. Outcomes are resolved against Binance and
+            Yahoo Finance OHLCV candles.
             Win rate, total P&amp;L, and the equity curve count only resolved trades — signals refused by the
             full-risk gate or that expired without hitting TP/SL within 48h are surfaced as separate counters,
             not folded into the headline numbers. No cherry-picking, no hidden losses.

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -156,6 +156,29 @@ function formatTime(ts: number): string {
   return `${month} ${day}, ${hh}:${mm} ${tz}`;
 }
 
+/** Short "Mon D, YYYY" stamp for the headline "since <date>" provenance. */
+function formatDateStamp(ts: number): string {
+  return new Date(ts).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/** Human window descriptor for the selected period, anchored to the earliest
+ * recorded signal. "All" with no data is unbounded; a fixed window shows the
+ * actual span it covers given how much history exists. */
+function periodWindowLabel(period: Period, earliestTs: number | null): string {
+  const opt = PERIOD_OPTIONS.find(o => o.value === period);
+  if (!opt) return '';
+  if (opt.days === null) {
+    return earliestTs ? `since ${formatDateStamp(earliestTs)}` : 'full archive';
+  }
+  const start = Date.now() - opt.days * 86_400_000;
+  const effectiveStart = earliestTs ? Math.max(start, earliestTs) : start;
+  return `${formatDateStamp(effectiveStart)} – ${formatDateStamp(Date.now())}`;
+}
+
 function HitRateBar({ value }: { value: number }) {
   const color = value >= 60 ? 'bg-emerald-500' : value >= 50 ? 'bg-zinc-500' : 'bg-red-500';
   const textColor = value >= 60 ? 'text-emerald-400' : value >= 50 ? 'text-zinc-400' : 'text-red-400';
@@ -410,6 +433,10 @@ export function TrackRecordClient() {
   const [leaderboard, setLeaderboard] = useState<LeaderboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [rollingWinRates, setRollingWinRates] = useState<RollingWinRates | null>(null);
+  // Break-even win-rate for the current scope/period, from the equity summary.
+  // Surfaced at the headline so the headline win-rate reads against the bar the
+  // system needs, not a meaningless flat 50%.
+  const [headlineBreakEven, setHeadlineBreakEven] = useState<number | null>(null);
   const [now, setNow] = useState(() => Date.now());
   // Earliest signal we have data for in the current scope. Used to grey out
   // period buttons whose window pre-dates any recorded signal — a 5Y button
@@ -465,9 +492,13 @@ export function TrackRecordClient() {
         const data = await equityRes.value.json();
         if (isCancelled()) return;
         setRollingWinRates(data.rollingWinRates ?? null);
+        setHeadlineBreakEven(
+          typeof data.summary?.breakEvenWinRate === 'number' ? data.summary.breakEvenWinRate : null,
+        );
       } else {
         if (isCancelled()) return;
         setRollingWinRates(null);
+        setHeadlineBreakEven(null);
       }
     } catch {
       if (isCancelled()) return;
@@ -564,12 +595,19 @@ export function TrackRecordClient() {
                 total return
                 <InfoHint text={STAT_HINTS.totalReturnLinear} label="What total return means" />
               </span>
+              {/* Provenance stamp — the window this headline actually covers,
+                  so a number from 26 days of data doesn't read as "all time". */}
+              <span className="text-[11px] font-mono text-[var(--text-secondary)]">
+                {periodWindowLabel(period, earliestTimestamp)}
+              </span>
             </div>
             <div className="flex items-baseline gap-1.5">
               <span className={`text-xl font-semibold tabular-nums ${
-                stats && stats.winRate >= 55 ? 'text-emerald-400'
-                : stats && stats.winRate >= 45 ? 'text-zinc-400'
-                : stats ? 'text-red-400' : 'text-[var(--foreground)]'
+                headlineBreakEven !== null && stats
+                  ? stats.winRate >= headlineBreakEven ? 'text-emerald-400' : 'text-red-400'
+                  : stats && stats.winRate >= 55 ? 'text-emerald-400'
+                  : stats && stats.winRate >= 45 ? 'text-zinc-400'
+                  : stats ? 'text-red-400' : 'text-[var(--foreground)]'
               }`}>
                 {stats ? `${stats.winRate}%` : '—'}
               </span>
@@ -577,6 +615,14 @@ export function TrackRecordClient() {
                 win rate
                 <InfoHint text={STAT_HINTS.winRate24h} label="What win rate means" />
               </span>
+              {/* Break-even win-rate at the headline (not only in sub-cards):
+                  a sub-50% win-rate above break-even is still profitable. */}
+              {headlineBreakEven !== null && (
+                <span className="text-[11px] font-mono text-[var(--text-secondary)] inline-flex items-center gap-1">
+                  break-even {headlineBreakEven}%
+                  <InfoHint text={STAT_HINTS.breakEvenWinRate} label="What break-even win rate means" />
+                </span>
+              )}
             </div>
             <div className="flex items-baseline gap-1.5">
               <span className="text-xl font-semibold tabular-nums text-[var(--foreground)]">
@@ -637,10 +683,23 @@ export function TrackRecordClient() {
                   : snap.winRate >= 45
                     ? 'text-zinc-300'
                     : 'text-red-400';
+                // Actual data span available. When the recorded history is
+                // shorter than the window label, a "90d win rate" really only
+                // covers N days — say so rather than imply 90 days of data.
+                const windowDays = Number(window.replace('d', ''));
+                const dataAgeDays = earliestTimestamp
+                  ? Math.max(1, Math.floor((Date.now() - earliestTimestamp) / 86_400_000))
+                  : null;
+                const isThinWindow = dataAgeDays !== null && dataAgeDays < windowDays;
                 return (
                   <div key={window} className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-4">
                     <div className="text-[10px] uppercase tracking-wide text-[var(--text-secondary)] font-mono">
                       Rolling win rate · {window}
+                      {isThinWindow && (
+                        <span className="ml-1 normal-case text-amber-400/80">
+                          (only {dataAgeDays}d of data)
+                        </span>
+                      )}
                     </div>
                     <div className="mt-2 flex items-end justify-between gap-3">
                       <div className={`text-2xl font-bold tabular-nums ${winTone}`}>
@@ -836,7 +895,7 @@ export function TrackRecordClient() {
                 label="Total P&L"
                 value={`${stats.totalPnlPct >= 0 ? '+' : ''}${stats.totalPnlPct}%`}
                 accent={stats.totalPnlPct >= 0 ? 'emerald' : 'red'}
-                hint="Sum at fixed 1R"
+                hint="Raw sum of per-signal market %"
                 tooltip={STAT_HINTS.totalReturnLinear}
               />
               <StatCard
@@ -957,9 +1016,15 @@ export function TrackRecordClient() {
 
         {/* Per-Symbol Breakdown */}
         <section className="mb-8">
-          <h2 className="text-xs uppercase tracking-wider text-[var(--text-secondary)] font-mono font-semibold mb-3">
-            Per-Symbol Performance
-          </h2>
+          <div className="mb-3 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+            <h2 className="text-xs uppercase tracking-wider text-[var(--text-secondary)] font-mono font-semibold">
+              Per-Symbol Performance
+            </h2>
+            {/* Date range the hit-rates below cover, for the selected period. */}
+            <span className="text-[10px] font-mono text-[var(--text-secondary)]">
+              {periodWindowLabel(period, earliestTimestamp)}
+            </span>
+          </div>
           <div className="glass-card rounded-2xl overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full min-w-[560px] text-xs font-mono">

--- a/apps/web/app/track-record/page.tsx
+++ b/apps/web/app/track-record/page.tsx
@@ -15,19 +15,19 @@ const TrackRecordClient = dynamic(
 const ogImage = '/api/og/track-record';
 
 export const metadata: Metadata = {
-  title: 'Verified Signal Track Record — TradeClaw',
+  title: 'Recorded Signal Track Record — TradeClaw',
   description:
-    'Transparent, verified trading signal performance. Win rates, P&L, equity curves, and per-symbol breakdown across crypto, forex, and commodities.',
+    'Transparent trading signal performance, resolved against Binance/Yahoo OHLCV. Win rates, P&L, equity curves, and per-symbol breakdown across crypto, forex, and commodities.',
   openGraph: {
-    title: 'Verified Signal Track Record — TradeClaw',
+    title: 'Recorded Signal Track Record — TradeClaw',
     description:
-      'Real performance data for TradeClaw AI trading signals. No cherry-picking, no hiding losses.',
+      'Real performance data for TradeClaw AI trading signals, resolved against Binance/Yahoo OHLCV. No cherry-picking, no hiding losses.',
     images: [{ url: ogImage, width: 1200, height: 630, alt: 'TradeClaw Track Record' }],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Verified Signal Track Record — TradeClaw',
-    description: 'Real performance data for TradeClaw AI trading signals.',
+    title: 'Recorded Signal Track Record — TradeClaw',
+    description: 'Real performance data for TradeClaw AI trading signals, resolved against Binance/Yahoo OHLCV.',
     images: [ogImage],
   },
 };

--- a/apps/web/components/data-provenance-badge.tsx
+++ b/apps/web/components/data-provenance-badge.tsx
@@ -94,3 +94,21 @@ export function getDataProvenance(data: {
   if (hasSim && !hasLive) return 'simulated';
   return 'live';
 }
+
+/**
+ * Derive provenance from FULL-HISTORY counts (live vs simulated), not a
+ * paginated page slice. A page can be all-live while the full track record is
+ * mixed — `getDataProvenance` over the visible page would mislabel that as
+ * "Live verified". Callers with whole-history totals must use this instead.
+ */
+export function getDataProvenanceFromCounts(counts: {
+  live?: number;
+  simulated?: number;
+}): DataProvenance {
+  const live = counts.live ?? 0;
+  const simulated = counts.simulated ?? 0;
+  if (live === 0 && simulated === 0) return 'empty';
+  if (live > 0 && simulated > 0) return 'mixed';
+  if (simulated > 0 && live === 0) return 'simulated';
+  return 'live';
+}

--- a/apps/web/components/landing/ab-hero.tsx
+++ b/apps/web/components/landing/ab-hero.tsx
@@ -73,6 +73,12 @@ function trackImpression(v: Variant) {
     const counts: Record<Variant, number> = raw ? JSON.parse(raw) : { a: 0, b: 0, c: 0 };
     counts[v] = (counts[v] || 0) + 1;
     localStorage.setItem("tc_ab_impressions", JSON.stringify(counts));
+    // Record when tracking first began on this browser so the /ab-stats
+    // dashboard can show an honest "since <date>" instead of an open-ended
+    // count. Only set once.
+    if (!localStorage.getItem("tc_ab_since")) {
+      localStorage.setItem("tc_ab_since", new Date().toISOString());
+    }
   } catch {}
 }
 

--- a/apps/web/lib/__tests__/track-record-stats.test.ts
+++ b/apps/web/lib/__tests__/track-record-stats.test.ts
@@ -1,0 +1,99 @@
+jest.mock('../signal-history-cache', () => ({
+  getCachedHistory: jest.fn(),
+}));
+
+import { computeTrackRecordStats } from '../track-record-stats';
+import { isCountedResolved, type SignalHistoryRecord } from '../signal-history';
+import { getCachedHistory } from '../signal-history-cache';
+
+const mockedHistory = getCachedHistory as jest.MockedFunction<typeof getCachedHistory>;
+
+function mkRecord(
+  id: string,
+  opts: {
+    confidence?: number;
+    hit?: boolean;
+    pnlPct?: number;
+    target?: 'TP1' | 'SL' | 'expired';
+    gateBlocked?: boolean;
+    isSimulated?: boolean;
+    ageDays?: number;
+  },
+): SignalHistoryRecord {
+  const ageMs = (opts.ageDays ?? 1) * 86_400_000;
+  return {
+    id,
+    pair: 'BTCUSD',
+    timeframe: 'H1',
+    direction: 'BUY',
+    confidence: opts.confidence ?? 80,
+    entryPrice: 50000,
+    timestamp: Date.now() - ageMs,
+    tp1: 51000,
+    sl: 49500,
+    isSimulated: opts.isSimulated ?? false,
+    gateBlocked: opts.gateBlocked ?? false,
+    outcomes: {
+      '4h': null,
+      '24h': {
+        price: 51000,
+        pnlPct: opts.pnlPct ?? (opts.hit ? 2.0 : -1.0),
+        hit: opts.hit ?? false,
+        target: opts.target ?? (opts.hit ? 'TP1' : 'SL'),
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  mockedHistory.mockReset();
+});
+
+describe('computeTrackRecordStats — OG/embed honesty parity', () => {
+  it('excludes auto-expired rows from the resolved count, matching isCountedResolved', async () => {
+    const rows = [
+      mkRecord('win', { hit: true }),
+      mkRecord('loss', { hit: false }),
+      // Auto-expire placeholder: pnl 0, no hit, target 'expired'. The page body
+      // (isCountedResolved) drops it; the OG/embed must drop it too.
+      mkRecord('expired', { hit: false, pnlPct: 0, target: 'expired' }),
+    ];
+    mockedHistory.mockResolvedValue(rows);
+
+    const stats = await computeTrackRecordStats('all');
+
+    const expectedResolved = rows.filter(isCountedResolved);
+    expect(stats.total).toBe(expectedResolved.length); // 2, NOT 3
+    expect(stats.total).toBe(2);
+    expect(stats.wins).toBe(1);
+    expect(stats.winRate).toBe(50); // 1/2, not 1/3
+  });
+
+  it('excludes gate-blocked and simulated rows like the page body', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('win', { hit: true }),
+      mkRecord('blocked', { hit: true, gateBlocked: true }),
+      mkRecord('sim', { hit: true, isSimulated: true }),
+    ]);
+
+    const stats = await computeTrackRecordStats('all');
+
+    expect(stats.total).toBe(1);
+    expect(stats.wins).toBe(1);
+  });
+
+  it('respects the premium / standard band split on resolved rows', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('premium-win', { hit: true, confidence: 90 }),
+      mkRecord('standard-loss', { hit: false, confidence: 50 }),
+    ]);
+
+    const premium = await computeTrackRecordStats('premium');
+    const standard = await computeTrackRecordStats('standard');
+
+    expect(premium.total).toBe(1);
+    expect(premium.wins).toBe(1);
+    expect(standard.total).toBe(1);
+    expect(standard.wins).toBe(0);
+  });
+});

--- a/apps/web/lib/track-record-stats.ts
+++ b/apps/web/lib/track-record-stats.ts
@@ -1,0 +1,57 @@
+import { isCountedResolved } from './signal-history';
+import { getResolvedSlice } from './signal-slice';
+import { PRO_PREMIUM_MIN_CONFIDENCE } from './tier';
+
+export type TrackRecordBand = 'all' | 'premium' | 'standard';
+
+export interface TrackRecordStats {
+  /** Resolved-signal count (the denominator). */
+  total: number;
+  /** Resolved signals whose 24h outcome hit. */
+  wins: number;
+  /** wins / total × 100, one decimal. 0 when total is 0. */
+  winRate: number;
+  /** Sum of resolved 24h pnlPct, two decimals. */
+  totalPnl: number;
+}
+
+export function parseBand(raw: string | null | undefined): TrackRecordBand {
+  if (raw === 'premium' || raw === 'standard' || raw === 'all') return raw;
+  return 'all';
+}
+
+/**
+ * 30-day resolved-signal stats for the public track-record SHARE surfaces
+ * (OG social card + embed). Computed through the SAME resolved-signal logic
+ * the page body and /api/signals/equity use — getResolvedSlice +
+ * isCountedResolved — so the social card, the embed, and the page never
+ * disagree on win-rate / P&L under the same banner (honesty contract,
+ * cross-surface consistency). The prior raw SQL counted `outcome_24h IS NOT
+ * NULL`, which folded in auto-expired and gate-blocked rows the page excludes.
+ *
+ * Scope is fixed to 'pro' (the full track record, same as the page default)
+ * and period to '30d' (the advertised window). Band narrows by confidence,
+ * matching the embed's premium/standard split.
+ */
+export async function computeTrackRecordStats(band: TrackRecordBand): Promise<TrackRecordStats> {
+  const slice = await getResolvedSlice({ scope: 'pro', period: '30d' });
+
+  let resolved = slice.resolved;
+  if (band === 'premium') {
+    resolved = resolved.filter(r => r.confidence >= PRO_PREMIUM_MIN_CONFIDENCE);
+  } else if (band === 'standard') {
+    resolved = resolved.filter(r => r.confidence < PRO_PREMIUM_MIN_CONFIDENCE);
+  }
+  // Re-apply the canonical resolved predicate after the band filter so the
+  // denominator stays identical to the page body's definition.
+  resolved = resolved.filter(isCountedResolved);
+
+  const total = resolved.length;
+  const wins = resolved.filter(r => r.outcomes['24h']!.hit).length;
+  const totalPnl = +resolved
+    .reduce((sum, r) => sum + r.outcomes['24h']!.pnlPct, 0)
+    .toFixed(2);
+  const winRate = total > 0 ? +((wins / total) * 100).toFixed(1) : 0;
+
+  return { total, wins, winRate, totalPnl };
+}

--- a/docs/operators/honesty-contract.md
+++ b/docs/operators/honesty-contract.md
@@ -1,0 +1,25 @@
+# Honesty Contract — public measurement surfaces
+
+Phase 6a standard. Every public surface that renders a performance number must satisfy ALL of the following. A surface passes only when every rendered number satisfies 1–7.
+
+1. **Provenance label.** Each number is one of: `live-measured`, `synthetic`, `illustrative`. The label is visible without hover, at skim distance — adjacent to the value, not only in a section heading or page footer.
+
+2. **Sample size + window.** Every win-rate / return / Sharpe / accuracy figure shows N (resolved signals) and the date range it covers. A 5-signal Sharpe must not look identical to a 500-signal one.
+
+3. **No fabricated curve.** No simulated or hand-authored equity curve, monthly heatmap, or axis is presented as if it were real measured performance. Illustrative charts are watermarked.
+
+4. **Win-rate context.** A win-rate is shown alongside its break-even win-rate; "above / below break-even" is explicit. Loss% is computed from `losses / resolved`, never as a `100 − winRate` residual that hides pending/expired rows.
+
+5. **Cost honesty.** Returns are net of the stated round-trip cost (currently 2bps); the cost is disclosed near the number.
+
+6. **Claim backing.** Any headline word like "verified" maps to a named recorded source that INCLUDES losses and no-edge periods. If the data cannot back the word, the word is softened to what the data supports (Phase 6 decision 4) — never the reverse. Outcomes resolved against an external price source are described as "resolved against <provider> OHLCV", not "verified".
+
+7. **Fallback labeling.** Synthetic-fallback or estimated data (shown when an upstream API fails, or when an indicator is algorithmically derived rather than measured) is visibly marked "simulated / estimated — not measured". Real-but-thin data (e.g. 1–19 resolved signals) is labeled "insufficient live data (N=<n>)", NOT mislabeled as simulated.
+
+## Cross-surface consistency
+
+Two surfaces that present the same metric for the same window (e.g. the track-record page body, its OG social card, and its embed) must compute that metric the same way — same resolved-signal filter, same denominator. They must never show different numbers under the same claim.
+
+## Source of findings
+
+`docs/plans/2026-06-13-phase6a-audit-findings.md` — the 151-item audit this contract remediates.

--- a/docs/plans/2026-06-13-phase6-honest-regime-product.md
+++ b/docs/plans/2026-06-13-phase6-honest-regime-product.md
@@ -1,0 +1,104 @@
+# Phase 6 — Honest, regime-aware repositioning (design)
+
+Date: 2026-06-13
+Status: design / spec — awaiting owner review before implementation plan
+Author: session continuation after Phase 5 (PR #118 merged to main @ `b0a344b`)
+Supersedes the "Phase 5 (execution) — webhook go-live" block in `docs/plans/2026-06-10-engine-makeover.md` as the next active phase. Execution go-live stays gated; see Out of scope.
+
+## Why this phase exists
+
+Phases 4, 4.5, and 5 ran three independent edge-hunts under pre-registered frozen gates. All three failed at a retail cost structure:
+
+- **Timing (Phase 4 / 4.5):** single-asset OHLCV timing has no deployable edge after costs.
+- **Funding carry (Phase 5):** raw yield is real (+39.50% on 2x unlevered capital over 6.75y, all folds positive) but compresses to +2.35%/yr recently — below passive once cost bites.
+- **Cross-sectional momentum (Phase 5):** B1 is a survivorship mirage; B2's single subwindow PASS is a benchmark artifact.
+
+Full reasoning: `docs/research/2026-06-13-phase5-verdict-carry-xsection.md`.
+
+The load-bearing conclusion: there is no directional signal to sell. The durable asset is the validated edge-vs-noise bench (it killed three candidates before any customer saw them) and the Phase 3 regime engine (`docs/operators/regime-engine.md`). The owner's verbatim intent from the umbrella plan stands: **"The track record is the selling point; the engine is the moat."**
+
+So the product repositions from "follow these profitable signals" to **"here is the market regime, here is what we have honestly measured to work and not work, decide for yourself."** Honesty is the moat — which means the public surface must be *true* before it can lead with regime context.
+
+## Decisions (locked with owner, 2026-06-13)
+
+1. **Positioning:** reposition to a regime-context + honest-measurement product (not another edge-hunt, not carry re-test, not hold).
+2. **Audience / win condition:** the public honest-track-record surface. Win = GitHub stars + Alpha Screener (SaaS) signups. Not the narrow paid-SaaS-only play; not the B2B/IB layer (that is the separate TradingRail business and is not folded in here).
+3. **Sequence:** honesty sweep first (audit + fix every public measurement surface), regime presentation second. The most rigorous option — chosen because a product whose moat is honest measurement cannot half-ship the honesty.
+4. **"Verified" claim default:** if the audit finds the recorded data cannot back `/track-record`'s live "Verified — no hiding losses" claim, **soften the wording to exactly what the data supports** (e.g. "tracked signals, recorded outcomes, sample N") rather than ship an unbacked claim. Upgrade the claim later only if measurement improves. Never ship a claim the data can't back.
+
+## Current state verified on `main` (not assumed)
+
+- `apps/web/app/results/page.tsx` — **already partially remediated.** Title is "Strategy Profiles (Illustrative)"; description states "Hand-authored example metrics — not engine output. See /track-record for live, tracked performance." Still renders attractive win rates / Sharpe under that banner (`VALIDATION_SUMMARY`, `result.metrics.winRate`). Audit must judge whether the "Illustrative" framing is loud enough at a skim.
+- `apps/web/app/track-record/page.tsx` — **highest liability.** Metadata claims "Verified Signal Track Record", "Real performance data", "No cherry-picking, no hiding losses." Truth depends on `TrackRecordClient` data source and whether measurement is honest (the firehose / Pro-gate recording gap noted in prior audits: the Pro broadcast-gate decision was never recorded, so the displayed record may measure the wrong population).
+- `apps/web/app/backtest/page.tsx` — **fine.** Live interactive tool computing RSI/MACD/EMA on real candles via `@tradeclaw/strategies`; user-driven, not fabricated.
+- **Regime is not on any public page.** It exists only at `apps/web/app/admin/weekly-regime/` (operator) and `apps/web/app/api/v1/regime/route.ts` (API), persisted to `market_regimes`, resolved through `fetchResolvedRegimeMap()` (`apps/web/lib/regime-resolution.ts`) with the weekly-card override. Promoting it to the public hero is net-new presentation of data that already exists.
+
+## Phase 6a — Honesty sweep
+
+### 6a.1 Audit
+Inventory every public measurement surface and classify each displayed number, with `file:line` evidence and its data source, into one of:
+- `live-measured` — from a recorded source, with a stated sample size and date range
+- `synthetic-fallback` — generated when an upstream API fails (must be labeled)
+- `illustrative` — hand-authored example (must be labeled, e.g. current `/results`)
+- `over-optimistic-framing` — real data presented in a misleading way (cherry-picked window, hidden denominator, win-rate without sample size)
+- `unverifiable` — cannot trace to a source
+
+Surfaces in scope (public, measurement-bearing): `track-record`, `results`, `accuracy`, `benchmark`, `calibration`, `confidence`, `consensus`, `allocation`, `ab-stats`, plus the feeding APIs `/api/signals/equity`, `/api/signals/history`, `/api/signals/accuracy-context`, `/api/og/track-record`, `/embed/track-record`. The audit explicitly credits already-honest surfaces rather than re-flagging them.
+
+Output: a remediation table (surface → metric → classification → evidence → required fix). This step is read-only and fans out across ~10 surfaces — suited to parallel audit subagents.
+
+### 6a.2 Honesty contract
+One page, the rule every measurement surface must satisfy:
+- Every metric declares provenance: `live-measured` / `synthetic` / `illustrative`.
+- Every performance number shows sample size (N) and date range.
+- No fabricated or simulated equity curve is presented as real.
+- The headline "verified" claim is backed by a named recorded source that **includes losses and no-edge periods**, or the wording is softened to what the data supports (per decision 4).
+- Synthetic-fallback data is visibly labeled, never silently shown as real.
+
+### 6a.3 Remediate
+Fix each flagged item to the contract: relabel, add provenance + sample size, correct the measurement, or remove. Priority order: `/track-record` (the live "verified" claim) → any `over-optimistic-framing` → `unverifiable` → labeling polish on already-illustrative surfaces. Default action on the "verified" claim is soften-to-provable (decision 4); fixing the recording gap to *earn* "verified" is logged as a possible follow-up, not assumed into this phase.
+
+## Phase 6b — Regime + credibility surface (on the now-honest base)
+
+### 6b.1 Public regime view
+Surface current regime per asset from `/api/v1/regime` + `market_regimes`. Show the regime label (trend / volatile / range), how it is classified (the feature basis, in plain language), and its stability (recent flips). Net-new read-only presentation; no new data pipeline.
+
+### 6b.2 "What we tested and killed" panel
+For timing / carry / cross-sectional: the one-line honest verdict, each linking its registered research doc. This is the bench's credibility made visible — the differentiator. Pull verdicts verbatim from the Phase 4.5 and Phase 5 verdict docs; do not re-summarize loosely.
+
+### 6b.3 Lead the narrative
+Reframe the landing/hero so the public-facing story leads with regime context + honest measurement, with clear CTAs to the GitHub repo (stars) and Alpha Screener (signups).
+
+## Out of scope (logged, not creeping in)
+
+- Execution / webhook go-live — stays gated; no edge exists to execute on.
+- Flipping `TRADECLAW_STRATEGY_ROUTER_MODE` to active — it records only; do not activate.
+- The ~50 non-measurement public routes — untouched this phase.
+- The B2B / IB embeddable regime layer — that is the separate TradingRail business.
+- Earning the "verified" claim by fixing the Pro-gate recording gap — logged as a follow-up; default is soften-to-provable.
+
+## Build approach
+
+- 6a.1 audit: parallel read-only subagents, one per surface group; results merged into one remediation table.
+- 6a.3 remediation + 6b UI: TDD where measurement logic is involved (a metric's correctness gets a test); presentation-only changes get a documented manual check.
+- Each phase ships as its own PR. Branch isolation per repo discipline; the repo root is shared with concurrent jobs, so a feature branch based on current `origin/main` (`b0a344b`), not the stale local `main`.
+- Archive `gateguard-session.json` at phase start (the 50-clear cap recurs every phase; only the owner archives the state file).
+
+## Verification
+
+- Every remediated surface gets a test or a documented manual check.
+- The final "verified"/"tracked" wording maps to a specific named recorded data source (or is softened until it does).
+- Type-check passes; the 5 required CI checks (Lint & Type Check, Build, Unit Tests, Strategy Backtests, Docker Build) green per PR. Playwright E2E is non-required and chronically red on main — not a gate.
+
+## Risks
+
+- The audit may find the track record is mostly unbackable, forcing a large softening that weakens the marketing claim. Accepted: an honest weak claim beats a strong false one (decision 4).
+- Regime presentation invites "so what do I do with it?" — mitigated by the honest framing (context, not instruction) and the tested-and-killed panel setting expectations.
+- Concurrent writers on the shared repo root. Mitigated by feature-branch isolation off current `origin/main` and explicit-filename staging.
+
+## References
+
+- `docs/plans/2026-06-10-engine-makeover.md` — umbrella roadmap (owner intent, phase history).
+- `docs/research/2026-06-13-phase5-verdict-carry-xsection.md` — Phase 5 verdict.
+- `docs/plans/2026-06-12-phase4.5-entry-strategy-rethink.md` — Phase 4.5 timing verdict.
+- `docs/operators/regime-engine.md` — the regime engine (the moat).

--- a/docs/plans/2026-06-13-phase6a-audit-findings.md
+++ b/docs/plans/2026-06-13-phase6a-audit-findings.md
@@ -1,0 +1,250 @@
+# Phase 6a — Honesty Audit Findings
+
+Date: 2026-06-13
+Branch: `phase6-honest-regime-product`
+Method: 7 read-only audit subagents, one per surface group (Task 1 of `docs/plans/2026-06-13-phase6a-honesty-sweep-plan.md`).
+Status: complete — awaiting owner review before remediation (Task 3).
+
+## Summary
+
+~151 findings across 11 public surfaces. Counts by classification (approx):
+
+| classification | count | meaning |
+|---|---|---|
+| already-honest | ~23 | declares provenance + N; no change |
+| live-measured (missing N/date) | ~48 | real number, but no sample size or date range shown next to it |
+| illustrative (label not inline) | ~30 | hand-authored; labeled only at section/hero level, not at the value |
+| over-optimistic-framing | ~24 | real data shown misleadingly, OR a false "this is the real thing" claim |
+| synthetic-fallback (weak label) | ~10 | simulated/estimated data with a missing or tiny label |
+| unverifiable | ~14 | number cannot be traced to a source |
+
+Per-surface totals: track-record ~44, results 30, benchmark 18, accuracy 16, allocation+ab-stats ~16, calibration 13, confidence+consensus ~14.
+
+The single most honest surface is **calibration**. The single worst structural defect is the **track-record OG/embed inconsistency** (below). **benchmark** is a pricing/marketing page — its issues are marketing-claim honesty, not trading-measurement honesty (flagged separately for scope).
+
+---
+
+## Remediation priorities
+
+### P0 — false claims and internal contradictions (fix first)
+
+1. **track-record OG card + embed page use raw SQL that skips `isCountedResolved`** — they count auto-expired rows in the resolved denominator, so the social card and embed show a LOWER win-rate and different P&L than the page body, all under the same "Verified Track Record" banner. Two surfaces, same claim, contradictory numbers — this directly breaks "no hiding losses". Files: `apps/web/app/api/og/track-record/route.tsx:77-86`, `apps/web/app/embed/track-record/page.tsx:71-74`. Fix: route OG + embed through the same resolved-slice logic the page uses (`/api/signals/equity` or `getResolvedSlice`), so every surface shows identical numbers for the same window.
+2. **"Verified" used 6+ times with no external verifier** — page title, OG heading, embed label, hero eyebrow, equity-curve heading, transparency note. Per decision 4, soften to "Recorded / Tracked … resolved against Binance/Yahoo OHLCV" everywhere. Files: `track-record/page.tsx:18,24`, `TrackRecordClient.tsx:552,1258`, `equity-curve.tsx:400`, `og/track-record/route.tsx:71`, `embed/track-record/page.tsx:64`.
+3. **confidence page CODE_SNIPPET labeled "matches signal-generator.ts" but has wrong weights** — omits Volume, inflates MACD 20→25, and shows a `scaleConfidence` function the live calculator never calls. False "this is the real code" claim. File: `ConfidenceClient.tsx:149-157`. Fix: correct the snippet to the real weights, or drop the "matches" claim.
+4. **consensus `trend24h` arrow is a deterministic char-code+hour formula**, not a real 24h change, rendered on EVERY row including live-sourced ones with no label. File: `ConsensusClient.tsx:38-42`, `consensus/route.ts:42-48`. Fix: label "algorithmically estimated, not a measured 24h change", compute a real trend, or remove.
+5. **accuracy DataProvenanceBadge derived from the current 25-row page**, not full history — can show "Live verified" when the full record is "Mixed data". File: `AccuracyClient.tsx:171`. Fix: derive provenance from full-history stats.
+6. **allocation Current Exposure / Headroom / snapshot come from a paper-trading demo account with no "demo" label** — a real-looking exposure % that is not live capital. File: `AllocationClient.tsx:166-167,187-193`. Fix: add a prominent "Paper / demo account" label.
+7. **ab-stats "WINNING" badge fires on N=1** with no significance test or minimum sample gate. File: `ABStatsClient.tsx:95-98,117-119`. Fix: relabel "leading", add a min-impression gate, keep the existing "single-browser localStorage" caveat prominent.
+
+### P1 — live-measured numbers missing N / date range
+
+Add sample size (N) and date range adjacent to each. Concentrations:
+- **track-record:** headline total return + win-rate (no "since <date>"), equity Sharpe (no N-days — a 5-day Sharpe looks like a 500-day one), avgRWin/avgRLoss/expectancy (no SL-subset N), per-symbol hit-rates, trailing-week band cards. Files across `TrackRecordClient.tsx`, `equity-curve.tsx`, `trailing-week-band-callout.tsx`.
+- **accuracy:** win-rate, avg P&L, total P&L cards — no date range; "Avg Confidence" uses a DIFFERENT denominator (all records) than win-rate (resolved) — `AccuracyClient.tsx:208`; loss% bar is residual `100−winRate` not `losses/resolved` — `AccuracyClient.tsx:328`. Fix denominators + show N/date.
+- **calibration:** Brier/ECE/win-rate cards have N but no date range — `CalibrationClient.tsx:257-273`.
+- **consensus:** bullish %, buy/sell counts, avg confidences — no time window shown — `ConsensusClient.tsx:82-210`.
+
+### P1.5 — real-but-thin data mislabeled as simulated
+
+- **calibration / accuracy:** when 1–19 real resolved signals exist, the API sets `isSimulated: true` and the UI shows a "Demo data / simulated signal history" banner over REAL (thin) numbers. Files: `calibration/route.ts:112`, `CalibrationClient.tsx:243-251`, `accuracy` provenance. Fix: distinguish "insufficient live data (N=<n>)" from the true simulated case (N=0 catch-block fallback).
+
+### P2 — illustrative labels not inline at the value
+
+- **results:** page-level disclosure (hero badge, paragraph, disclaimer bar) is solid, but all ~27 rendered values — 5 MetricCards, the 5×5 comparison table, the PRNG equity curve (with hardcoded `Mar/Jun/Sep/Dec/Feb` axis labels implying real calendar data), the monthly heatmap — carry the "illustrative" tag only at section/hero level. A skim reader mid-page sees compelling green +41.3% / Sharpe 2.05 with no inline provenance. Fix: add an inline "illustrative" marker at the value/card/table level; watermark the PRNG chart.
+- **confidence:** interactive calculator labeled weakly; presets ("Perfect Setup" rsi:95) not marked invented. `ConfidenceClient.tsx:79-93,229`.
+- **synthetic-fallback weak labels:** consensus "ESTIMATED" badge is `text-[10px]` — easy to miss (`ConsensusClient.tsx:54-55`); allocation paper-account values unlabeled (see P0.6); calibration catch-block demo values labeled only in secondary text.
+
+### Scope flag — benchmark
+
+`benchmark` is a pricing/competitor-comparison page, not a trading-performance page. Its findings (the "$200/mo" headline that no listed SaaS matches; competitor prices with no source/date; "Join 1,000-star mission" implying a near-1000 star count; pre-written social posts asserting savings as fact) are real but are marketing-claim honesty, a different category from the measurement honesty that is the product moat. Owner decision: fold benchmark into Phase 6a, or split it into a marketing-honesty follow-up.
+
+---
+
+## Per-surface findings tables
+
+### track-record (+ OG + embed)
+
+Summary: already-honest 12 · live-measured 22 · over-optimistic-framing 10.
+
+| metric / claim | file:line | data source | classification | required fix |
+|---|---|---|---|---|
+| title "Verified Signal Track Record" | page.tsx:18 | marketing claim | over-optimistic-framing | no external verifier; soften wording / define "verified" |
+| OG desc "Real performance data / No hiding losses" | page.tsx:24 | marketing claim | over-optimistic-framing | claim weakened by gate/expired exclusions; add caveat |
+| hero eyebrow "Verified Track Record" | TrackRecordClient.tsx:552 | copy | over-optimistic-framing | scope label or remove "Verified" |
+| headline total return "+X%" | TrackRecordClient.tsx:561 | /api/signals/history totalPnlPct | live-measured | add "(since <date>)" adjacent |
+| headline win-rate "X%" | TrackRecordClient.tsx:571 | /api/signals/history winRate | live-measured | show break-even win-rate at headline level |
+| resolved-signals count | TrackRecordClient.tsx:583 | /api/signals/history resolved | already-honest | — |
+| rolling 7d/30d/90d win rates | TrackRecordClient.tsx:633-658 | /api/signals/equity rollingWinRates | live-measured | label thin windows (7d on <7d data) |
+| "Resolved" stat card | TrackRecordClient.tsx:822-828 | history resolved | already-honest | — |
+| "Avg P&L" per resolved | TrackRecordClient.tsx:829-835 | history avgPnlPct | live-measured | co-locate N + date |
+| "Total P&L" stat card | TrackRecordClient.tsx:836-842 | history totalPnlPct (raw sum) | live-measured | hint says "Sum at fixed 1R" but value is raw market pnl sum — mislabel; fix wording |
+| "Streak" | TrackRecordClient.tsx:843-849 | history streak | already-honest | — |
+| expired/gate-blocked/pending counters | TrackRecordClient.tsx:851-871 | history | already-honest | — |
+| category win-rate (All/Majors/Thematic) | TrackRecordClient.tsx:363 | /api/signals/equity winRate | live-measured | n= shown; add date range |
+| category expectancyR | TrackRecordClient.tsx:373-376 | equity expectancyR | live-measured | add date range |
+| category break-even win-rate | TrackRecordClient.tsx:378-380 | equity breakEvenWinRate | already-honest | — |
+| Pro scope banner | TrackRecordClient.tsx:769-773 | copy | live-measured | scope label, acceptable |
+| broadcast disclaimer "recorded since 2026-06-10" | TrackRecordClient.tsx:728-729 | equity scope=broadcast | already-honest | — |
+| per-symbol totalSignals | TrackRecordClient.tsx:993 | /api/leaderboard | already-honest | — |
+| per-symbol hitRate4h/24h | TrackRecordClient.tsx:994-995 | /api/leaderboard | live-measured | add date range for selected period |
+| per-symbol avgPnl/totalPnl | TrackRecordClient.tsx:999-1004 | /api/leaderboard | live-measured | N via row, ok |
+| all-signals per-row P&L | TrackRecordClient.tsx:1168 | history outcomes 24h pnlPct | already-honest | OHLCV-sourced |
+| all-signals "expired" label | TrackRecordClient.tsx:1164 | history | already-honest | — |
+| pagination "X–Y of Z" | TrackRecordClient.tsx:1042 | history total | already-honest | — |
+| transparency note (OHLCV providers) | TrackRecordClient.tsx:1255-1259 | resolution | already-honest | — |
+| "No cherry-picking, no hidden losses" | TrackRecordClient.tsx:1258 | copy | over-optimistic-framing | smooth-outliers toggle weakens; add caveat |
+| equity Total Return (compounded) | equity-curve.tsx:479 | equity totalReturn | live-measured | add date range |
+| equity Max Drawdown | equity-curve.tsx:492 | equity maxDrawdown | live-measured | add N/date |
+| equity Win Rate | equity-curve.tsx:511 | equity winRate | already-honest | break-even adjacent |
+| equity Sharpe (annualized) | equity-curve.tsx:541 | equity sharpeRatio | live-measured | show N days (a 5-day Sharpe ≠ 500-day) |
+| equity Avg R per Win/Loss | equity-curve.tsx:551-559 | equity avgRWin/Loss | live-measured | show SL-subset N |
+| equity Expectancy | equity-curve.tsx:572 | equity expectancyR | live-measured | show SL-subset N |
+| smooth-outliers (P95) toggle | equity-curve.tsx:449-462 | clips P95 of R-dist | over-optimistic-framing | flattering shareable curve; persist/label when active |
+| trailing-week 7d returns (all/premium) | trailing-week-band-callout.tsx:123 | equity 7d | live-measured | surface "premium = conf≥85"; show window |
+| trailing-week win-rate/expectancy | trailing-week-band-callout.tsx:129-141 | equity | live-measured | break-even + SL-subset N |
+| OG "VERIFIED TRACK RECORD — 30 DAYS" | og/track-record/route.tsx:71 | hardcoded | over-optimistic-framing | "verified" + OG window (30d) differs from page default (all) |
+| OG signal count (30d) | og/track-record/route.tsx:77 | raw SQL, NO isCountedResolved | live-measured | includes auto-expired — inconsistent with page |
+| OG win rate (30d) | og/track-record/route.tsx:81 | raw SQL win_rate | over-optimistic-framing | denominator includes expired → differs from page |
+| OG total P/L (30d) | og/track-record/route.tsx:85-86 | raw SQL total_pnl | over-optimistic-framing | sums expired rows → differs from page |
+| embed "verified track record (30d)" | embed/track-record/page.tsx:64 | hardcoded | over-optimistic-framing | "verified" gap |
+| embed signals/wins (30d) | embed/track-record/page.tsx:71 | raw SQL | live-measured | same denominator gap as OG |
+| embed win rate (30d) | embed/track-record/page.tsx:73 | raw SQL win_rate | over-optimistic-framing | inconsistent with page |
+| embed Σ PnL (30d) | embed/track-record/page.tsx:74 | raw SQL total_pnl | over-optimistic-framing | inconsistent with page; no N |
+| equity heading "Verified against real market data" | equity-curve.tsx:400 | copy | over-optimistic-framing | reword to "resolved against Binance/Yahoo OHLCV" |
+
+### results
+
+Summary: already-honest 3 · illustrative 27. All numbers come from hand-authored `SEED_DATA` / `VALIDATION_SUMMARY` and PRNG-generated curves (`backtest-results.ts`). Page-level disclosure is solid; per-value inline labels are missing.
+
+| metric / claim | file:line | classification | required fix |
+|---|---|---|---|
+| "Illustrative Examples" badge | ResultsClient.tsx:220-223 | already-honest | — |
+| disclosure paragraph | ResultsClient.tsx:227-232 | already-honest | — |
+| disclaimer bar | ResultsClient.tsx:261-264 | already-honest | — |
+| example window dates | ResultsClient.tsx:237-239 | illustrative | inline qualifier |
+| coverage strategy-runs (15) | ResultsClient.tsx:244 | illustrative | inline qualifier |
+| coverage total trades (2,821) | ResultsClient.tsx:244 | illustrative | inline qualifier |
+| coverage asset count (3) | ResultsClient.tsx:246 | illustrative | inline qualifier |
+| weighted win rate (62.4%) | ResultsClient.tsx:251 | illustrative | inline qualifier |
+| average Sharpe (1.50) | ResultsClient.tsx:251 | illustrative | inline qualifier |
+| best Sharpe call-out (2.05) | ResultsClient.tsx:254 | illustrative | inline qualifier |
+| best return (+41.3%) | ResultsClient.tsx:259 | illustrative | inline qualifier |
+| avg drawdown (-13.8%) | ResultsClient.tsx:259 | illustrative | inline qualifier |
+| MetricCard Total Return | ResultsClient.tsx:321-327 | illustrative | inline label on card |
+| MetricCard Win Rate | ResultsClient.tsx:328-333 | illustrative | inline label on card |
+| MetricCard Sharpe | ResultsClient.tsx:334-339 | illustrative | inline label on card |
+| MetricCard Max Drawdown | ResultsClient.tsx:340-346 | illustrative | inline label on card |
+| MetricCard Total Trades | ResultsClient.tsx:347-352 | illustrative | inline label on card |
+| equity curve (PRNG) | ResultsClient.tsx:356-364 | illustrative | watermark chart body |
+| equity curve date axis (Mar..Feb) | ResultsClient.tsx:143 | illustrative | axis implies real calendar — most misleading element |
+| monthly returns heatmap | ResultsClient.tsx:369-381 | illustrative | per-cell qualifier |
+| avg hold time | ResultsClient.tsx:386-394 | illustrative | inline qualifier |
+| example period card | ResultsClient.tsx:395-404 | already-honest | labeled "Example Period" inline |
+| comparison table Return/WinRate/Sharpe/MaxDD/Trades (5 cols × rows) | ResultsClient.tsx:455-469 | illustrative | table-level qualifier; emerald Sharpe highlight draws attention |
+
+### accuracy
+
+Summary: already-honest 5 · live-measured 6 · over-optimistic-framing 3 · synthetic-fallback 1 · illustrative 1 · unverifiable 1.
+
+| metric / claim | file:line | data source | classification | required fix |
+|---|---|---|---|---|
+| Total Signals | AccuracyClient.tsx:197 | history records.length (incl pending/expired) | live-measured | clarify includes pending/expired |
+| Win Rate | AccuracyClient.tsx:200 | history wins/resolved (isCountedResolved) | live-measured | show resolved N + date |
+| Avg P&L | AccuracyClient.tsx:205 | history avgPnlPct | live-measured | show N/date |
+| Avg Confidence | AccuracyClient.tsx:208 | history over ALL records (≠ win-rate denom) | over-optimistic-framing | align denominator / label |
+| Wins / Losses | AccuracyClient.tsx:209-210 | history | live-measured | show date |
+| Total P&L | AccuracyClient.tsx:213 | history flat sum | live-measured | "Total P&L" implies compounding; clarify |
+| Resolved X/Y | AccuracyClient.tsx:216 | history | already-honest | — |
+| win% bar label | AccuracyClient.tsx:327 | winRate | live-measured | N adjacent |
+| loss% bar label | AccuracyClient.tsx:328 | 100−winRate residual | over-optimistic-framing | compute from losses/resolved; pending not shown |
+| per-row confidence badge | AccuracyClient.tsx:527-529 | model-emitted | unverifiable | document meaning/calibration |
+| per-row 4h/24h result | AccuracyClient.tsx:443-543 | resolveFromCandles | already-honest | labeled live/example |
+| per-row P&L% | AccuracyClient.tsx:451 | resolveFromCandles/expired placeholder | synthetic-fallback | label expired rows in P&L cell |
+| MetricMeta n=X | AccuracyClient.tsx:179 | resolved | already-honest | — |
+| Recent Outcomes n shown | AccuracyClient.tsx:231 | display slice | already-honest | — |
+| DataProvenanceBadge | AccuracyClient.tsx:171 | current 25-row page only | over-optimistic-framing | derive from full history |
+| transparency note | AccuracyClient.tsx:504-508 | prose (refs JSON path; prod is Postgres) | illustrative | correct path; raise prominence |
+
+### benchmark (pricing/marketing — scope flag)
+
+Summary: illustrative 3 · over-optimistic-framing 5 · unverifiable 10. All from hand-authored `SAAS_OPTIONS`/`VPS_OPTIONS`/`FEATURE_ROWS` constants.
+
+| metric / claim | file:line | classification | required fix |
+|---|---|---|---|
+| "$200/mo" headline | BenchmarkClient.tsx:205 | over-optimistic-framing | no listed SaaS = $200; ground or relabel |
+| "$0 TradeClaw/mo" | BenchmarkClient.tsx:214 | illustrative | note "+~$4 VPS" |
+| "Average SaaS/mo" | BenchmarkClient.tsx:218 | over-optimistic-framing | disclose N=4 curated plans |
+| 4 SaaS prices | BenchmarkClient.tsx:235 | unverifiable | source + last-verified date |
+| TradeClaw "$0 (or $4 VPS)" bar | BenchmarkClient.tsx:254 | illustrative | prominence |
+| savings calculator output | BenchmarkClient.tsx:327 | unverifiable | source prices |
+| "{freeVPSMonths} months of VPS" | BenchmarkClient.tsx:334 | illustrative | label $4/mo basis |
+| 4 VPS prices | BenchmarkClient.tsx:42-45 | unverifiable | source + date |
+| feature comparison rows | BenchmarkClient.tsx:60-70 | unverifiable | methodology/tier/date |
+| feature-table cost row | BenchmarkClient.tsx:412-414 | unverifiable | source/date |
+| "Join 1,000-star mission" | BenchmarkClient.tsx:539 | over-optimistic-framing | fetch live star count or remove |
+| pre-written social posts ("saves me $X/yr") | BenchmarkClient.tsx:187-189 | over-optimistic-framing | unverified savings asserted as fact |
+
+### calibration
+
+Summary: live-measured 8 · over-optimistic-framing 1 · synthetic-fallback 1 · already-honest 3. The most honest surface.
+
+| metric / claim | file:line | data source | classification | required fix |
+|---|---|---|---|---|
+| Total Signals | CalibrationClient.tsx:257 | /api/calibration isCountedResolved | live-measured | add date range |
+| Overall Win Rate | CalibrationClient.tsx:261 | /api/calibration | live-measured | add date range |
+| Brier + quality label | CalibrationClient.tsx:265-266 | /api/calibration | live-measured | N/date; document thresholds |
+| ECE + verdict | CalibrationClient.tsx:271-273 | /api/calibration | live-measured | N/date adjacent |
+| calibration curve | CalibrationClient.tsx:299 | per-bucket winRate | live-measured | bucket N drawn; add date |
+| bucket "Actual" win rate | CalibrationClient.tsx:338 | /api/calibration | live-measured | N present; add date |
+| bucket "Error" diff | CalibrationClient.tsx:341 | derived | live-measured | N present; add date |
+| bucket "Status" badge | CalibrationClient.tsx:344-358 | derived (5pp threshold) | live-measured | show threshold inline |
+| "Demo data" banner on 1–19 real signals | CalibrationClient.tsx:243-251 + route.ts:112 | real thin data | over-optimistic-framing | distinguish "insufficient live data (N=x)" from simulated |
+| catch-block fallback demo values | CalibrationClient.tsx:173-188 | hardcoded | synthetic-fallback | raise label prominence per-card |
+| footer "Updated:" | CalibrationClient.tsx:384 | data.updatedAt | already-honest | — |
+| footer "N signals analyzed" | CalibrationClient.tsx:384 | totalSignals | already-honest | — |
+| methodology + data-source line | CalibrationClient.tsx:375-378 | prose, toggles with isSimulated | already-honest | — |
+
+### confidence + consensus
+
+confidence summary: over-optimistic-framing 2 · unverifiable 2 · illustrative 3. consensus summary: live-measured 5 · synthetic-fallback 4.
+
+| surface | metric / claim | file:line | data source | classification | required fix |
+|---|---|---|---|---|---|
+| confidence | live confidence score (giant number) | ConfidenceClient.tsx:229 | in-browser weighted sum | illustrative | prominent "interactive demo, not a live signal" label |
+| confidence | tier thresholds (55..90) | ConfidenceClient.tsx:96-104 | hardcoded constants | unverifiable | cite verified commit/version |
+| confidence | "+15% confluence boost / capped at 70" claims | ConfidenceClient.tsx:418-420 | prose | unverifiable | cite code path or remove |
+| confidence | CODE_SNIPPET weights (RSI20/MACD25/EMA20/STOCH15/BB10) | ConfidenceClient.tsx:149-152 | hardcoded string ≠ actual INDICATORS | over-optimistic-framing | omits Volume, MACD wrong; "matches signal-generator.ts" misleading |
+| confidence | scaleConfidence (48–95) in snippet | ConfidenceClient.tsx:155-157 | string; calculator never calls it | over-optimistic-framing | remove/correct |
+| confidence | presets "Strong BUY"/"Perfect Setup" | ConfidenceClient.tsx:79-93 | hardcoded | illustrative | note presets are invented examples |
+| confidence | per-indicator contribution bars | ConfidenceClient.tsx:332-334 | in-browser sum | illustrative | covered by page-level label |
+| consensus | overallBullish % gauge | ConsensusClient.tsx:16 | /api/consensus H1+H4 | live-measured | show time window |
+| consensus | total buy/sell signal counts | ConsensusClient.tsx:208-210 | /api/consensus | live-measured | show lookback window |
+| consensus | per-asset buy/sell counts+% | ConsensusClient.tsx:82-93 | /api/consensus | live-measured | show window |
+| consensus | per-asset avg buy/sell confidence | ConsensusClient.tsx:100-105 | /api/consensus | live-measured | show N averaged |
+| consensus | trend24h arrow (every row) | ConsensusClient.tsx:38-42 + route.ts:42-48 | deterministic char-code+hour, NOT real 24h | synthetic-fallback | label "algorithmically estimated" or compute real |
+| consensus | synthetic fallback counts/confidences | ConsensusClient.tsx:54-55 + route.ts:68-88 | deterministic seed | synthetic-fallback | "ESTIMATED" badge is text-[10px] — raise prominence |
+| consensus | mostBullish/Bearish/Conflicted tickers | ConsensusClient.tsx:190-202 | signal pool | live-measured | show N (N=1 looks like N=20) |
+| consensus | "updated every 60s from live signal engine" | ConsensusClient.tsx:177 + page.tsx:6 | partly false when synthetic active | synthetic-fallback | qualify "or estimated when live unavailable" |
+
+### allocation + ab-stats
+
+allocation summary: live-measured 2 · illustrative 4 · synthetic-fallback 3. ab-stats summary: live-measured 5 · over-optimistic-framing 3.
+
+| surface | metric / claim | file:line | data source | classification | required fix |
+|---|---|---|---|---|---|
+| allocation | Active Regime label | AllocationClient.tsx:157-159 | /api/v1/regime DB | live-measured | show N symbols + detectedAt |
+| allocation | Max Exposure rule values | AllocationClient.tsx:45-47 | hardcoded ALLOCATION_RULES (display mirror) | illustrative | "(policy rules — not fetched live)" note |
+| allocation | Leverage rule values | AllocationClient.tsx:45-47 | hardcoded | illustrative | same |
+| allocation | Max Position rule values | AllocationClient.tsx:45-47 | hardcoded | illustrative | same |
+| allocation | Current Exposure % | AllocationClient.tsx:166-167 | /api/widget/portfolio paper-demo user | synthetic-fallback | "Paper / demo account" label |
+| allocation | Headroom % | AllocationClient.tsx:187-188 | paper-demo vs hardcoded max | synthetic-fallback | demo label + denominator note |
+| allocation | snapshot sub-line | AllocationClient.tsx:191-193 | paper-demo DB | synthetic-fallback | demo label inline |
+| allocation | per-symbol regime tag | AllocationClient.tsx:279 | /api/v1/regime DB | live-measured | show detectedAt per card |
+| allocation | per-symbol Max pos/Dir | AllocationClient.tsx:283-284 | hardcoded rules | illustrative | tooltip "policy rule, not live" |
+| ab-stats | Total Impressions | ABStatsClient.tsx:74 | localStorage single-browser | live-measured | add first-seen date |
+| ab-stats | Total GitHub Clicks | ABStatsClient.tsx:77 | localStorage | live-measured | add date |
+| ab-stats | Overall CTR % | ABStatsClient.tsx:82-84 | localStorage, no min N | over-optimistic-framing | show N fraction; caveat below threshold |
+| ab-stats | per-variant impressions | ABStatsClient.tsx:141-143 | localStorage | live-measured | add date |
+| ab-stats | per-variant clicks | ABStatsClient.tsx:142-144 | localStorage | live-measured | add date |
+| ab-stats | per-variant CTR % | ABStatsClient.tsx:93,149 | localStorage, no N gate | over-optimistic-framing | show N; suppress/caveat below 30 |
+| ab-stats | "WINNING" badge | ABStatsClient.tsx:95-119 | max-clicks, fires on N=1 | over-optimistic-framing | "leading" + min-sample gate + no-stat-test note |

--- a/docs/plans/2026-06-13-phase6a-honesty-sweep-plan.md
+++ b/docs/plans/2026-06-13-phase6a-honesty-sweep-plan.md
@@ -1,0 +1,184 @@
+# Phase 6a — Honesty Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every public measurement surface provably honest — each displayed number declares its provenance and sample size, no unbacked claim ships — before Phase 6b promotes regime context to the public hero.
+
+**Architecture:** A read-only parallel audit fans out one subagent per surface, each classifying every displayed metric against a fixed schema; results merge into one findings table. A one-page honesty contract codifies the rule. Remediation then runs as a per-finding loop — TDD where a measurement number is computed, wording/labeling edits otherwise — one commit per finding.
+
+**Tech Stack:** Next.js App Router (`apps/web`), React client components, TypeScript, the `signal-history` / `signal-slice` / equity API libs, Jest (`*.test.ts`), the 5 required CI checks.
+
+**Spec:** `docs/plans/2026-06-13-phase6-honest-regime-product.md` (decisions 1–4 govern this plan; decision 4 = soften unbacked claims to what the data supports).
+
+**Branch:** `phase6-honest-regime-product` (already created off `origin/main` `b0a344b`; spec committed at `d1b7bbd`).
+
+---
+
+## File structure
+
+- **Create (Task 1 output):** `docs/plans/2026-06-13-phase6a-audit-findings.md` — the merged findings table.
+- **Create (Task 2 output):** `docs/operators/honesty-contract.md` — the one-page contract.
+- **Modify (Task 3, per finding):** the flagged client/lib files under `apps/web/app/<surface>/*Client.tsx` and their API/lib feeders. Exact files are unknown until Task 1; each finding row names its own `file:line`.
+
+### In-scope surfaces → entry files (audit targets)
+
+| Surface | Page | Client | Primary data source |
+|---|---|---|---|
+| track-record | `apps/web/app/track-record/page.tsx` | `track-record/TrackRecordClient.tsx` | `/api/signals/equity`, `/api/signals/history` |
+| results | `apps/web/app/results/page.tsx` | `results/ResultsClient.tsx` | hand-authored `VALIDATION_SUMMARY` (illustrative) |
+| accuracy | `apps/web/app/accuracy/page.tsx` | `accuracy/AccuracyClient.tsx` | `/api/signals/accuracy-context` |
+| benchmark | `apps/web/app/benchmark/page.tsx` | `benchmark/BenchmarkClient.tsx` | (audit to trace) |
+| calibration | `apps/web/app/calibration/page.tsx` | `calibration/CalibrationClient.tsx` | `/api/calibration` |
+| confidence | `apps/web/app/confidence/page.tsx` | (audit to locate client) | (audit to trace) |
+| consensus | `apps/web/app/consensus/page.tsx` | (audit to locate client) | (audit to trace) |
+| allocation | `apps/web/app/allocation/page.tsx` | (audit to locate client) | (audit to trace) |
+| ab-stats | `apps/web/app/ab-stats/page.tsx` | (audit to locate client) | (audit to trace) |
+| og/embed | `apps/web/app/api/og/track-record/route.tsx`, `apps/web/app/embed/track-record/page.tsx` | — | mirror of track-record |
+
+---
+
+### Task 1: Honesty audit (read-only fan-out → findings table)
+
+**Files:**
+- Create: `docs/plans/2026-06-13-phase6a-audit-findings.md`
+
+This task is discovery, not TDD. Its "test" is the completeness check in Step 4.
+
+- [ ] **Step 1: Freeze the audit row schema**
+
+Every flagged item is one row. Classifications are exactly these six (no others):
+- `already-honest` — declares provenance + sample size; no change needed
+- `live-measured` — from a recorded source but MISSING a visible sample size or date range
+- `synthetic-fallback` — shown without a visible "simulated / API unavailable" label
+- `illustrative` — hand-authored, label present but not prominent at a skim
+- `over-optimistic-framing` — real data shown misleadingly (cherry-picked window, hidden denominator, win-rate with no N, win-rate not compared to break-even)
+- `unverifiable` — cannot trace the number to any source
+
+Row format:
+
+```
+| surface | metric / claim | file:line | data source | classification | required fix |
+```
+
+- [ ] **Step 2: Dispatch one audit subagent per surface (parallel)**
+
+Use `superpowers:dispatching-parallel-agents`. One read-only subagent per row of the in-scope table above (≈10). Each subagent receives this exact charter:
+
+> Read the page, its client component, and every data source it fetches. For EACH number, percentage, equity curve, or performance claim rendered to the user, emit one row in the frozen schema. Classify against the six categories. Quote the `file:line`. Trace each number to its source (API route, lib function, or hand-authored constant) and state whether a sample size (N) and date range are shown next to it. Do NOT propose UI redesigns. Do NOT edit files. Return only the rows.
+
+- [ ] **Step 3: Merge + dedup the rows**
+
+Concatenate all subagent rows into one table, grouped by surface. Drop exact duplicates. Do not re-summarize — keep each subagent's `file:line` verbatim.
+
+- [ ] **Step 4: Completeness check**
+
+Verify every in-scope surface produced ≥1 row (a surface with zero flagged items still gets one `already-honest` row stating so). Verify no row has an empty `data source` or `classification`. If a surface was skipped, re-dispatch its subagent. This is the task's pass condition.
+
+- [ ] **Step 5: Write + commit the findings doc**
+
+Write the merged table to `docs/plans/2026-06-13-phase6a-audit-findings.md` with a one-paragraph summary (counts per classification). Then:
+
+```bash
+git add docs/plans/2026-06-13-phase6a-audit-findings.md
+git commit -m "docs(audit): Phase 6a honesty audit — measurement-surface findings table"
+```
+
+---
+
+### Task 2: Honesty contract doc
+
+**Files:**
+- Create: `docs/operators/honesty-contract.md`
+
+- [ ] **Step 1: Write the contract**
+
+The full content (this is the deliverable, not a placeholder):
+
+```markdown
+# Honesty Contract — public measurement surfaces
+
+Every public surface that renders a performance number must satisfy ALL of:
+
+1. Provenance label. Each number is one of: `live-measured`, `synthetic`, `illustrative`. The label is visible without hover, at skim distance.
+2. Sample size + window. Every win-rate / return / Sharpe shows N (resolved signals) and the date range it covers.
+3. No fabricated curve. No simulated or hand-authored equity curve is presented as real performance.
+4. Win-rate context. A win-rate is shown alongside its break-even win-rate; "above/below break-even" is explicit.
+5. Cost honesty. Returns are net of the stated round-trip cost (currently 2bps); the cost is disclosed.
+6. Claim backing. Any headline word like "verified" maps to a named recorded source that INCLUDES losses and no-edge periods. If the data cannot back the word, the word is softened to what the data supports (Phase 6 decision 4) — never the reverse.
+7. Fallback labeling. Synthetic-fallback data (shown when an upstream API fails) is visibly marked "simulated — live data unavailable".
+
+A surface passes only when every rendered number satisfies 1–7.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/operators/honesty-contract.md
+git commit -m "docs(honesty): contract for public measurement surfaces"
+```
+
+---
+
+### Task 3: Remediation loop (one pass per finding row)
+
+Drive this from the Task 1 table. Process every row whose classification is NOT `already-honest`. Order: `track-record` rows first (highest liability), then `over-optimistic-framing`, then `unverifiable`, then the rest. Use `superpowers:subagent-driven-development` — one task per finding.
+
+For EACH finding, pick the matching recipe. Each recipe is concrete; the row supplies the `file:line`.
+
+- [ ] **Recipe A — `over-optimistic-framing` or `live-measured` missing N (measurement-visible):** TDD.
+  1. Write a failing test asserting the rendered/returned payload includes the sample size and (where applicable) break-even comparison. Example for an equity-style endpoint:
+     ```ts
+     it('exposes resolvedSignals (N) and breakEvenWinRate alongside winRate', async () => {
+       const res = await GET(makeReq('/api/signals/equity?scope=pro&period=all'));
+       const body = await res.json();
+       expect(body.summary.resolvedSignals).toBeGreaterThanOrEqual(0);
+       expect(body.summary).toHaveProperty('breakEvenWinRate');
+     });
+     ```
+  2. Run it: `npm test -- <path>` → expect FAIL.
+  3. Add the field to the payload / surface it in the client next to the number.
+  4. Run it → expect PASS.
+  5. Commit: `git add <files> && git commit -m "fix(<surface>): show N + break-even alongside win-rate"`.
+
+- [ ] **Recipe B — `illustrative` not prominent:** wording/labeling, no test.
+  1. Add a visible inline badge next to the metric block, e.g. `<span className="...">Illustrative — hand-authored, not engine output</span>` (match the page's existing badge styling; do not invent a component).
+  2. Manual check: load the page, confirm the badge is visible at skim distance above the fold.
+  3. Commit: `git add <file> && git commit -m "fix(<surface>): make illustrative label prominent"`.
+
+- [ ] **Recipe C — `synthetic-fallback` unlabeled:** labeling.
+  1. Where the fallback path is taken, set a flag and render "simulated — live data unavailable" near the affected numbers.
+  2. Manual check: force the fallback (mock the API to fail) and confirm the label renders.
+  3. Commit: `git add <files> && git commit -m "fix(<surface>): label synthetic fallback data"`.
+
+- [ ] **Recipe D — `unverifiable`:** remove or label.
+  1. If the number has no source, remove the element OR replace it with an explicit "unverified / illustrative" label. Default to removal unless the row's required-fix says otherwise.
+  2. Manual check: page renders without the unbacked number.
+  3. Commit: `git add <file> && git commit -m "fix(<surface>): remove unverifiable metric"`.
+
+- [ ] **Recipe E — unbacked "verified" claim (track-record headline):** soften wording (decision 4).
+  1. Change the claim to what the recorded data supports. Concrete before/after:
+     - Before: `"Verified Signal Track Record … Real performance data. No cherry-picking, no hiding losses."`
+     - After: `"Tracked Signal Record — recorded outcomes for N resolved signals since <date>, net of 2bps cost. Includes losses and break-even periods."`
+     Update `metadata` (title/description/openGraph/twitter) in `apps/web/app/track-record/page.tsx` AND the in-page hero copy in `TrackRecordClient.tsx`, AND the mirror in `apps/web/app/api/og/track-record/route.tsx`.
+  2. Manual check: grep the three files for "Verified"/"verified" — none remain unless backed.
+  3. Commit: `git add <files> && git commit -m "fix(track-record): soften headline claim to recorded-outcomes wording"`.
+
+- [ ] **Final step: full verification before PR**
+  1. `npm run -w apps/web type-check` (or repo's type-check script) → green.
+  2. `npm test` for touched packages → green.
+  3. Confirm every non-`already-honest` row has a corresponding commit.
+  4. Push branch, open PR titled `Phase 6a: honesty sweep — every public metric declares provenance + sample size`. Required CI (Lint&Type, Build, Unit Tests, Strategy Backtests, Docker Build) green; E2E non-required.
+
+---
+
+## Self-review
+
+**Spec coverage:** 6a.1 audit → Task 1; 6a.2 contract → Task 2; 6a.3 remediation → Task 3 (recipes cover all six classifications and decision 4). Phase 6b is intentionally a separate plan (independent subsystem, not findings-gated).
+
+**Placeholder scan:** Task 1/2 content is fully written. Task 3 recipes are concrete with worked code/wording; the only deferred specifics (exact `file:line`) are supplied by Task 1's table at execution time — a real data dependency, not a placeholder.
+
+**Type consistency:** classifications are the same six names in Step 1, the contract, and the recipes. Field names (`resolvedSignals`, `breakEvenWinRate`, `winRate`) match the verified `/api/signals/equity` payload.
+
+## Gate to Phase 6b
+
+Phase 6b (public regime view + "tested & killed" panel + hero reframe) gets its own plan after 6a's PR merges. It does not depend on the audit findings, but it must sit on the honest base 6a produces.


### PR DESCRIPTION
## Phase 6a — Honesty sweep

After Phase 5 (#118) proved no retail-cost edge clears its frozen gates (timing, carry, and cross-sectional all dead), the product repositions from "follow these signals" to **regime context + honest measurement**. Honesty is the moat — so the public surface must be *true* before regime context can lead. This PR is the honesty sweep; the regime presentation (Phase 6b) follows on the honest base.

Design: `docs/plans/2026-06-13-phase6-honest-regime-product.md` · Plan: `docs/plans/2026-06-13-phase6a-honesty-sweep-plan.md` · Audit: `docs/plans/2026-06-13-phase6a-audit-findings.md` · Contract: `docs/operators/honesty-contract.md`

### What this does
A 7-agent read-only audit classified every number on 11 public measurement surfaces (151 findings), then a full-sweep remediation fixed them to the honesty contract (provenance label, sample size + window, no fabricated curve, win-rate vs break-even, cost honesty, claim-backing, fallback labeling).

### Fixes by surface
- **track-record** — OG card + embed now use the SAME resolved-signal logic as the page body (they were running raw SQL that counted auto-expired rows → a lower win-rate under the same "Verified" banner: a real internal contradiction). Shared helper `apps/web/lib/track-record-stats.ts` (TDD). Softened unbacked "verified" → "recorded / resolved against Binance/Yahoo OHLCV". Added N + date range + break-even on headline metrics; honest Sharpe (N trading days) and R-subset denominators; persistent banner when the equity curve is P95-smoothed.
- **consensus** — `trend24h` arrow (a char-code+hour formula, not a real 24h move) labeled "est."; fallback "ESTIMATED" badge made prominent; live-engine claim qualified; signal window shown.
- **confidence** — code snippet corrected to the real `INDICATORS` weights (it claimed to match `signal-generator.ts` but omitted Volume / inflated MACD); calculator labeled an interactive demo.
- **accuracy** — provenance badge derived from full history (not the 25-row page); aligned the avg-confidence denominator with win-rate; honest loss% (`losses/resolved`); date window.
- **allocation** — paper/demo exposure labeled as such; policy-rule provenance noted; regime freshness (N + detectedAt).
- **ab-stats** — "WINNING" → "LEADING", gated on ≥30 impressions; CTR shows N fractions; not-a-controlled-experiment caveat.
- **calibration** — distinguishes thin real data ("insufficient live data, N=n") from genuinely simulated; date windows; prominent demo labels.
- **results** — inline "illustrative" markers on every metric/table; in-canvas watermark + replaced the misleading calendar axis on the PRNG curve.
- **benchmark** — grounded the "$200/mo" headline to listed prices; dated competitor prices; replaced the unverifiable "1,000-star" target with the live star count.

### Verification
- Unit tests (root `jest`): **1407 passed, 0 failed**, 26 skipped.
- `tsc` clean on all touched files. (Pre-existing baseline tsc errors in unrelated regime/router/cron files are not introduced here and are outside what `next build` gates.)
- Measurement-logic changes (OG/embed consistency, accuracy denominators, calibration thin-vs-simulated) are TDD-backed.

### Not in scope
- Phase 6b: public regime view + "what we tested and killed" panel + hero reframe (own PR, on this honest base).
- No trading behavior changed; `TRADECLAW_STRATEGY_ROUTER_MODE` stays dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
