### PR TITLE
fix(social): public OG card + daily/weekly posts use the resolved-signal denominator

### DIFF
--- a/apps/web/app/api/cron/social/daily/route.ts
+++ b/apps/web/app/api/cron/social/daily/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { query } from '../../../../../lib/db-pool';
+import { getSocialSummaryStats } from '../../../../../lib/social-summary-stats';
 import { enqueueSummaryPost } from '../../../../../lib/social-queue';
 
 function isAuthorized(req: NextRequest): boolean {
@@ -12,43 +12,31 @@ export async function GET(req: NextRequest) {
   if (!isAuthorized(req)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const today = new Date().toISOString().slice(0, 10);
-  const rows = await query<{
-    total: string; wins: string; losses: string; win_rate: string; total_pnl: string;
-  }>(`
-    SELECT
-      COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL)::text AS total,
-      COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::text AS wins,
-      COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL AND (outcome_24h->>'hit')::boolean = false)::text AS losses,
-      CASE WHEN COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) > 0
-        THEN ROUND(COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::numeric
-          / COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) * 100, 1)::text
-        ELSE '0' END AS win_rate,
-      COALESCE(ROUND(SUM((outcome_24h->>'pnlPct')::numeric) FILTER (WHERE outcome_24h IS NOT NULL), 2)::text, '0') AS total_pnl
-    FROM signal_history
-    WHERE is_simulated = false
-      AND created_at >= $1::date
-      AND created_at < $1::date + INTERVAL '1 day'
-  `, [today]);
-
-  const s = rows[0] ?? { total: '0', wins: '0', losses: '0', win_rate: '0', total_pnl: '0' };
-  if (Number(s.total) === 0) {
+  // Resolved denominator identical to /track-record and the OG card
+  // (getSocialSummaryStats → getResolvedSlice + isCountedResolved): excludes
+  // simulated, gate-blocked, and auto-expired rows so the posted win-rate /
+  // P&L matches the page this caption links to.
+  const s = await getSocialSummaryStats('daily', today);
+  if (s.total === 0) {
     return NextResponse.json({ skipped: true, reason: 'No resolved signals today' });
   }
 
-  const pnl = Number(s.total_pnl);
+  const pnl = s.totalPnlPct;
+  const winRate = s.winRatePct.toFixed(1);
+  const pnlStr = `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`;
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://tradeclaw.win';
   const imageUrl = `${baseUrl}/api/og/summary?period=daily&date=${today}`;
   const copy = [
     `Today on TradeClaw: ${s.total} signals resolved`,
-    `${s.wins}W / ${s.losses}L (${s.win_rate}%)`,
-    `P/L: ${pnl >= 0 ? '+' : ''}${s.total_pnl}%`,
+    `${s.wins}W / ${s.losses}L (${winRate}%)`,
+    `P/L: ${pnlStr}%`,
     '',
     `Track live: ${baseUrl}/track-record`,
     '#TradeClaw #Trading #Signals',
   ].join('\n');
 
   const post = await enqueueSummaryPost('daily_summary', copy, imageUrl, {
-    date: today, total: s.total, wins: s.wins, losses: s.losses, winRate: s.win_rate, totalPnl: s.total_pnl,
+    date: today, total: s.total, wins: s.wins, losses: s.losses, winRate, totalPnl: pnl.toFixed(2),
   });
 
   return NextResponse.json({ ok: true, postId: post.id });

--- a/apps/web/app/api/cron/social/weekly/route.ts
+++ b/apps/web/app/api/cron/social/weekly/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { query } from '../../../../../lib/db-pool';
+import { getSocialSummaryStats } from '../../../../../lib/social-summary-stats';
 import { enqueueSummaryPost } from '../../../../../lib/social-queue';
 
 function isAuthorized(req: NextRequest): boolean {
@@ -12,66 +12,39 @@ export async function GET(req: NextRequest) {
   if (!isAuthorized(req)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const today = new Date().toISOString().slice(0, 10);
-  const rows = await query<{
-    total: string; wins: string; losses: string; win_rate: string; total_pnl: string;
-    best_symbol: string | null; best_pnl: string | null;
-    worst_symbol: string | null; worst_pnl: string | null;
-  }>(`
-    WITH stats AS (
-      SELECT
-        COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL)::text AS total,
-        COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::text AS wins,
-        COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL AND (outcome_24h->>'hit')::boolean = false)::text AS losses,
-        CASE WHEN COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) > 0
-          THEN ROUND(COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::numeric
-            / COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) * 100, 1)::text
-          ELSE '0' END AS win_rate,
-        COALESCE(ROUND(SUM((outcome_24h->>'pnlPct')::numeric) FILTER (WHERE outcome_24h IS NOT NULL), 2)::text, '0') AS total_pnl
-      FROM signal_history
-      WHERE is_simulated = false
-        AND created_at >= ($1::date - INTERVAL '7 days')
-        AND created_at < $1::date + INTERVAL '1 day'
-    ),
-    by_symbol AS (
-      SELECT pair, ROUND(SUM((outcome_24h->>'pnlPct')::numeric), 2) AS pnl
-      FROM signal_history
-      WHERE is_simulated = false AND outcome_24h IS NOT NULL
-        AND created_at >= ($1::date - INTERVAL '7 days')
-        AND created_at < $1::date + INTERVAL '1 day'
-      GROUP BY pair
-    )
-    SELECT
-      s.*,
-      (SELECT pair FROM by_symbol ORDER BY pnl DESC LIMIT 1) AS best_symbol,
-      (SELECT pnl::text FROM by_symbol ORDER BY pnl DESC LIMIT 1) AS best_pnl,
-      (SELECT pair FROM by_symbol ORDER BY pnl ASC LIMIT 1) AS worst_symbol,
-      (SELECT pnl::text FROM by_symbol ORDER BY pnl ASC LIMIT 1) AS worst_pnl
-    FROM stats s
-  `, [today]);
-
-  const s = rows[0];
-  if (!s || Number(s.total) === 0) {
+  // Resolved denominator identical to /track-record and the OG card
+  // (getSocialSummaryStats → getResolvedSlice + isCountedResolved). Best/worst
+  // symbol is derived from the SAME resolved set, so the prior raw SQL's
+  // gate-blocked/auto-expired leakage no longer inflates the recap.
+  const s = await getSocialSummaryStats('weekly', today);
+  if (s.total === 0) {
     return NextResponse.json({ skipped: true, reason: 'No resolved signals this week' });
   }
 
-  const pnl = Number(s.total_pnl);
+  const pnl = s.totalPnlPct;
+  const winRate = s.winRatePct.toFixed(1);
+  const pnlStr = `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`;
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://tradeclaw.win';
   const imageUrl = `${baseUrl}/api/og/summary?period=weekly&date=${today}`;
   const lines = [
     `Weekly Recap on TradeClaw`,
-    `${s.total} signals | ${s.wins}W / ${s.losses}L (${s.win_rate}%)`,
-    `P/L: ${pnl >= 0 ? '+' : ''}${s.total_pnl}%`,
+    `${s.total} signals | ${s.wins}W / ${s.losses}L (${winRate}%)`,
+    `P/L: ${pnlStr}%`,
   ];
-  if (s.best_symbol) lines.push(`Best: ${s.best_symbol} (+${s.best_pnl}%)`);
-  if (s.worst_symbol && s.worst_symbol !== s.best_symbol) lines.push(`Worst: ${s.worst_symbol} (${s.worst_pnl}%)`);
+  if (s.bestSymbol && s.bestPnlPct !== null) {
+    lines.push(`Best: ${s.bestSymbol} (${s.bestPnlPct >= 0 ? '+' : ''}${s.bestPnlPct.toFixed(2)}%)`);
+  }
+  if (s.worstSymbol && s.worstSymbol !== s.bestSymbol && s.worstPnlPct !== null) {
+    lines.push(`Worst: ${s.worstSymbol} (${s.worstPnlPct >= 0 ? '+' : ''}${s.worstPnlPct.toFixed(2)}%)`);
+  }
   lines.push('', `Full breakdown: ${baseUrl}/track-record`, '#TradeClaw #WeeklyRecap #Trading');
 
   const copy = lines.join('\n');
   const post = await enqueueSummaryPost('weekly_summary', copy, imageUrl, {
     date: today, total: s.total, wins: s.wins, losses: s.losses,
-    winRate: s.win_rate, totalPnl: s.total_pnl,
-    bestSymbol: s.best_symbol, bestPnl: s.best_pnl,
-    worstSymbol: s.worst_symbol, worstPnl: s.worst_pnl,
+    winRate, totalPnl: pnl.toFixed(2),
+    bestSymbol: s.bestSymbol, bestPnl: s.bestPnlPct,
+    worstSymbol: s.worstSymbol, worstPnl: s.worstPnlPct,
   });
 
   return NextResponse.json({ ok: true, postId: post.id });

--- a/apps/web/app/api/og/summary/route.tsx
+++ b/apps/web/app/api/og/summary/route.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/og';
-import { query } from '../../../../lib/db-pool';
+import { getSocialSummaryStats } from '../../../../lib/social-summary-stats';
 
 export const runtime = 'nodejs';
 
@@ -7,25 +7,14 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const period = searchParams.get('period') === 'weekly' ? 'weekly' : 'daily';
   const dateStr = searchParams.get('date') ?? new Date().toISOString().slice(0, 10);
-  const interval = period === 'weekly' ? '7 days' : '1 day';
 
-  const rows = await query<{
-    total: string; wins: string; losses: string; win_rate: string; total_pnl: string;
-  }>(`
-    SELECT
-      COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL)::text AS total,
-      COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::text AS wins,
-      COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL AND (outcome_24h->>'hit')::boolean = false)::text AS losses,
-      CASE WHEN COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) > 0
-        THEN ROUND(COUNT(*) FILTER (WHERE (outcome_24h->>'hit')::boolean = true)::numeric / COUNT(*) FILTER (WHERE outcome_24h IS NOT NULL) * 100, 1)::text
-        ELSE '0' END AS win_rate,
-      COALESCE(ROUND(SUM((outcome_24h->>'pnlPct')::numeric) FILTER (WHERE outcome_24h IS NOT NULL), 2)::text, '0') AS total_pnl
-    FROM signal_history
-    WHERE is_simulated = false AND created_at >= ($1::date - $2::interval) AND created_at < $1::date + INTERVAL '1 day'
-  `, [dateStr, interval]);
-
-  const s = rows[0] ?? { total: '0', wins: '0', losses: '0', win_rate: '0', total_pnl: '0' };
-  const pnl = Number(s.total_pnl);
+  // Same resolved denominator as /track-record (getSocialSummaryStats →
+  // getResolvedSlice + isCountedResolved): excludes simulated, gate-blocked,
+  // and auto-expired rows. The prior raw SQL counted `outcome_24h IS NOT NULL`,
+  // inflating the win-rate / P&L this shared card advertises against the page
+  // it links to.
+  const s = await getSocialSummaryStats(period, dateStr);
+  const pnl = s.totalPnlPct;
   const pnlColor = pnl >= 0 ? '#10b981' : '#f43f5e';
   const title = period === 'weekly' ? 'WEEKLY SUMMARY' : 'DAILY P/L';
 
@@ -81,12 +70,12 @@ export async function GET(request: Request) {
         <div style={{ display: 'flex', gap: '56px', marginBottom: '40px' }}>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <div style={{ fontSize: '64px', fontWeight: 800, color: pnlColor }}>
-              {pnl >= 0 ? '+' : ''}{s.total_pnl}%
+              {pnl >= 0 ? '+' : ''}{pnl.toFixed(2)}%
             </div>
             <div style={{ fontSize: '16px', color: '#6b7280', letterSpacing: '0.08em' }}>TOTAL P/L</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <div style={{ fontSize: '64px', fontWeight: 800, color: '#ffffff' }}>{s.win_rate}%</div>
+            <div style={{ fontSize: '64px', fontWeight: 800, color: '#ffffff' }}>{s.winRatePct.toFixed(1)}%</div>
             <div style={{ fontSize: '16px', color: '#6b7280', letterSpacing: '0.08em' }}>WIN RATE</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>

--- a/apps/web/lib/__tests__/social-summary-stats.test.ts
+++ b/apps/web/lib/__tests__/social-summary-stats.test.ts
@@ -1,0 +1,148 @@
+jest.mock('../signal-history-cache', () => ({
+  getCachedHistory: jest.fn(),
+}));
+
+import { getSocialSummaryStats } from '../social-summary-stats';
+import { isCountedResolved, type SignalHistoryRecord } from '../signal-history';
+import { getCachedHistory } from '../signal-history-cache';
+
+const mockedHistory = getCachedHistory as jest.MockedFunction<typeof getCachedHistory>;
+
+const DAY = 86_400_000;
+const ANCHOR = '2026-06-14';
+const ANCHOR_MS = Date.parse(`${ANCHOR}T00:00:00.000Z`);
+
+function mkRecord(
+  id: string,
+  opts: {
+    pair?: string;
+    hit?: boolean;
+    pnlPct?: number;
+    target?: 'TP1' | 'SL' | 'expired';
+    gateBlocked?: boolean;
+    isSimulated?: boolean;
+    /** Whole-day offset from the anchor midnight (0 = anchor day, -1 = day before). */
+    dayOffset?: number;
+  },
+): SignalHistoryRecord {
+  // Place each record at noon of its target day so it sits unambiguously
+  // inside that UTC calendar day regardless of window edges.
+  const timestamp = ANCHOR_MS + (opts.dayOffset ?? 0) * DAY + DAY / 2;
+  return {
+    id,
+    pair: opts.pair ?? 'BTCUSD',
+    timeframe: 'H1',
+    direction: 'BUY',
+    confidence: 80,
+    entryPrice: 50000,
+    timestamp,
+    tp1: 51000,
+    sl: 49500,
+    isSimulated: opts.isSimulated ?? false,
+    gateBlocked: opts.gateBlocked ?? false,
+    outcomes: {
+      '4h': null,
+      '24h': {
+        price: 51000,
+        pnlPct: opts.pnlPct ?? (opts.hit ? 2.0 : -1.0),
+        hit: opts.hit ?? false,
+        target: opts.target ?? (opts.hit ? 'TP1' : 'SL'),
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  mockedHistory.mockReset();
+});
+
+describe('getSocialSummaryStats — public social/OG denominator parity', () => {
+  it('uses the canonical isCountedResolved denominator: excludes expired, gate-blocked, and simulated rows', async () => {
+    const rows = [
+      mkRecord('win', { hit: true, dayOffset: 0 }),
+      mkRecord('loss', { hit: false, dayOffset: 0 }),
+      // Auto-expire placeholder — /track-record drops it, so the card must too.
+      mkRecord('expired', { hit: false, pnlPct: 0, target: 'expired', dayOffset: 0 }),
+      // Gate-blocked: engine refused the trade; not a real outcome.
+      mkRecord('blocked', { hit: true, gateBlocked: true, dayOffset: 0 }),
+      // Simulated: never counts.
+      mkRecord('sim', { hit: true, isSimulated: true, dayOffset: 0 }),
+    ];
+    mockedHistory.mockResolvedValue(rows);
+
+    const s = await getSocialSummaryStats('daily', ANCHOR);
+
+    // The win-rate denominator must equal what isCountedResolved keeps (2), not
+    // the pre-sweep `outcome_24h IS NOT NULL` count (5).
+    expect(rows.filter(isCountedResolved).length).toBe(2);
+    expect(s.total).toBe(2);
+    expect(s.wins).toBe(1);
+    expect(s.losses).toBe(1);
+    expect(s.winRatePct).toBe(50);
+    expect(s.totalPnlPct).toBe(1); // +2.0 win + -1.0 loss
+  });
+
+  it('daily window counts only the anchor day', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('today', { hit: true, dayOffset: 0 }),
+      mkRecord('yesterday', { hit: true, dayOffset: -1 }),
+      mkRecord('tomorrow', { hit: true, dayOffset: 1 }),
+    ]);
+
+    const s = await getSocialSummaryStats('daily', ANCHOR);
+
+    expect(s.total).toBe(1);
+    expect(s.wins).toBe(1);
+  });
+
+  it('weekly window spans [date-7d, date+1d): includes 7 days back, excludes the 8th', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('d0', { hit: true, dayOffset: 0 }),
+      mkRecord('d-7', { hit: false, dayOffset: -7 }), // included (window start)
+      mkRecord('d-8', { hit: true, dayOffset: -8 }), // excluded (before window)
+    ]);
+
+    const s = await getSocialSummaryStats('weekly', ANCHOR);
+
+    expect(s.total).toBe(2); // d0 + d-7
+    expect(s.wins).toBe(1);
+    expect(s.losses).toBe(1);
+  });
+
+  it('reports best / worst symbol by summed resolved P&L over the window', async () => {
+    mockedHistory.mockResolvedValue([
+      mkRecord('btc1', { pair: 'BTCUSD', hit: true, pnlPct: 3, dayOffset: 0 }),
+      mkRecord('btc2', { pair: 'BTCUSD', hit: true, pnlPct: 2, dayOffset: 0 }),
+      mkRecord('eth1', { pair: 'ETHUSD', hit: false, pnlPct: -3, dayOffset: 0 }),
+    ]);
+
+    const s = await getSocialSummaryStats('daily', ANCHOR);
+
+    expect(s.bestSymbol).toBe('BTCUSD');
+    expect(s.bestPnlPct).toBe(5);
+    expect(s.worstSymbol).toBe('ETHUSD');
+    expect(s.worstPnlPct).toBe(-3);
+  });
+
+  it('degrades to zeros / nulls on an empty window without dividing by zero', async () => {
+    mockedHistory.mockResolvedValue([mkRecord('old', { hit: true, dayOffset: -30 })]);
+
+    const s = await getSocialSummaryStats('daily', ANCHOR);
+
+    expect(s.total).toBe(0);
+    expect(s.wins).toBe(0);
+    expect(s.winRatePct).toBe(0);
+    expect(s.totalPnlPct).toBe(0);
+    expect(s.bestSymbol).toBeNull();
+    expect(s.worstSymbol).toBeNull();
+  });
+
+  it('falls back to today when the date string is unparseable (OG query param guard)', async () => {
+    mockedHistory.mockResolvedValue([]);
+    // Must not throw on bad input from the public query string.
+    await expect(getSocialSummaryStats('daily', 'not-a-date')).resolves.toMatchObject({
+      total: 0,
+      winRatePct: 0,
+    });
+  });
+});

--- a/apps/web/lib/social-summary-stats.ts
+++ b/apps/web/lib/social-summary-stats.ts
@@ -1,0 +1,100 @@
+import { getResolvedSlice } from './signal-slice';
+
+export type SocialSummaryPeriod = 'daily' | 'weekly';
+
+export interface SocialSummaryStats {
+  /** Resolved-signal count in the window (the win-rate denominator). */
+  total: number;
+  /** Resolved signals whose 24h outcome hit. */
+  wins: number;
+  /** Resolved signals whose 24h outcome did not hit. */
+  losses: number;
+  /** wins / total × 100, one decimal. 0 when total is 0. */
+  winRatePct: number;
+  /** Sum of resolved 24h pnlPct over the window, two decimals. */
+  totalPnlPct: number;
+  /** Pair with the highest summed resolved P&L in the window (weekly recap). */
+  bestSymbol: string | null;
+  bestPnlPct: number | null;
+  /** Pair with the lowest summed resolved P&L in the window (weekly recap). */
+  worstSymbol: string | null;
+  worstPnlPct: number | null;
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Resolved-signal summary for the public social surfaces — the
+ * /api/og/summary card image and the daily/weekly social-post crons.
+ *
+ * Computed through the SAME resolved population as /track-record
+ * (getResolvedSlice + isCountedResolved), windowed to the post period, so the
+ * win-rate / W-L / P&L on the social card and caption match the page they link
+ * to. The prior raw SQL counted `outcome_24h IS NOT NULL`, which folded in
+ * auto-expired and gate-blocked rows the page excludes — inflating the public
+ * numbers and breaking the honesty / cross-surface-consistency contract that
+ * the Phase 6a sweep established for every other track-record surface.
+ *
+ * Window (UTC, anchored on `dateStr` = YYYY-MM-DD):
+ *   daily  → [date, date + 1d)        the given day
+ *   weekly → [date - 7d, date + 1d)   the trailing week ending that day
+ *
+ * An unparseable `dateStr` (the OG route reads it from the public query string)
+ * falls back to the current UTC day rather than throwing.
+ */
+export async function getSocialSummaryStats(
+  period: SocialSummaryPeriod,
+  dateStr: string,
+): Promise<SocialSummaryStats> {
+  const parsed = Date.parse(`${dateStr}T00:00:00.000Z`);
+  const anchor = Number.isNaN(parsed)
+    ? Date.parse(`${new Date().toISOString().slice(0, 10)}T00:00:00.000Z`)
+    : parsed;
+  const end = anchor + DAY_MS;
+  const start = period === 'weekly' ? anchor - 7 * DAY_MS : anchor;
+
+  const { resolved } = await getResolvedSlice({ scope: 'pro' });
+  const windowed = resolved.filter(r => r.timestamp >= start && r.timestamp < end);
+
+  const total = windowed.length;
+  const wins = windowed.filter(r => r.outcomes['24h']!.hit).length;
+  const losses = total - wins;
+  const totalPnlPct = +windowed
+    .reduce((sum, r) => sum + r.outcomes['24h']!.pnlPct, 0)
+    .toFixed(2);
+  const winRatePct = total > 0 ? +((wins / total) * 100).toFixed(1) : 0;
+
+  // Best / worst symbol by summed resolved P&L over the same window — used by
+  // the weekly recap, computed off the same resolved set so it can't disagree.
+  const byPair = new Map<string, number>();
+  for (const r of windowed) {
+    byPair.set(r.pair, (byPair.get(r.pair) ?? 0) + r.outcomes['24h']!.pnlPct);
+  }
+  let bestSymbol: string | null = null;
+  let bestPnlPct: number | null = null;
+  let worstSymbol: string | null = null;
+  let worstPnlPct: number | null = null;
+  for (const [pair, pnl] of byPair) {
+    const rounded = +pnl.toFixed(2);
+    if (bestPnlPct === null || rounded > bestPnlPct) {
+      bestPnlPct = rounded;
+      bestSymbol = pair;
+    }
+    if (worstPnlPct === null || rounded < worstPnlPct) {
+      worstPnlPct = rounded;
+      worstSymbol = pair;
+    }
+  }
+
+  return {
+    total,
+    wins,
+    losses,
+    winRatePct,
+    totalPnlPct,
+    bestSymbol,
+    bestPnlPct,
+    worstSymbol,
+    worstPnlPct,
+  };
+}


### PR DESCRIPTION
## Summary

A multi-agent audit of the last 7 days (Phases 3–6, PRs #110–#119) found **one** confirmed real defect after adversarial verification — the rest of the merged engine work (regime engine, strategy router, execution/risk, calibration, research CLIs, UI claims) is clean.

**The bug:** the Phase 6a honesty sweep moved every `/track-record` surface onto the canonical `isCountedResolved` denominator (excludes simulated, gate-blocked, and auto-expired rows) and its own docstring labels the old `outcome_24h IS NOT NULL` SQL wrong. But three **public, auto-posted** surfaces were never migrated and still advertised an inflated win-rate / W-L / P&L that contradicts the `/track-record` page they link to:

- `/api/og/summary` — shared social card image
- `/api/cron/social/daily` — daily post caption
- `/api/cron/social/weekly` — weekly post caption + best/worst symbol

Gate-blocked rows get `outcome_24h` written (`resolveRealOutcomes` doesn't skip them) and mark-to-market expired rows carry real nonzero `pnlPct`, so the old SQL counted both as wins/losses. The in-process `instrumentation.ts` timer drives these crons over loopback (bypassing the edge), so they post **live**.

**The fix:** consolidate all three onto a single `getSocialSummaryStats()` helper that reuses `getResolvedSlice` + `isCountedResolved` — the exact predicate the page body uses — so the public numbers can no longer drift from `/track-record`. Root cause was three duplicated copies of the same SQL; one was swept and these were missed. Also aligns the daily OG card window to the daily caption window (one day, not two).

## Files
- `apps/web/lib/social-summary-stats.ts` (new) — single resolved-denominator helper
- `apps/web/lib/__tests__/social-summary-stats.test.ts` (new) — 6 tests
- `apps/web/app/api/og/summary/route.tsx`
- `apps/web/app/api/cron/social/daily/route.ts`
- `apps/web/app/api/cron/social/weekly/route.ts`

## Test Plan
- [x] `npx tsc --noEmit --project apps/web/tsconfig.json` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` (jest) — 141 suites / 1413 tests pass (+6 new), 0 failures
- [x] `npm run build` (Next production) — exit 0, all three routes compile
- [x] New test asserts denominator parity vs `isCountedResolved`, daily/weekly windowing, best/worst symbol, empty-window divide-by-zero guard, unparseable-date guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)