### PR TITLE
fix(track-record): premium badge tells the truth + realized return at the headline

### DIFF
--- a/apps/web/app/api/signals/equity/route.test.ts
+++ b/apps/web/app/api/signals/equity/route.test.ts
@@ -156,4 +156,22 @@ describe('GET /api/signals/equity summary metrics', () => {
     // The old full-population formula would have returned 0.667*2 + 0.333*-1 = +1.0R.
     expect(body.summary.expectancyR).toBe(0.5);
   });
+
+  it('summaryOnly=1 drops the points array but keeps summary + rollingWinRates', async () => {
+    primeSlice([
+      record({ id: 'a', entryPrice: 100, sl: 99, outcomes: { '4h': null, '24h': { price: 102, pnlPct: 2, hit: true } } }),
+      record({ id: 'b', entryPrice: 100, sl: 99, outcomes: { '4h': null, '24h': { price: 99, pnlPct: -1, hit: false } } }),
+    ]);
+
+    const res = await GET(makeReq('/api/signals/equity?summaryOnly=1'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Curve omitted for summary-only consumers…
+    expect(body.points).toEqual([]);
+    // …but the aggregate stats the callout reads are intact.
+    expect(body.summary.totalSignals).toBe(2);
+    expect(body.summary.sizedTrades).toBe(2);
+    expect(body.rollingWinRates).toBeDefined();
+  });
 });

--- a/apps/web/app/api/signals/equity/route.ts
+++ b/apps/web/app/api/signals/equity/route.ts
@@ -304,6 +304,13 @@ export async function GET(request: NextRequest) {
     // the marketing pitch.
     const scope = parseScope(searchParams.get('scope'));
     const category = parseCategoryFilter(searchParams.get('category'));
+    // summaryOnly drops the (potentially ~3.3k-point) `points` array and
+    // returns just `summary` + `rollingWinRates`. Summary-only consumers — the
+    // trailing-week band callout compares totalReturn / win-rate / expectancy
+    // across bands and windows — don't need the curve, so they skip shipping
+    // the full point set over the wire on every fetch.
+    const summaryOnly = searchParams.get('summaryOnly') === '1'
+      || searchParams.get('summaryOnly') === 'true';
     // smooth=median2x clamps each trade's pnl to ±2× median(|pnl|) before
     // compounding. Off by default — the marketing surface opts in.
     const smoothParam = searchParams.get('smooth');
@@ -337,7 +344,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(
       {
-        points,
+        points: summaryOnly ? [] : points,
         summary,
         rollingWinRates,
         band,

--- a/apps/web/app/components/trailing-week-band-callout.tsx
+++ b/apps/web/app/components/trailing-week-band-callout.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { InfoHint } from '@/components/InfoHint';
+import { classifyBandComparison } from '@/lib/band-comparison';
 
 interface BandSummary {
   totalReturn: number;
@@ -17,18 +18,25 @@ interface BandResponse {
   summary: BandSummary | null;
 }
 
-interface Loaded {
+interface BandPair {
   all: BandSummary | null;
   premium: BandSummary | null;
 }
 
+interface Loaded {
+  sevenDay: BandPair;
+  allTime: BandPair | null;
+}
+
 /**
- * Trailing-7d callout: shows premium-band vs full-firehose side-by-side over
- * the last week. The whole point of the paid filter is the gap between these
- * two columns during chop. When premium ≥ all, the filter is paying its rent.
+ * Trailing-7d callout: premium-band vs full-firehose side-by-side over the last
+ * week, with an all-time context line so a single chop week can't stand in for
+ * the long run. The filter only "pays its rent" when premium beats all-signals
+ * on per-trade quality (win rate AND expectancy), not merely by trading less —
+ * see classifyBandComparison.
  *
- * Two parallel GETs to /api/signals/equity?period=7d with band=all and
- * band=premium. Lightweight enough to render above the main equity card.
+ * Four parallel summary-only GETs to /api/signals/equity (7d + all-time, each
+ * band=all / band=premium). summaryOnly=1 skips the point payload.
  */
 export function TrailingWeekBandCallout() {
   const [data, setData] = useState<Loaded | null>(null);
@@ -36,22 +44,29 @@ export function TrailingWeekBandCallout() {
 
   useEffect(() => {
     let cancelled = false;
-    async function load(): Promise<void> {
+    async function fetchSummary(period: string, band: string): Promise<BandSummary | null> {
       try {
-        const [allRes, premRes] = await Promise.all([
-          fetch('/api/signals/equity?period=7d&scope=pro&band=all'),
-          fetch('/api/signals/equity?period=7d&scope=pro&band=premium'),
-        ]);
-        if (!allRes.ok || !premRes.ok) return;
-        const allJson = (await allRes.json()) as BandResponse;
-        const premJson = (await premRes.json()) as BandResponse;
-        if (cancelled) return;
-        setData({ all: allJson.summary, premium: premJson.summary });
+        const res = await fetch(`/api/signals/equity?period=${period}&scope=pro&band=${band}&summaryOnly=1`);
+        if (!res.ok) return null;
+        const json = (await res.json()) as BandResponse;
+        return json.summary;
       } catch {
-        // silent — callout just hides
-      } finally {
-        if (!cancelled) setLoading(false);
+        return null;
       }
+    }
+    async function load(): Promise<void> {
+      const [all7, prem7, allAll, premAll] = await Promise.all([
+        fetchSummary('7d', 'all'),
+        fetchSummary('7d', 'premium'),
+        fetchSummary('all', 'all'),
+        fetchSummary('all', 'premium'),
+      ]);
+      if (cancelled) return;
+      setData({
+        sevenDay: { all: all7, premium: prem7 },
+        allTime: allAll && premAll ? { all: allAll, premium: premAll } : null,
+      });
+      setLoading(false);
     }
     load();
     return () => {
@@ -60,12 +75,22 @@ export function TrailingWeekBandCallout() {
   }, []);
 
   if (loading) return null;
-  if (!data?.all || !data?.premium) return null;
+  if (!data?.sevenDay.all || !data.sevenDay.premium) return null;
 
-  const a = data.all;
-  const p = data.premium;
-  const delta = +(p.totalReturn - a.totalReturn).toFixed(2);
-  const filterPaidRent = delta > 0;
+  const a = data.sevenDay.all;
+  const p = data.sevenDay.premium;
+  const cmp = classifyBandComparison(a, p);
+  const badgeTone =
+    cmp.tone === 'positive'
+      ? 'bg-emerald-500/15 text-emerald-400'
+      : cmp.tone === 'neutral'
+        ? 'bg-amber-500/15 text-amber-300'
+        : 'bg-red-500/15 text-red-400';
+
+  const allTime = data.allTime;
+  const allTimeCmp = allTime?.all && allTime.premium
+    ? classifyBandComparison(allTime.all, allTime.premium)
+    : null;
 
   return (
     <section
@@ -77,23 +102,18 @@ export function TrailingWeekBandCallout() {
           <h3 className="flex items-center gap-2 text-sm font-semibold tracking-tight text-white">
             Last 7 Days — Premium Filter vs Full Firehose
             <InfoHint
-              text="Side-by-side return of the premium band (confidence ≥ 85) versus all signals over the last 7 days. The gap is what the paid filter is doing for you in the current market regime."
+              text="Side-by-side return of the premium band (confidence ≥ 85) versus all signals over the last 7 days. Premium only beats all when it picks better trades (higher win rate AND expectancy) — not when it merely trades less during a losing week."
               label="What this comparison shows"
             />
           </h3>
           <p className="mt-0.5 text-[11px] text-zinc-600">
-            Same window, same sizing. The gap shows what the high-confidence filter caught (or missed) this week.
+            Same window, same sizing. A smaller loss from fewer trades is not the same as higher accuracy.
           </p>
         </div>
         <span
-          className={`shrink-0 rounded-md px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-wider ${
-            filterPaidRent
-              ? 'bg-emerald-500/15 text-emerald-400'
-              : 'bg-zinc-500/15 text-zinc-400'
-          }`}
+          className={`shrink-0 rounded-md px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-wider ${badgeTone}`}
         >
-          Premium {delta >= 0 ? '+' : ''}
-          {delta.toFixed(2)}% vs All
+          {cmp.label}
         </span>
       </div>
 
@@ -101,6 +121,29 @@ export function TrailingWeekBandCallout() {
         <BandCard label="All signals" data={a} accent="zinc" />
         <BandCard label="Premium only (conf ≥ 85)" data={p} accent="emerald" />
       </div>
+
+      {/* All-time context — the 7-day gap is regime-dependent; show the full
+         record so a single chop week can't stand in for the long run. */}
+      {allTime?.all && allTime.premium && allTimeCmp && (
+        <p className="mt-3 text-[11px] font-mono text-zinc-500">
+          <span className="uppercase tracking-wider text-zinc-600">All-time</span>{' '}
+          All {allTime.all.totalReturn >= 0 ? '+' : ''}{allTime.all.totalReturn.toFixed(2)}%{' '}
+          ({allTime.all.totalSignals.toLocaleString()} trades)
+          {' · '}
+          Premium {allTime.premium.totalReturn >= 0 ? '+' : ''}{allTime.premium.totalReturn.toFixed(2)}%{' '}
+          ({allTime.premium.totalSignals.toLocaleString()} trades)
+          {' — '}
+          <span className={
+            allTimeCmp.tone === 'positive' ? 'text-emerald-400'
+            : allTimeCmp.tone === 'negative' ? 'text-red-400'
+            : 'text-amber-300'
+          }>
+            {allTimeCmp.verdict === 'premium_better' ? 'filter ahead over the full record'
+              : allTimeCmp.verdict === 'premium_fewer_trades' ? 'filter only ahead by trading less'
+              : 'filter behind over the full record'}
+          </span>
+        </p>
+      )}
     </section>
   );
 }

--- a/apps/web/app/components/trailing-week-band-callout.tsx
+++ b/apps/web/app/components/trailing-week-band-callout.tsx
@@ -55,18 +55,23 @@ export function TrailingWeekBandCallout() {
       }
     }
     async function load(): Promise<void> {
-      const [all7, prem7, allAll, premAll] = await Promise.all([
-        fetchSummary('7d', 'all'),
-        fetchSummary('7d', 'premium'),
-        fetchSummary('all', 'all'),
-        fetchSummary('all', 'premium'),
-      ]);
-      if (cancelled) return;
-      setData({
-        sevenDay: { all: all7, premium: prem7 },
-        allTime: allAll && premAll ? { all: allAll, premium: premAll } : null,
-      });
-      setLoading(false);
+      try {
+        const [all7, prem7, allAll, premAll] = await Promise.all([
+          fetchSummary('7d', 'all'),
+          fetchSummary('7d', 'premium'),
+          fetchSummary('all', 'all'),
+          fetchSummary('all', 'premium'),
+        ]);
+        if (cancelled) return;
+        setData({
+          sevenDay: { all: all7, premium: prem7 },
+          allTime: allAll && premAll ? { all: allAll, premium: premAll } : null,
+        });
+      } finally {
+        // Always clear loading (unless unmounted) so an unexpected throw can't
+        // leave the callout stuck hidden with no recovery path.
+        if (!cancelled) setLoading(false);
+      }
     }
     load();
     return () => {

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -519,6 +519,8 @@ export function TrackRecordClient() {
     } catch {
       if (isCancelled()) return;
       setRollingWinRates(null);
+      setHeadlineCompoundedReturn(null);
+      setHeadlineMaxDrawdown(null);
       // silently fail
     } finally {
       if (!isCancelled()) setLoading(false);

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -437,6 +437,11 @@ export function TrackRecordClient() {
   // Surfaced at the headline so the headline win-rate reads against the bar the
   // system needs, not a meaningless flat 50%.
   const [headlineBreakEven, setHeadlineBreakEven] = useState<number | null>(null);
+  // Realized (position-sized) compounded return + max drawdown from the equity
+  // summary. Surfaced at the headline so the number a subscriber could actually
+  // earn sits next to the raw unsized total, not buried in the equity card.
+  const [headlineCompoundedReturn, setHeadlineCompoundedReturn] = useState<number | null>(null);
+  const [headlineMaxDrawdown, setHeadlineMaxDrawdown] = useState<number | null>(null);
   const [now, setNow] = useState(() => Date.now());
   // Earliest signal we have data for in the current scope. Used to grey out
   // period buttons whose window pre-dates any recorded signal — a 5Y button
@@ -466,6 +471,9 @@ export function TrackRecordClient() {
 
       const equityParams = new URLSearchParams({ period: p, scope: s, band });
       if (c !== 'all') equityParams.set('category', c);
+      // Headline reads summary fields only (rolling win-rates, break-even,
+      // realized return, drawdown) — the curve itself is fetched by EquityCurve.
+      equityParams.set('summaryOnly', '1');
 
       const [historyRes, leaderboardRes, equityRes] = await Promise.allSettled([
         fetch(`/api/signals/history?${historyParams.toString()}`),
@@ -495,10 +503,18 @@ export function TrackRecordClient() {
         setHeadlineBreakEven(
           typeof data.summary?.breakEvenWinRate === 'number' ? data.summary.breakEvenWinRate : null,
         );
+        setHeadlineCompoundedReturn(
+          typeof data.summary?.totalReturn === 'number' ? data.summary.totalReturn : null,
+        );
+        setHeadlineMaxDrawdown(
+          typeof data.summary?.maxDrawdown === 'number' ? data.summary.maxDrawdown : null,
+        );
       } else {
         if (isCancelled()) return;
         setRollingWinRates(null);
         setHeadlineBreakEven(null);
+        setHeadlineCompoundedReturn(null);
+        setHeadlineMaxDrawdown(null);
       }
     } catch {
       if (isCancelled()) return;
@@ -592,7 +608,7 @@ export function TrackRecordClient() {
                 {stats ? `${stats.totalPnlPct > 0 ? '+' : ''}${stats.totalPnlPct}%` : '—'}
               </span>
               <span className="text-sm text-[var(--text-secondary)] inline-flex items-center gap-1">
-                total return
+                total return · unsized
                 <InfoHint text={STAT_HINTS.totalReturnLinear} label="What total return means" />
               </span>
               {/* Provenance stamp — the window this headline actually covers,
@@ -633,6 +649,31 @@ export function TrackRecordClient() {
                 <InfoHint text={STAT_HINTS.resolved} label="What resolved signals means" />
               </span>
             </div>
+            {/* Realized (position-sized) return at headline weight — the number a
+               real subscriber could earn, shown next to the raw unsized total so
+               the achievable figure isn't buried. Paired with max drawdown so the
+               path's cost is never hidden behind the return. */}
+            {headlineCompoundedReturn !== null && (
+              <div className="flex items-baseline gap-1.5">
+                <span className={`text-xl font-semibold tabular-nums ${
+                  headlineCompoundedReturn > 0 ? 'text-emerald-400'
+                  : headlineCompoundedReturn < 0 ? 'text-red-400'
+                  : 'text-[var(--foreground)]'
+                }`}>
+                  {headlineCompoundedReturn > 0 ? '+' : ''}{headlineCompoundedReturn}%
+                </span>
+                <span className="text-xs text-[var(--text-secondary)] inline-flex items-center gap-1">
+                  realized · 1% risk
+                  <InfoHint text={STAT_HINTS.totalReturnCompounded} label="What realized compounded return means" />
+                </span>
+                {headlineMaxDrawdown !== null && (
+                  <span className="text-[11px] font-mono text-red-400/80 inline-flex items-center gap-1">
+                    max drawdown −{headlineMaxDrawdown}%
+                    <InfoHint text={STAT_HINTS.maxDrawdown} label="What max drawdown means" />
+                  </span>
+                )}
+              </div>
+            )}
             {resolutionHeartbeat && (
               <div
                 className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-mono ${

--- a/apps/web/lib/band-comparison.test.ts
+++ b/apps/web/lib/band-comparison.test.ts
@@ -1,0 +1,56 @@
+import { classifyBandComparison, type BandSummaryLite } from './band-comparison';
+
+function band(overrides: Partial<BandSummaryLite>): BandSummaryLite {
+  return {
+    totalReturn: 0,
+    winRate: 50,
+    totalSignals: 100,
+    expectancyR: 0,
+    ...overrides,
+  };
+}
+
+describe('classifyBandComparison', () => {
+  it('credits the filter only when premium beats all on win rate AND expectancy AND return', () => {
+    const all = band({ totalReturn: 5, winRate: 35, expectancyR: 0.04 });
+    const premium = band({ totalReturn: 12, winRate: 40, expectancyR: 0.15, totalSignals: 30 });
+
+    const r = classifyBandComparison(all, premium);
+    expect(r.verdict).toBe('premium_better');
+    expect(r.tone).toBe('positive');
+    expect(r.returnDelta).toBe(7);
+  });
+
+  it('does NOT credit premium when its total return wins only by trading less (lower win rate / worse expectancy)', () => {
+    // The live 7d cherry-pick: All -40.32% (WR 28.1, exp -0.17R, 256), Premium
+    // -7.83% (WR 25.8, exp -0.23R, 31). Premium "wins" the week by trading ~8× less.
+    const all = band({ totalReturn: -40.32, winRate: 28.1, expectancyR: -0.17, totalSignals: 256 });
+    const premium = band({ totalReturn: -7.83, winRate: 25.8, expectancyR: -0.23, totalSignals: 31 });
+
+    const r = classifyBandComparison(all, premium);
+    expect(r.verdict).toBe('premium_fewer_trades');
+    expect(r.tone).toBe('neutral');
+    expect(r.returnDelta).toBe(32.49);
+    expect(r.label.toLowerCase()).toContain('fewer trades');
+  });
+
+  it('flags premium as underperforming when its total return is worse (all-time reality)', () => {
+    // Live all-time: All +41.16%, Premium -1.7%.
+    const all = band({ totalReturn: 41.16, winRate: 37.9, expectancyR: 0.04, totalSignals: 3313 });
+    const premium = band({ totalReturn: -1.7, winRate: 34.6, expectancyR: 0.02, totalSignals: 191 });
+
+    const r = classifyBandComparison(all, premium);
+    expect(r.verdict).toBe('premium_worse');
+    expect(r.tone).toBe('negative');
+    expect(r.returnDelta).toBe(-42.86);
+  });
+
+  it('falls back to win-rate when expectancy is unknowable on either band', () => {
+    const all = band({ totalReturn: 1, winRate: 30, expectancyR: null });
+    const premium = band({ totalReturn: 4, winRate: 35, expectancyR: null, totalSignals: 20 });
+
+    const r = classifyBandComparison(all, premium);
+    // Higher win rate + higher return, expectancy null → treated as genuine.
+    expect(r.verdict).toBe('premium_better');
+  });
+});

--- a/apps/web/lib/band-comparison.test.ts
+++ b/apps/web/lib/band-comparison.test.ts
@@ -53,4 +53,24 @@ describe('classifyBandComparison', () => {
     // Higher win rate + higher return, expectancy null → treated as genuine.
     expect(r.verdict).toBe('premium_better');
   });
+
+  it('falls back to win-rate when expectancy is unknowable on ONE side only', () => {
+    // A band with no sized trades reports expectancyR null; the other has data.
+    const all = band({ totalReturn: 1, winRate: 30, expectancyR: 0.04, totalSignals: 200 });
+    const premium = band({ totalReturn: 4, winRate: 35, expectancyR: null, totalSignals: 20 });
+
+    const r = classifyBandComparison(all, premium);
+    expect(r.verdict).toBe('premium_better');
+  });
+
+  it('treats an exactly-equal return with no quality edge as neutral "matched", not "underperformed"', () => {
+    const all = band({ totalReturn: 5.32, winRate: 40, expectancyR: 0.05 });
+    const premium = band({ totalReturn: 5.32, winRate: 38, expectancyR: 0.03, totalSignals: 50 });
+
+    const r = classifyBandComparison(all, premium);
+    expect(r.returnDelta).toBe(0);
+    expect(r.tone).toBe('neutral');
+    expect(r.verdict).toBe('premium_worse');
+    expect(r.label.toLowerCase()).toContain('matched');
+  });
 });

--- a/apps/web/lib/band-comparison.ts
+++ b/apps/web/lib/band-comparison.ts
@@ -1,0 +1,82 @@
+/**
+ * Honest premium-vs-all comparison for the track-record band callout.
+ *
+ * The paid value proposition is that the high-confidence ("premium", conf ≥ 85)
+ * filter selects BETTER trades. A naive "premium total return > all total return"
+ * test credits the filter even when premium merely traded LESS during a losing
+ * window — accumulating a smaller loss is not the same as higher accuracy. This
+ * classifier only calls the filter a winner when premium beats all-signals on
+ * per-trade quality (win rate AND expectancy) as well as total return; otherwise
+ * it states the honest mechanism (fewer trades) or that premium underperformed.
+ */
+
+export interface BandSummaryLite {
+  /** Compounded total return for the window, in percent. */
+  totalReturn: number;
+  /** Win rate for the window, in percent. */
+  winRate: number;
+  /** Sized/resolved trade count for the window. */
+  totalSignals: number;
+  /** Expectancy in R per trade. Null when no sized trades (R undefined). */
+  expectancyR: number | null;
+}
+
+export type BandVerdict = 'premium_better' | 'premium_fewer_trades' | 'premium_worse';
+
+export interface BandComparison {
+  verdict: BandVerdict;
+  /** premium.totalReturn − all.totalReturn, 2 dp. */
+  returnDelta: number;
+  tone: 'positive' | 'neutral' | 'negative';
+  /** Short, honest badge label. */
+  label: string;
+}
+
+function pct(n: number): string {
+  return `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`;
+}
+
+export function classifyBandComparison(
+  all: BandSummaryLite,
+  premium: BandSummaryLite,
+): BandComparison {
+  const returnDelta = +(premium.totalReturn - all.totalReturn).toFixed(2);
+
+  const higherWinRate = premium.winRate >= all.winRate;
+  // Expectancy is the per-trade edge. When it's defined on both bands, require
+  // premium ≥ all; when it's unknowable (no sized trades either side), fall back
+  // to win rate so we never silently treat "unknown" as "better".
+  const higherExpectancy =
+    premium.expectancyR !== null && all.expectancyR !== null
+      ? premium.expectancyR >= all.expectancyR
+      : higherWinRate;
+
+  const genuinelyBetter = higherWinRate && higherExpectancy;
+
+  if (genuinelyBetter && returnDelta >= 0) {
+    return {
+      verdict: 'premium_better',
+      returnDelta,
+      tone: 'positive',
+      label: `Premium outperformed ${pct(returnDelta)} vs All`,
+    };
+  }
+
+  if (returnDelta > 0) {
+    // Premium's total beats all, but not on per-trade quality — it just traded
+    // less. Don't credit the filter for accuracy it didn't provide.
+    return {
+      verdict: 'premium_fewer_trades',
+      returnDelta,
+      tone: 'neutral',
+      label: `Premium ${pct(returnDelta)} vs All — fewer trades, not higher accuracy`,
+    };
+  }
+
+  return {
+    verdict: 'premium_worse',
+    returnDelta,
+    tone: 'negative',
+    label: `Premium underperformed ${pct(returnDelta)} vs All`,
+  };
+}

--- a/apps/web/lib/band-comparison.ts
+++ b/apps/web/lib/band-comparison.ts
@@ -43,9 +43,9 @@ export function classifyBandComparison(
   const returnDelta = +(premium.totalReturn - all.totalReturn).toFixed(2);
 
   const higherWinRate = premium.winRate >= all.winRate;
-  // Expectancy is the per-trade edge. When it's defined on both bands, require
-  // premium ≥ all; when it's unknowable (no sized trades either side), fall back
-  // to win rate so we never silently treat "unknown" as "better".
+  // Expectancy is the per-trade edge. Require premium ≥ all when both are
+  // defined; if either is unknowable (a band with no sized trades — R is
+  // undefined), fall back to win rate so "unknown" is never read as "better".
   const higherExpectancy =
     premium.expectancyR !== null && all.expectancyR !== null
       ? premium.expectancyR >= all.expectancyR
@@ -70,6 +70,17 @@ export function classifyBandComparison(
       returnDelta,
       tone: 'neutral',
       label: `Premium ${pct(returnDelta)} vs All — fewer trades, not higher accuracy`,
+    };
+  }
+
+  if (returnDelta === 0) {
+    // Identical return with no per-trade edge (we'd have returned premium_better
+    // above otherwise). "Underperformed +0.00%" would be self-contradictory.
+    return {
+      verdict: 'premium_worse',
+      returnDelta,
+      tone: 'neutral',
+      label: 'Premium matched All — no per-trade edge',
     };
   }
 

--- a/docs/plans/2026-06-14-track-record-honesty-fixes.md
+++ b/docs/plans/2026-06-14-track-record-honesty-fixes.md
@@ -1,0 +1,45 @@
+# Track-record honesty fixes (2026-06-14)
+
+Source: cross-surface consistency audit of `/track-record` against live `tradeclaw.win/api/signals/*`.
+
+## Findings actioned
+
+1. **CRITICAL — deceptive Premium-vs-All badge.** `TrailingWeekBandCallout` advertises
+   `Premium +X% vs All` colored as "filter paying rent" whenever premium's *total return* beats
+   all-signals over the last 7 days. Live data shows this is misleading:
+   - 7d window: All −40.32% (win 28.1%, exp −0.17R, 256 trades) vs Premium −7.83%
+     (win 25.8%, exp −0.23R, 31 trades). Premium has a **lower** win rate and **worse**
+     per-trade expectancy that week; it "wins" only by trading ~8× less.
+   - All-time: All **+41.16%** vs Premium **−1.7%** (191 trades, win 34.6%, Sharpe 0.03).
+     The premium filter underperforms the firehose on return, win rate, expectancy, and Sharpe
+     over the full record.
+
+2. **HIGH — headline hierarchy.** The header leads with `+76.35%` (raw sum of per-signal
+   market %, no sizing, no costs) in 5xl, while the realized compounded figure a subscriber
+   could actually earn (`+41.16%`, with a −82.57% max drawdown) sits lower in the equity card.
+
+## Retracted (not a bug)
+
+- R-stat trio (win-rate × avgR vs expectancy/break-even) reconciles once avgR/win is read
+  correctly (~1.71R, not 1.66R). Confirmed by `route.test.ts` "computes expectancyR from the
+  sized-trade population". No change.
+- Counts reconcile: 3,313 resolved + 2,345 expired + 3,723 gate-blocked + 5 pending = 9,386 total.
+- Max drawdown −82.57% is the real peak-to-trough of the compounded path. Honest. No change.
+
+## Plan (3 commits, layered)
+
+1. **api:** add `summaryOnly` to `GET /api/signals/equity` — returns `summary` +
+   `rollingWinRates` with `points: []`, so summary-only consumers skip the ~3.3k-point payload.
+   Test in `route.test.ts`.
+2. **product:** `lib/band-comparison.ts` pure classifier (`classifyBandComparison`) +
+   unit test; rewire `TrailingWeekBandCallout` to (a) gate the positive framing on genuine
+   per-trade quality (win rate AND expectancy ≥ all), (b) show an all-time Premium-vs-All
+   context line via `summaryOnly`.
+3. **product:** surface realized compounded return + max drawdown at the `/track-record`
+   headline; label the raw `+76.35%` as unsized.
+
+## Verify
+
+- `npm run -w apps/web type-check` (or `tsc --noEmit`) green.
+- `npx jest band-comparison route.test --modulePathIgnorePatterns="standalone"` green.
+- No change to win-rate computation (honesty contract: win-rate byte-matches across surfaces).


### PR DESCRIPTION
## Why

Cross-surface consistency audit of `/track-record` against live `tradeclaw.win/api/signals/*` surfaced two honesty problems (the headline-vs-compounded difference a user asked about is **not** one — that's two labeled views of the same trades).

### 1. Deceptive Premium-vs-All badge (critical)
The trailing-week callout showed a green **"Premium +X% vs All"** whenever premium's *total return* beat all-signals. That's misleading: premium can "win" a losing week purely by trading fewer signals.
- Live 7d: All **−40.32%** (win 28.1%, exp −0.17R, 256 trades) vs Premium **−7.83%** (win **25.8%**, exp **−0.23R**, 31 trades). Premium has a *lower* win rate and *worse* per-trade expectancy — it only "wins" by firing ~8× fewer trades.
- Live all-time: All **+41.16%** vs Premium **−1.7%** (191 trades, win 34.6%, Sharpe 0.03). The premium filter underperforms the firehose on return, win rate, expectancy, and Sharpe over the full record.

### 2. Headline hierarchy
The header led with **+76.35%** (raw sum of per-signal market %, no sizing, no costs) in 5xl, while the realized figure a subscriber could actually earn (**+41.16%**, with a **−82.57%** max drawdown) sat lower in the equity card.

## What changed
- **`lib/band-comparison.ts`** (new, unit-tested): `classifyBandComparison` only frames premium as outperforming when it beats all on win rate **AND** expectancy; otherwise it states the honest mechanism ("fewer trades, not higher accuracy") or that premium underperformed. Handles one-sided-null expectancy and exactly-equal returns.
- **`trailing-week-band-callout.tsx`**: badge now uses the classifier (tone-aware) and adds an **all-time context line** so a single chop week can't stand in for the long run.
- **`TrackRecordClient.tsx`**: labels the raw total **"unsized"** and surfaces realized compounded return + max drawdown at headline weight. Win-rate computation unchanged (honesty contract: win-rate byte-matches across surfaces).
- **`api/signals/equity` `summaryOnly=1`**: returns `summary` + `rollingWinRates` with `points: []`, so the callout/headline skip the ~3.3k-point payload. Curve consumers unchanged.

Plan: `docs/plans/2026-06-14-track-record-honesty-fixes.md`

## Not addressed (out of scope)
This makes the page tell the truth; it does not make the premium tier worth selling. That premium is net-negative all-time is a product call.

## Test plan
- [x] `tsc -p apps/web` green (run `npm run build:signals` first — gitignored dist).
- [x] Jest 10/10: `band-comparison.test.ts` (6) + `equity/route.test.ts` (4, incl. new `summaryOnly`).
- [x] ESLint 0 errors on changed files.
- [x] code-reviewer subagent pass; 1 HIGH (lost `finally` guard) + MEDIUM/LOW all remediated.
- [ ] Manual: load `/track-record`, confirm badge tone matches the week's quality and the all-time line renders; confirm headline shows realized return + max DD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)