### PR TITLE
fix(report): kill PRNG-fabricated stats on /wrapped, /api/report, and the weekly pulse

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -29,7 +29,7 @@ jobs:
           script: |
             const now = new Date();
 
-            // ISO week helper
+            // ISO week helper (real, date-derived — not random).
             function getISOWeek(date) {
               const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
               const dayNum = d.getUTCDay() || 7;
@@ -38,30 +38,13 @@ jobs:
               return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
             }
 
-            // Seeded PRNG
-            function mulberry32(seed) {
-              return function () {
-                let t = (seed += 0x6d2b79f5);
-                t = Math.imul(t ^ (t >>> 15), t | 1);
-                t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-                return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-              };
-            }
-
             const weekNum = getISOWeek(now);
-            const seed = now.getFullYear() * 100 + weekNum;
-            const rand = mulberry32(seed);
 
-            const totalSignals = Math.floor(rand() * 80 + 120);
-            const winRate = Math.floor(rand() * 20 + 60);
-            const assets = ['BTCUSD', 'ETHUSD', 'XAUUSD', 'XAGUSD', 'EURUSD', 'GBPUSD', 'USDJPY', 'BNBUSD', 'SOLUSD', 'ADAUSD'];
-            const topAsset = assets[Math.floor(rand() * assets.length)];
-            const topAccuracy = Math.floor(rand() * 15 + 70);
-            const uptime = (99 + rand() * 0.9).toFixed(2);
-            const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-            const daily = days.map(d => ({ day: d, count: Math.floor(rand() * 25 + 12) }));
-
-            // Get repo stats
+            // Real repo metrics from the GitHub API. We deliberately do NOT
+            // republish signal performance numbers here: the only honest source
+            // is the live, resolved-signal report at tradeclaw.win/report. This
+            // workflow used to fabricate win rate / signal count / top asset with
+            // a seeded PRNG — removed so nothing on a public surface is invented.
             const repoData = await github.rest.repos.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -69,8 +52,8 @@ jobs:
             const stars = repoData.data.stargazers_count;
             const forks = repoData.data.forks_count;
 
-            // Get new contributors (last 7 days proxy: compare commit authors)
-            let newContributors = 0;
+            // Active contributors in the last 7 days (real commit authors).
+            let activeContributors = 0;
             try {
               const since = new Date(now.getTime() - 7 * 86400000).toISOString();
               const commits = await github.rest.repos.listCommits({
@@ -80,53 +63,47 @@ jobs:
                 per_page: 100,
               });
               const uniqueAuthors = new Set(
-                commits.data
-                  .map(c => c.author?.login)
-                  .filter(Boolean)
+                commits.data.map(c => c.author?.login).filter(Boolean)
               );
-              newContributors = uniqueAuthors.size;
+              activeContributors = uniqueAuthors.size;
             } catch {
-              newContributors = 0;
+              activeContributors = 0;
             }
 
-            // Build week date label
+            // Week date label
             const day = now.getUTCDay();
             const mondayOffset = day === 0 ? 6 : day - 1;
             const monday = new Date(now.getTime() - mondayOffset * 86400000);
             const weekLabel = monday.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
 
-            // Build progress bar
+            // Star progress bar (real stars).
             const starsProgress = Math.min(Math.round((stars / 1000) * 20), 20);
             const progressBar = '█'.repeat(starsProgress) + '░'.repeat(20 - starsProgress);
-
-            const dailyTable = daily.map(d => `| ${d.day} | ${d.count} |`).join('\n');
 
             const body = [
               `## 📊 TradeClaw Weekly Pulse — Week of ${weekLabel}`,
               '',
-              `> Auto-generated every Monday. [View live report →](https://tradeclaw.win/report)`,
+              `> Auto-generated every Monday. Live signal performance (win rate, signals resolved, top asset) → [tradeclaw.win/report](https://tradeclaw.win/report)`,
               '',
               '---',
               '',
-              '### 🎯 This Week at a Glance',
+              '### 🛠️ Repo & Community',
               '',
               '| Metric | Value |',
               '|--------|-------|',
-              `| ⚡ Signals Generated | **${totalSignals}** |`,
-              `| 🎯 Win Rate | **${winRate}%** |`,
-              `| 🏆 Top Asset | **${topAsset}** (${topAccuracy}% accuracy) |`,
-              `| 🔄 Active Contributors | **${newContributors}** |`,
               `| ⭐ Total Stars | **${stars}** |`,
               `| 🍴 Forks | **${forks}** |`,
-              `| 🟢 Uptime | **${uptime}%** |`,
+              `| 🔄 Active Contributors (7d) | **${activeContributors}** |`,
               '',
               '---',
               '',
-              '### 📅 Signals Per Day',
+              '### 📈 Signal Performance',
               '',
-              '| Day | Count |',
-              '|-----|-------|',
-              dailyTable,
+              'We keep all signal numbers on the live, real-data surfaces so they can never drift from what actually resolved:',
+              '',
+              '- [📊 Weekly Report](https://tradeclaw.win/report) — this week’s resolved win rate, signal count, and top asset',
+              '- [📈 Live Signals](https://tradeclaw.win/dashboard) — real-time signal feed',
+              '- [🏆 Leaderboard](https://tradeclaw.win/leaderboard) — accuracy by asset',
               '',
               '---',
               '',
@@ -136,20 +113,15 @@ jobs:
               `${stars}/1000  [${progressBar}]  ${Math.round((stars / 1000) * 100)}%`,
               '```',
               '',
-              `**${1000 - stars} more stars** to reach our 1,000 milestone! If you find TradeClaw useful, please give it a ⭐ — it costs nothing and helps other developers discover the project.`,
+              `**${Math.max(0, 1000 - stars)} more stars** to reach our 1,000 milestone! If you find TradeClaw useful, please give it a ⭐ — it costs nothing and helps other developers discover the project.`,
               '',
               '---',
               '',
               '### 🔗 Quick Links',
               '',
-              '- [📈 Live Signals](https://tradeclaw.win/dashboard) — real-time signal feed',
-              '- [🏆 Leaderboard](https://tradeclaw.win/leaderboard) — accuracy by asset',
-              '- [📊 Full Report](https://tradeclaw.win/report) — this week\'s stats',
               '- [🤝 Contribute](https://tradeclaw.win/contribute) — good first issues',
               '',
-              '---',
-              '',
-              '*Feel free to share your results from following TradeClaw signals this week! What worked? What didn\'t? Let the community know below.*',
+              '*Following TradeClaw signals this week? Share what worked and what didn\'t below — real results from the community are always welcome.*',
             ].join('\n');
 
             if (context.payload?.inputs?.dry_run === 'true') {
@@ -182,10 +154,8 @@ jobs:
               return;
             }
 
-            // Get repo node ID
             const repoNodeId = repoData.data.node_id;
 
-            // Create discussion
             const createMutation = `
               mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
                 createDiscussion(input: {
@@ -213,10 +183,9 @@ jobs:
               .addHeading('📊 Weekly Pulse Posted', 2)
               .addTable([
                 [{ data: 'Metric', header: true }, { data: 'Value', header: true }],
-                ['Signals', String(totalSignals)],
-                ['Win Rate', `${winRate}%`],
-                ['Top Asset', topAsset],
                 ['Stars', String(stars)],
+                ['Forks', String(forks)],
+                ['Active Contributors (7d)', String(activeContributors)],
                 ['Discussion', url],
               ])
               .write();

--- a/apps/web/app/api/report/route.ts
+++ b/apps/web/app/api/report/route.ts
@@ -1,75 +1,23 @@
 import { NextResponse } from 'next/server';
+import { getWeeklyPulse } from '../../../lib/weekly-pulse';
 
 export const revalidate = 3600;
 
-// Seeded PRNG (mulberry32) — deterministic per ISO week
-function mulberry32(seed: number) {
-  return function () {
-    let t = (seed += 0x6d2b79f5);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function getISOWeek(date: Date): number {
-  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-  const dayNum = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-}
-
-const ASSETS = [
-  'BTCUSD', 'ETHUSD', 'SOLUSD', 'BNBUSD', 'XRPUSD', 'DOGEUSD',
-  'ADAUSD', 'AVAXUSD', 'DOTUSD', 'LINKUSD', 'LTCUSD', 'BCHUSD',
-  'NEARUSD', 'SUIUSD', 'INJUSD', 'PEPEUSD', 'SHIBUSD',
-  'XAUUSD', 'XAGUSD', 'EURUSD', 'GBPUSD', 'USDJPY',
-];
-
+// Weekly Pulse: real, resolved-signal stats for the current ISO week, computed
+// from signal_history through the canonical isCountedResolved predicate. This
+// replaced a mulberry32 PRNG that fabricated win rate / signal count / top
+// asset unconditionally. When fewer than WEEKLY_PULSE_MIN signals have resolved
+// the payload sets hasEnoughData=false and the page shows an honest empty state.
 export async function GET() {
-  const now = new Date();
-  const weekNum = getISOWeek(now);
-  const seed = now.getFullYear() * 100 + weekNum;
-  const rand = mulberry32(seed);
-
-  // Generate deterministic weekly stats
-  const totalSignals = Math.floor(rand() * 80 + 120); // 120–200
-  const winRate = Math.floor(rand() * 20 + 60); // 60–80%
-  const topAssetIdx = Math.floor(rand() * ASSETS.length);
-  const topAsset = ASSETS[topAssetIdx];
-  const topAccuracy = Math.floor(rand() * 15 + 70); // 70–85%
-  const newContributors = Math.floor(rand() * 3); // 0–2
-  const starsThisWeek = Math.floor(rand() * 5 + 1); // 1–5
-
-  // Daily breakdown (Mon-Sun)
-  const dailyBreakdown = Array.from({ length: 7 }, () =>
-    Math.floor(rand() * 25 + 12)
-  ) as [number, number, number, number, number, number, number];
-
-  // Compute week start (Monday 00:00 UTC)
-  const day = now.getUTCDay();
-  const mondayOffset = day === 0 ? 6 : day - 1;
-  const weekStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - mondayOffset));
-
-  return NextResponse.json(
-    {
-      weekOf: weekStart.toISOString().split('T')[0],
-      isoWeek: weekNum,
-      totalSignals,
-      winRate,
-      topAsset,
-      topAccuracy,
-      newContributors,
-      starsThisWeek,
-      dailyBreakdown,
-      generatedAt: now.toISOString(),
-    },
-    {
+  try {
+    const pulse = await getWeeklyPulse();
+    return NextResponse.json(pulse, {
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600',
       },
-    }
-  );
+    });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/apps/web/app/api/wrapped/route.ts
+++ b/apps/web/app/api/wrapped/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getWrappedStats } from '../../../lib/wrapped-stats';
+
+// Real, platform-wide "year in review" for TradeClaw's tracked signals — total
+// resolved signals, best/worst pair, accuracy trend, win streak, all from
+// signal_history via isCountedResolved. Replaced a client-side seeded LCG that
+// fabricated per-"user" stats (the product has no per-user trade ledger).
+// hasEnoughData=false → the page shows an honest "not enough history yet" state.
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const currentYear = new Date().getUTCFullYear();
+    const parsed = Number(searchParams.get('year'));
+    const year =
+      Number.isInteger(parsed) && parsed >= 2020 && parsed <= currentYear ? parsed : currentYear;
+
+    const stats = await getWrappedStats(year);
+    return NextResponse.json(stats, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600',
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/app/report/ReportClient.tsx
+++ b/apps/web/app/report/ReportClient.tsx
@@ -5,12 +5,13 @@ import Link from 'next/link';
 import {
   BarChart2,
   TrendingUp,
-  Users,
   Star,
   ExternalLink,
   Share2,
   Trophy,
   Activity,
+  Target,
+  Gauge,
   RefreshCw,
   ChevronRight,
 } from 'lucide-react';
@@ -18,12 +19,12 @@ import {
 interface ReportData {
   weekOf: string;
   isoWeek: number;
+  hasEnoughData: boolean;
   totalSignals: number;
   winRate: number;
   topAsset: string;
   topAccuracy: number;
-  newContributors: number;
-  starsThisWeek: number;
+  avgConfidence: number;
   dailyBreakdown: [number, number, number, number, number, number, number];
   generatedAt: string;
 }
@@ -69,7 +70,6 @@ function BarChart({ data }: { data: number[] }) {
       const barH = (val / max) * chartH;
       const y = padY + chartH - barH;
 
-      // Gradient fill
       const grad = ctx.createLinearGradient(0, y, 0, y + barH);
       grad.addColorStop(0, 'rgba(16,185,129,0.9)');
       grad.addColorStop(1, 'rgba(16,185,129,0.2)');
@@ -78,26 +78,18 @@ function BarChart({ data }: { data: number[] }) {
       ctx.roundRect(x, y, barW, barH, 3);
       ctx.fill();
 
-      // Value label
       ctx.fillStyle = 'rgba(255,255,255,0.6)';
       ctx.font = `600 9px -apple-system, sans-serif`;
       ctx.textAlign = 'center';
       ctx.fillText(String(val), x + barW / 2, y - 4);
 
-      // Day label
       ctx.fillStyle = 'rgba(255,255,255,0.4)';
       ctx.font = `500 9px -apple-system, sans-serif`;
       ctx.fillText(DAYS[i], x + barW / 2, H - 4);
     });
   }, [data]);
 
-  return (
-    <canvas
-      ref={canvasRef}
-      className="w-full"
-      style={{ height: 160 }}
-    />
-  );
+  return <canvas ref={canvasRef} className="w-full" style={{ height: 160 }} />;
 }
 
 export default function ReportClient() {
@@ -109,7 +101,7 @@ export default function ReportClient() {
     if (isRefresh) setRefreshing(true);
     try {
       const res = await fetch('/api/report');
-      const json = await res.json() as ReportData;
+      const json = (await res.json()) as ReportData;
       setData(json);
     } catch {
       // silent fail
@@ -124,14 +116,14 @@ export default function ReportClient() {
   }, []);
 
   const handleShare = () => {
-    if (!data) return;
+    if (!data || !data.hasEnoughData) return;
     const tweet = encodeURIComponent(
       `📊 TradeClaw Weekly Pulse — Week ${data.isoWeek}\n\n` +
-      `⚡ ${data.totalSignals} signals fired\n` +
-      `🎯 ${data.winRate}% win rate\n` +
-      `🏆 Top asset: ${data.topAsset} (${data.topAccuracy}% accuracy)\n\n` +
-      `Open-source AI trading signals → https://github.com/naimkatiman/tradeclaw\n\n` +
-      `#algotrading #opensource #tradeclaw`
+        `⚡ ${data.totalSignals} signals resolved\n` +
+        `🎯 ${data.winRate}% win rate\n` +
+        `🏆 Top asset: ${data.topAsset} (${data.topAccuracy}% accuracy)\n\n` +
+        `Open-source AI trading signals → https://github.com/naimkatiman/tradeclaw\n\n` +
+        `#algotrading #opensource #tradeclaw`,
     );
     window.open(`https://twitter.com/intent/tweet?text=${tweet}`, '_blank');
   };
@@ -155,7 +147,7 @@ export default function ReportClient() {
   const stats = [
     {
       icon: Activity,
-      label: 'Signals Generated',
+      label: 'Signals Resolved',
       value: data.totalSignals.toLocaleString(),
       sub: 'This week',
       color: 'text-emerald-400',
@@ -170,18 +162,18 @@ export default function ReportClient() {
       bg: 'from-blue-500/10 to-transparent',
     },
     {
-      icon: Users,
-      label: 'New Contributors',
-      value: data.newContributors === 0 ? 'None yet' : `+${data.newContributors}`,
-      sub: 'GitHub this week',
+      icon: Target,
+      label: 'Top Accuracy',
+      value: `${data.topAccuracy}%`,
+      sub: data.topAsset === '—' ? 'No data yet' : data.topAsset,
       color: 'text-purple-400',
       bg: 'from-purple-500/10 to-transparent',
     },
     {
-      icon: Star,
-      label: 'New Stars',
-      value: `+${data.starsThisWeek}`,
-      sub: 'Toward 1,000',
+      icon: Gauge,
+      label: 'Avg Confidence',
+      value: `${data.avgConfidence}`,
+      sub: 'Resolved signals',
       color: 'text-zinc-400',
       bg: 'from-zinc-500/10 to-transparent',
     },
@@ -199,11 +191,10 @@ export default function ReportClient() {
         </div>
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div>
-            <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-2">
-              Weekly Pulse
-            </h1>
+            <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-2">Weekly Pulse</h1>
             <p className="text-[var(--text-secondary)] text-sm max-w-xl">
-              Signals fired, win rates, top performers — every week, auto-generated from TradeClaw live data.
+              Signals resolved, win rates, top performers — every week, auto-generated from
+              TradeClaw&apos;s real resolved signal history.
             </p>
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
@@ -215,80 +206,100 @@ export default function ReportClient() {
               <RefreshCw className={`w-3 h-3 ${refreshing ? 'animate-spin' : ''}`} />
               Refresh
             </button>
-            <button
-              onClick={handleShare}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-xs text-emerald-400 hover:bg-emerald-500/20 transition-colors"
-            >
-              <Share2 className="w-3 h-3" />
-              Share on X
-            </button>
+            {data.hasEnoughData && (
+              <button
+                onClick={handleShare}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-xs text-emerald-400 hover:bg-emerald-500/20 transition-colors"
+              >
+                <Share2 className="w-3 h-3" />
+                Share on X
+              </button>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Stats grid */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
-        {stats.map((s) => (
-          <div
-            key={s.label}
-            className={`glass rounded-2xl p-4 bg-gradient-to-br ${s.bg} border border-[var(--border)]`}
-          >
-            <div className="flex items-center gap-1.5 mb-2">
-              <s.icon className={`w-3.5 h-3.5 ${s.color}`} />
-              <span className="text-[10px] text-[var(--text-secondary)] uppercase tracking-widest font-semibold">
-                {s.label}
-              </span>
-            </div>
-            <div className={`text-2xl font-bold tracking-tight mb-0.5 ${s.color}`}>
-              {s.value}
-            </div>
-            <div className="text-[10px] text-[var(--text-secondary)]">{s.sub}</div>
-          </div>
-        ))}
-      </div>
-
-      {/* Main content grid */}
-      <div className="grid md:grid-cols-3 gap-6">
-        {/* Bar chart — spans 2 cols */}
-        <div className="md:col-span-2 glass rounded-2xl p-5 border border-[var(--border)]">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-sm font-semibold flex items-center gap-2">
-              <BarChart2 className="w-4 h-4 text-emerald-400" />
-              Signals per day
-            </h2>
-            <span className="text-[10px] text-[var(--text-secondary)]">Mon – Sun</span>
-          </div>
-          <BarChart data={data.dailyBreakdown} />
+      {!data.hasEnoughData ? (
+        /* Honest empty state — no fabricated numbers until real signals resolve */
+        <div className="glass rounded-2xl p-8 border border-[var(--border)] text-center mb-8">
+          <Activity className="w-6 h-6 text-emerald-400 mx-auto mb-3" />
+          <h2 className="text-lg font-semibold mb-2">Not enough resolved signals this week yet</h2>
+          <p className="text-sm text-[var(--text-secondary)] max-w-md mx-auto">
+            Real weekly numbers appear once at least 5 signals resolve.{' '}
+            <span className="text-[var(--foreground)]">{data.totalSignals}</span> resolved so far
+            this week. Check back as more outcomes settle, or see the{' '}
+            <Link href="/accuracy" className="text-emerald-400 hover:text-emerald-300">
+              full accuracy data
+            </Link>
+            .
+          </p>
         </div>
-
-        {/* Top asset card */}
-        <div className="glass rounded-2xl p-5 border border-[var(--border)] bg-gradient-to-br from-zinc-500/5 to-transparent flex flex-col justify-between">
-          <div>
-            <div className="flex items-center gap-2 mb-4">
-              <Trophy className="w-4 h-4 text-zinc-400" />
-              <span className="text-sm font-semibold">Top Asset</span>
-            </div>
-            <div className="text-4xl font-bold tracking-tight mb-1">{data.topAsset}</div>
-            <div className="text-sm text-[var(--text-secondary)] mb-4">
-              {data.topAccuracy}% accuracy this week
-            </div>
-            <div className="w-full bg-white/5 rounded-full h-1.5 mb-1">
+      ) : (
+        <>
+          {/* Stats grid */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
+            {stats.map((s) => (
               <div
-                className="bg-gradient-to-r from-zinc-400 to-zinc-300 h-1.5 rounded-full"
-                style={{ width: `${data.topAccuracy}%` }}
-              />
-            </div>
-            <div className="text-[10px] text-[var(--text-secondary)]">Accuracy rate</div>
+                key={s.label}
+                className={`glass rounded-2xl p-4 bg-gradient-to-br ${s.bg} border border-[var(--border)]`}
+              >
+                <div className="flex items-center gap-1.5 mb-2">
+                  <s.icon className={`w-3.5 h-3.5 ${s.color}`} />
+                  <span className="text-[10px] text-[var(--text-secondary)] uppercase tracking-widest font-semibold">
+                    {s.label}
+                  </span>
+                </div>
+                <div className={`text-2xl font-bold tracking-tight mb-0.5 ${s.color}`}>{s.value}</div>
+                <div className="text-[10px] text-[var(--text-secondary)]">{s.sub}</div>
+              </div>
+            ))}
           </div>
-          <Link
-            href={`/signal/${data.topAsset}-H1-BUY`}
-            className="mt-4 flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-300 transition-colors"
-          >
-            View latest signal
-            <ChevronRight className="w-3 h-3" />
-          </Link>
-        </div>
-      </div>
+
+          {/* Main content grid */}
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="md:col-span-2 glass rounded-2xl p-5 border border-[var(--border)]">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-sm font-semibold flex items-center gap-2">
+                  <BarChart2 className="w-4 h-4 text-emerald-400" />
+                  Signals per day
+                </h2>
+                <span className="text-[10px] text-[var(--text-secondary)]">Mon – Sun</span>
+              </div>
+              <BarChart data={data.dailyBreakdown} />
+            </div>
+
+            {/* Top asset card */}
+            <div className="glass rounded-2xl p-5 border border-[var(--border)] bg-gradient-to-br from-zinc-500/5 to-transparent flex flex-col justify-between">
+              <div>
+                <div className="flex items-center gap-2 mb-4">
+                  <Trophy className="w-4 h-4 text-zinc-400" />
+                  <span className="text-sm font-semibold">Top Asset</span>
+                </div>
+                <div className="text-4xl font-bold tracking-tight mb-1">{data.topAsset}</div>
+                <div className="text-sm text-[var(--text-secondary)] mb-4">
+                  {data.topAccuracy}% accuracy this week
+                </div>
+                <div className="w-full bg-white/5 rounded-full h-1.5 mb-1">
+                  <div
+                    className="bg-gradient-to-r from-zinc-400 to-zinc-300 h-1.5 rounded-full"
+                    style={{ width: `${data.topAccuracy}%` }}
+                  />
+                </div>
+                <div className="text-[10px] text-[var(--text-secondary)]">Accuracy rate</div>
+              </div>
+              {data.topAsset !== '—' && (
+                <Link
+                  href={`/signal/${data.topAsset}-H1-BUY`}
+                  className="mt-4 flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-300 transition-colors"
+                >
+                  View latest signal
+                  <ChevronRight className="w-3 h-3" />
+                </Link>
+              )}
+            </div>
+          </div>
+        </>
+      )}
 
       {/* GitHub Discussions + CTA */}
       <div className="mt-6 grid md:grid-cols-2 gap-4">

--- a/apps/web/app/wrapped/WrappedClient.tsx
+++ b/apps/web/app/wrapped/WrappedClient.tsx
@@ -22,25 +22,29 @@ import {
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
+// Mirrors the WrappedStats payload from /api/wrapped (computed server-side from
+// real signal_history via isCountedResolved). Kept as a local interface so this
+// client component never imports the server-only data module.
 interface WrappedStats {
   year: number;
+  hasEnoughData: boolean;
   totalSignals: number;
   bestPair: string;
   bestPairCount: number;
-  bestPairWinRate: number;
+  bestPairWinRate: number; // 0..1
   worstPair: string;
-  worstPairWinRate: number;
+  worstPairWinRate: number; // 0..1
   totalBuy: number;
   totalSell: number;
-  avgConfidence: number;
+  avgConfidence: number; // 0..100
   topTimeframe: string;
   totalWins: number;
   totalLosses: number;
-  overallWinRate: number;
+  overallWinRate: number; // 0..1
   longestStreak: number;
   monthlyActivity: number[];
   accuracyTrend: number[];
-  favoriteHour: number;
+  busiestHour: number; // 0..23 UTC
   uniquePairs: number;
 }
 
@@ -57,76 +61,6 @@ interface RevealCard {
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
-
-const PAIRS = ['BTCUSD', 'ETHUSD', 'XAUUSD', 'XAGUSD', 'EURUSD', 'GBPUSD', 'USDJPY', 'AUDUSD', 'USDCAD', 'NZDUSD'];
-const TIMEFRAMES = ['M15', 'H1', 'H4', 'D1'];
-
-function seededRandom(seed: number): () => number {
-  let s = seed;
-  return () => {
-    s = (s * 16807 + 0) % 2147483647;
-    return (s - 1) / 2147483646;
-  };
-}
-
-function buildStats(year: number): WrappedStats {
-  const rand = seededRandom(year * 42 + 7);
-
-  // Generate per-pair stats
-  const pairStats = PAIRS.map(pair => {
-    const count = Math.floor(rand() * 200) + 50;
-    const winRate = 0.45 + rand() * 0.35;
-    return { pair, count, winRate };
-  });
-
-  pairStats.sort((a, b) => b.winRate - a.winRate);
-  const bestPair = pairStats[0];
-  const worstPair = pairStats[pairStats.length - 1];
-
-  const totalSignals = pairStats.reduce((s, p) => s + p.count, 0);
-  const totalWins = pairStats.reduce((s, p) => s + Math.round(p.count * p.winRate), 0);
-  const totalLosses = totalSignals - totalWins;
-
-  // Monthly activity (Jan–Dec)
-  const monthlyActivity = Array.from({ length: 12 }, () => Math.floor(rand() * 180) + 40);
-
-  // Accuracy trend by month
-  const accuracyTrend = Array.from({ length: 12 }, (_, i) => {
-    const base = 0.52 + i * 0.02;
-    return Math.min(0.85, base + (rand() - 0.5) * 0.1);
-  });
-
-  // Timeframe preference
-  const tfIdx = Math.floor(rand() * TIMEFRAMES.length);
-
-  // Favorite hour
-  const favoriteHour = Math.floor(rand() * 14) + 7; // 7-20
-
-  const totalBuy = Math.round(totalSignals * (0.45 + rand() * 0.1));
-  const totalSell = totalSignals - totalBuy;
-
-  return {
-    year,
-    totalSignals,
-    bestPair: bestPair.pair,
-    bestPairCount: bestPair.count,
-    bestPairWinRate: bestPair.winRate,
-    worstPair: worstPair.pair,
-    worstPairWinRate: worstPair.winRate,
-    totalBuy,
-    totalSell,
-    avgConfidence: 62 + rand() * 20,
-    topTimeframe: TIMEFRAMES[tfIdx],
-    totalWins,
-    totalLosses,
-    overallWinRate: totalWins / totalSignals,
-    longestStreak: Math.floor(rand() * 12) + 3,
-    monthlyActivity,
-    accuracyTrend,
-    favoriteHour,
-    uniquePairs: PAIRS.length,
-  };
-}
 
 function formatPct(v: number): string {
   return `${(v * 100).toFixed(1)}%`;
@@ -166,9 +100,10 @@ function AccuracyTrendLine({ data }: { data: number[] }) {
   const pad = 4;
   const min = Math.min(...data) - 0.05;
   const max = Math.max(...data) + 0.05;
+  const span = max - min || 1;
   const pts = data.map((v, i) => {
     const x = pad + (i / (data.length - 1)) * (w - 2 * pad);
-    const y = h - pad - ((v - min) / (max - min)) * (h - 2 * pad);
+    const y = h - pad - ((v - min) / span) * (h - 2 * pad);
     return `${x},${y}`;
   });
   return (
@@ -189,7 +124,7 @@ function AccuracyTrendLine({ data }: { data: number[] }) {
       />
       {data.map((v, i) => {
         const x = pad + (i / (data.length - 1)) * (w - 2 * pad);
-        const y = h - pad - ((v - min) / (max - min)) * (h - 2 * pad);
+        const y = h - pad - ((v - min) / span) * (h - 2 * pad);
         return <circle key={i} cx={x} cy={y} r="3" fill="#10b981" opacity={0.7} />;
       })}
     </svg>
@@ -240,6 +175,48 @@ function AnimatedRevealCard({ card, index, isVisible }: { card: RevealCard; inde
 }
 
 /* ------------------------------------------------------------------ */
+/*  Header (year selector + restart)                                   */
+/* ------------------------------------------------------------------ */
+
+function WrappedHeader({
+  year,
+  currentYear,
+  onYear,
+  onRestart,
+}: {
+  year: number;
+  currentYear: number;
+  onYear: (y: number) => void;
+  onRestart: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 md:px-8 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
+      <Link href="/" className="text-sm font-medium flex items-center gap-1.5" style={{ color: 'var(--foreground)' }}>
+        <Sparkles size={16} className="text-emerald-500" />
+        TradeClaw
+      </Link>
+      <div className="flex items-center gap-3">
+        <select
+          value={year}
+          onChange={(e) => onYear(Number(e.target.value))}
+          className="text-xs rounded-lg px-2 py-1 border"
+          style={{ background: 'var(--bg-card)', borderColor: 'var(--border)', color: 'var(--foreground)' }}
+        >
+          {[currentYear, currentYear - 1, currentYear - 2].map((y) => (
+            <option key={y} value={y}>
+              {y}
+            </option>
+          ))}
+        </select>
+        <button onClick={onRestart} className="text-xs flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
+          <RotateCcw size={12} /> Restart
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main Component                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -247,23 +224,37 @@ export function WrappedClient() {
   const currentYear = new Date().getFullYear();
   const [year, setYear] = useState(currentYear);
   const [stats, setStats] = useState<WrappedStats | null>(null);
+  const [loading, setLoading] = useState(true);
   const [step, setStep] = useState(0); // 0 = intro, 1-6 = reveal cards, 7 = summary
   const [cardsVisible, setCardsVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Try loading from localStorage, fall back to generated
+  // Load real, server-computed stats for the selected year.
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem('tc-wrapped-history');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (parsed && parsed.year === year) {
-          startTransition(() => { setStats(parsed); });
-          return;
-        }
-      }
-    } catch { /* ignore */ }
-    startTransition(() => { setStats(buildStats(year)); });
+    let cancelled = false;
+    startTransition(() => {
+      setLoading(true);
+      setStep(0);
+    });
+    fetch(`/api/wrapped?year=${year}`)
+      .then((res) => res.json() as Promise<WrappedStats>)
+      .then((data) => {
+        if (cancelled) return;
+        startTransition(() => {
+          setStats(data);
+          setLoading(false);
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        startTransition(() => {
+          setStats(null);
+          setLoading(false);
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [year]);
 
   useEffect(() => {
@@ -271,23 +262,25 @@ export function WrappedClient() {
       const timer = setTimeout(() => setCardsVisible(true), 100);
       return () => clearTimeout(timer);
     }
-    startTransition(() => { setCardsVisible(false); });
+    startTransition(() => {
+      setCardsVisible(false);
+    });
   }, [step]);
 
-  const cards: RevealCard[] = stats ? [
+  const cards: RevealCard[] = stats && stats.hasEnoughData ? [
     {
       id: 'total',
       title: 'Total Signals',
       subtitle: 'Signals Tracked',
       value: stats.totalSignals.toLocaleString(),
-      detail: `That's ${Math.round(stats.totalSignals / 365)} signals every single day`,
+      detail: `${stats.uniquePairs} pairs tracked in ${stats.year}`,
       color: 'emerald',
       icon: <Zap size={32} />,
     },
     {
       id: 'best-pair',
       title: 'Best Pair',
-      subtitle: 'Your Top Performer',
+      subtitle: 'Top Performing Pair',
       value: stats.bestPair,
       detail: `${formatPct(stats.bestPairWinRate)} win rate across ${stats.bestPairCount} signals`,
       color: 'purple',
@@ -295,7 +288,7 @@ export function WrappedClient() {
     },
     {
       id: 'accuracy',
-      title: 'Overall Accuracy',
+      title: 'Signal Win Rate',
       subtitle: 'Win Rate',
       value: formatPct(stats.overallWinRate),
       detail: `${stats.totalWins} wins / ${stats.totalLosses} losses`,
@@ -307,25 +300,28 @@ export function WrappedClient() {
       title: 'Longest Streak',
       subtitle: 'Consecutive Wins',
       value: `${stats.longestStreak}`,
-      detail: `Your best winning streak of the year`,
+      detail: `Longest run of winning signals in ${stats.year}`,
       color: 'cyan',
       icon: <TrendingUp size={32} />,
     },
     {
       id: 'bias',
-      title: 'Trading Bias',
-      subtitle: stats.totalBuy > stats.totalSell ? 'Mostly Bullish' : 'Mostly Bearish',
-      value: stats.totalBuy > stats.totalSell ? `${Math.round((stats.totalBuy / stats.totalSignals) * 100)}% BUY` : `${Math.round((stats.totalSell / stats.totalSignals) * 100)}% SELL`,
+      title: 'Signal Bias',
+      subtitle: stats.totalBuy >= stats.totalSell ? 'Mostly Bullish' : 'Mostly Bearish',
+      value:
+        stats.totalBuy >= stats.totalSell
+          ? `${Math.round((stats.totalBuy / stats.totalSignals) * 100)}% BUY`
+          : `${Math.round((stats.totalSell / stats.totalSignals) * 100)}% SELL`,
       detail: `${stats.totalBuy} buys vs ${stats.totalSell} sells`,
-      color: stats.totalBuy > stats.totalSell ? 'emerald' : 'rose',
+      color: stats.totalBuy >= stats.totalSell ? 'emerald' : 'rose',
       icon: <BarChart3 size={32} />,
     },
     {
       id: 'timeframe',
-      title: 'Favorite Timeframe',
+      title: 'Most Active Timeframe',
       subtitle: 'Most Used',
       value: stats.topTimeframe,
-      detail: `You checked signals most around ${stats.favoriteHour}:00`,
+      detail: `Most signals fired around ${stats.busiestHour}:00 UTC`,
       color: 'purple',
       icon: <Calendar size={32} />,
     },
@@ -335,7 +331,7 @@ export function WrappedClient() {
 
   const next = useCallback(() => {
     setCardsVisible(false);
-    setTimeout(() => setStep(s => Math.min(s + 1, totalSteps - 1)), 200);
+    setTimeout(() => setStep((s) => Math.min(s + 1, totalSteps - 1)), 200);
   }, [totalSteps]);
 
   const restart = useCallback(() => {
@@ -343,11 +339,12 @@ export function WrappedClient() {
     setCardsVisible(false);
   }, []);
 
-  const shareText = stats
-    ? `My ${stats.year} TradeClaw Wrapped 🎁\n\n📊 ${stats.totalSignals} signals tracked\n🏆 Best pair: ${stats.bestPair} (${formatPct(stats.bestPairWinRate)})\n🎯 Overall accuracy: ${formatPct(stats.overallWinRate)}\n🔥 Longest streak: ${stats.longestStreak} wins\n\nGet your trading wrapped → tradeclaw.win/wrapped`
+  const shareText = stats && stats.hasEnoughData
+    ? `TradeClaw ${stats.year} Wrapped 🎁\n\n📊 ${stats.totalSignals} signals tracked\n🏆 Best pair: ${stats.bestPair} (${formatPct(stats.bestPairWinRate)})\n🎯 Signal win rate: ${formatPct(stats.overallWinRate)}\n🔥 Longest streak: ${stats.longestStreak} wins\n\nSee TradeClaw's signal year → tradeclaw.win/wrapped`
     : '';
 
   const handleShare = useCallback(() => {
+    if (!shareText) return;
     if (navigator.share) {
       navigator.share({ title: `TradeClaw Wrapped ${year}`, text: shareText, url: 'https://tradeclaw.win/wrapped' });
     } else {
@@ -355,36 +352,48 @@ export function WrappedClient() {
     }
   }, [shareText, year]);
 
-  if (!stats) return null;
+  // ── Loading ──────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--background)' }}>
+        <div className="w-8 h-8 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
 
-  return (
-    <div
-      ref={containerRef}
-      className="min-h-screen flex flex-col"
-      style={{ background: 'var(--background)' }}
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 md:px-8 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
-        <Link href="/" className="text-sm font-medium flex items-center gap-1.5" style={{ color: 'var(--foreground)' }}>
-          <Sparkles size={16} className="text-emerald-500" />
-          TradeClaw
-        </Link>
-        <div className="flex items-center gap-3">
-          <select
-            value={year}
-            onChange={(e) => { setYear(Number(e.target.value)); setStep(0); }}
-            className="text-xs rounded-lg px-2 py-1 border"
-            style={{ background: 'var(--bg-card)', borderColor: 'var(--border)', color: 'var(--foreground)' }}
-          >
-            {[currentYear, currentYear - 1, currentYear - 2].map(y => (
-              <option key={y} value={y}>{y}</option>
-            ))}
-          </select>
-          <button onClick={restart} className="text-xs flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
-            <RotateCcw size={12} /> Restart
-          </button>
+  // ── Honest empty state — not enough real resolved history ─────────
+  if (!stats || !stats.hasEnoughData) {
+    return (
+      <div className="min-h-screen flex flex-col" style={{ background: 'var(--background)' }}>
+        <WrappedHeader year={year} currentYear={currentYear} onYear={setYear} onRestart={restart} />
+        <div className="flex-1 flex items-center justify-center px-4 py-16">
+          <div className="max-w-md w-full text-center space-y-5">
+            <div
+              className="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-full"
+              style={{ background: 'var(--accent-muted)', color: '#10b981' }}
+            >
+              <Sparkles size={14} /> {year} Wrapped
+            </div>
+            <h1 className="text-2xl md:text-3xl font-bold">Not enough signal history yet</h1>
+            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+              TradeClaw Wrapped is built only from real resolved signal outcomes — no estimates, no
+              filler.{' '}
+              <span style={{ color: 'var(--foreground)' }}>{stats?.totalSignals ?? 0}</span> signals
+              have resolved for {year} so far. Check back as more outcomes settle, or explore the live{' '}
+              <Link href="/accuracy" className="text-emerald-500 hover:text-emerald-400">
+                accuracy data
+              </Link>
+              .
+            </p>
+          </div>
         </div>
       </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="min-h-screen flex flex-col" style={{ background: 'var(--background)' }}>
+      <WrappedHeader year={year} currentYear={currentYear} onYear={setYear} onRestart={restart} />
 
       {/* Progress bar */}
       <div className="h-1 w-full" style={{ background: 'var(--border)' }}>
@@ -400,7 +409,6 @@ export function WrappedClient() {
       {/* Content */}
       <div className="flex-1 flex items-center justify-center px-4 py-8 md:py-16">
         <div className="max-w-lg w-full">
-
           {/* Step 0: Intro */}
           {step === 0 && (
             <div className="text-center space-y-6">
@@ -408,7 +416,7 @@ export function WrappedClient() {
                 className="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-full"
                 style={{ background: 'var(--accent-muted)', color: '#10b981' }}
               >
-                <Sparkles size={14} /> Your Year in Trading
+                <Sparkles size={14} /> The Signal Year in Review
               </div>
               <h1 className="text-4xl md:text-6xl font-bold">
                 <span className="bg-clip-text text-transparent" style={{ backgroundImage: 'linear-gradient(135deg, #10b981, #a855f7)' }}>
@@ -416,17 +424,18 @@ export function WrappedClient() {
                 </span>
               </h1>
               <p className="text-lg" style={{ color: 'var(--text-secondary)' }}>
-                Your trading year in review. See your signals, wins, streaks, and patterns — all in one beautiful summary.
+                TradeClaw&apos;s signal year in review. Every tracked signal, win rate, streak, and
+                pattern — from real resolved outcomes.
               </p>
               <button
                 onClick={next}
                 className="inline-flex items-center gap-2 px-8 py-3 rounded-xl text-sm font-medium text-white transition-all hover:scale-105"
                 style={{ background: 'linear-gradient(135deg, #10b981, #059669)' }}
               >
-                Reveal My Stats <ArrowRight size={16} />
+                Reveal the Stats <ArrowRight size={16} />
               </button>
               <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                Based on your signal history + localStorage data
+                Based on TradeClaw&apos;s real resolved signal history
               </p>
             </div>
           )}
@@ -434,20 +443,12 @@ export function WrappedClient() {
           {/* Steps 1–6: Individual cards */}
           {step >= 1 && step <= cards.length && (
             <div className="space-y-6">
-              <AnimatedRevealCard
-                card={cards[step - 1]}
-                index={0}
-                isVisible={cardsVisible}
-              />
+              <AnimatedRevealCard card={cards[step - 1]} index={0} isVisible={cardsVisible} />
               <div className="flex justify-center">
                 <button
                   onClick={next}
                   className="inline-flex items-center gap-2 px-6 py-2.5 rounded-xl text-sm font-medium transition-all hover:scale-105"
-                  style={{
-                    background: 'var(--accent-muted)',
-                    color: '#10b981',
-                    border: '1px solid rgba(16,185,129,0.2)',
-                  }}
+                  style={{ background: 'var(--accent-muted)', color: '#10b981', border: '1px solid rgba(16,185,129,0.2)' }}
                 >
                   {step < cards.length ? 'Next' : 'See Summary'} <ChevronRight size={16} />
                 </button>
@@ -472,7 +473,7 @@ export function WrappedClient() {
             <div className="space-y-8">
               <div className="text-center space-y-2">
                 <h2 className="text-2xl md:text-3xl font-bold">
-                  Your <span className="text-emerald-500">{year}</span> Summary
+                  TradeClaw <span className="text-emerald-500">{year}</span> Summary
                 </h2>
                 <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
                   {stats.uniquePairs} pairs tracked • {stats.totalSignals.toLocaleString()} signals
@@ -536,11 +537,7 @@ export function WrappedClient() {
                 <Link
                   href="/accuracy"
                   className="flex-1 inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium transition-all hover:scale-105"
-                  style={{
-                    background: 'var(--accent-muted)',
-                    color: '#10b981',
-                    border: '1px solid rgba(16,185,129,0.2)',
-                  }}
+                  style={{ background: 'var(--accent-muted)', color: '#10b981', border: '1px solid rgba(16,185,129,0.2)' }}
                 >
                   <Eye size={16} /> View Accuracy
                 </Link>

--- a/apps/web/app/wrapped/page.tsx
+++ b/apps/web/app/wrapped/page.tsx
@@ -13,13 +13,13 @@ const WrappedClient = dynamic(
 );
 
 export const metadata: Metadata = {
-  title: 'Wrapped — Your Trading Year in Review | TradeClaw',
+  title: "Wrapped — TradeClaw's Signal Year in Review | TradeClaw",
   description:
-    'See your trading year in review — total signals, best pair, accuracy trend, win streaks, and more. Like Spotify Wrapped, but for trading.',
+    "TradeClaw's signal year in review — total signals tracked, best pair, accuracy trend, and win streaks, all from real resolved outcomes. Like Spotify Wrapped, but for trading signals.",
   openGraph: {
-    title: 'TradeClaw Wrapped — Your Trading Year in Review',
+    title: "TradeClaw Wrapped — The Signal Year in Review",
     description:
-      'Total signals, best pair, accuracy trend, win streaks. Your year in trading, beautifully summarized.',
+      'Total signals tracked, best pair, accuracy trend, win streaks — from real resolved signal history.',
     type: 'website',
   },
 };

--- a/apps/web/lib/__tests__/weekly-pulse.test.ts
+++ b/apps/web/lib/__tests__/weekly-pulse.test.ts
@@ -1,0 +1,119 @@
+import { computeWeeklyPulse, WEEKLY_PULSE_MIN } from '../weekly-pulse';
+import type { SignalHistoryRecord } from '../signal-history';
+
+// Fixed "now": 2026-06-17 is a Wednesday. Monday of that week = 2026-06-15.
+const NOW = new Date('2026-06-17T12:00:00.000Z');
+const MONDAY = Date.UTC(2026, 5, 15);
+const DAY = 86_400_000;
+
+function mk(
+  id: string,
+  opts: {
+    pair?: string;
+    hit?: boolean;
+    pnlPct?: number;
+    target?: 'TP1' | 'SL' | 'expired';
+    gateBlocked?: boolean;
+    isSimulated?: boolean;
+    confidence?: number;
+    /** Whole-day offset from Monday 00:00 UTC of the test week. */
+    dayOffset?: number;
+  },
+): SignalHistoryRecord {
+  // Noon of the target day so it sits unambiguously inside the UTC week.
+  const timestamp = MONDAY + (opts.dayOffset ?? 0) * DAY + DAY / 2;
+  return {
+    id,
+    pair: opts.pair ?? 'BTCUSD',
+    timeframe: 'H1',
+    direction: 'BUY',
+    confidence: opts.confidence ?? 80,
+    entryPrice: 50000,
+    timestamp,
+    isSimulated: opts.isSimulated ?? false,
+    gateBlocked: opts.gateBlocked ?? false,
+    outcomes: {
+      '4h': null,
+      '24h': {
+        price: 51000,
+        pnlPct: opts.pnlPct ?? (opts.hit ? 2 : -1),
+        hit: opts.hit ?? false,
+        target: opts.target ?? (opts.hit ? 'TP1' : 'SL'),
+      },
+    },
+  };
+}
+
+describe('computeWeeklyPulse — real-data weekly pulse (replaces mulberry32 PRNG)', () => {
+  it('aggregates real resolved signals and flags enough data at the threshold', () => {
+    const recs = [
+      mk('1', { hit: true, dayOffset: 0 }),
+      mk('2', { hit: true, dayOffset: 1 }),
+      mk('3', { hit: false, dayOffset: 2 }),
+      mk('4', { hit: true, dayOffset: 3 }),
+      mk('5', { hit: false, dayOffset: 4 }),
+    ];
+    const p = computeWeeklyPulse(recs, NOW);
+    expect(p.totalSignals).toBe(5);
+    expect(p.hasEnoughData).toBe(true);
+    expect(p.winRate).toBe(60); // 3 of 5
+    expect(p.dailyBreakdown).toEqual([1, 1, 1, 1, 1, 0, 0]);
+    expect(p.weekOf).toBe('2026-06-15');
+  });
+
+  it('excludes simulated, gate-blocked, and auto-expired rows (canonical denominator)', () => {
+    const recs = [
+      mk('w', { hit: true, dayOffset: 0 }),
+      mk('l', { hit: false, dayOffset: 0 }),
+      mk('exp', { hit: false, pnlPct: 0, target: 'expired', dayOffset: 0 }),
+      mk('blk', { hit: true, gateBlocked: true, dayOffset: 0 }),
+      mk('sim', { hit: true, isSimulated: true, dayOffset: 0 }),
+    ];
+    const p = computeWeeklyPulse(recs, NOW);
+    expect(p.totalSignals).toBe(2);
+    expect(p.winRate).toBe(50);
+  });
+
+  it('ignores signals outside the current week', () => {
+    const recs = [
+      mk('in', { hit: true, dayOffset: 0 }),
+      mk('lastWeek', { hit: true, dayOffset: -1 }),
+      mk('nextWeek', { hit: true, dayOffset: 7 }),
+    ];
+    const p = computeWeeklyPulse(recs, NOW);
+    expect(p.totalSignals).toBe(1);
+  });
+
+  it('picks the top asset by hit rate, breaking ties on sample size', () => {
+    const recs = [
+      mk('b1', { pair: 'BTCUSD', hit: true, dayOffset: 0 }),
+      mk('b2', { pair: 'BTCUSD', hit: true, dayOffset: 0 }),
+      mk('e1', { pair: 'ETHUSD', hit: false, dayOffset: 0 }),
+      mk('e2', { pair: 'ETHUSD', hit: false, dayOffset: 0 }),
+      mk('x1', { pair: 'XAUUSD', hit: true, dayOffset: 0 }),
+    ];
+    const p = computeWeeklyPulse(recs, NOW);
+    expect(p.topAsset).toBe('BTCUSD'); // 2/2 beats XAU 1/1 on volume
+    expect(p.topAccuracy).toBe(100);
+  });
+
+  it('returns an honest empty state below the threshold without dividing by zero', () => {
+    const recs = [mk('1', { hit: true, dayOffset: 0 }), mk('2', { hit: false, dayOffset: 0 })];
+    const p = computeWeeklyPulse(recs, NOW);
+    expect(p.totalSignals).toBe(2);
+    expect(p.hasEnoughData).toBe(false);
+  });
+
+  it('zeroes cleanly with no data', () => {
+    const p = computeWeeklyPulse([], NOW);
+    expect(p.totalSignals).toBe(0);
+    expect(p.winRate).toBe(0);
+    expect(p.topAsset).toBe('—');
+    expect(p.dailyBreakdown).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(p.hasEnoughData).toBe(false);
+  });
+
+  it('keeps the threshold aligned with the weekly-digest <5 contract', () => {
+    expect(WEEKLY_PULSE_MIN).toBe(5);
+  });
+});

--- a/apps/web/lib/__tests__/wrapped-stats.test.ts
+++ b/apps/web/lib/__tests__/wrapped-stats.test.ts
@@ -1,0 +1,139 @@
+import { computeWrappedStats, WRAPPED_MIN } from '../wrapped-stats';
+import type { SignalHistoryRecord } from '../signal-history';
+
+function mk(
+  id: string,
+  opts: {
+    pair?: string;
+    hit?: boolean;
+    direction?: 'BUY' | 'SELL';
+    confidence?: number;
+    timeframe?: string;
+    tsMs?: number;
+    pnlPct?: number;
+    target?: 'TP1' | 'SL' | 'expired';
+    gateBlocked?: boolean;
+    isSimulated?: boolean;
+  },
+): SignalHistoryRecord {
+  return {
+    id,
+    pair: opts.pair ?? 'BTCUSD',
+    timeframe: opts.timeframe ?? 'H1',
+    direction: opts.direction ?? 'BUY',
+    confidence: opts.confidence ?? 70,
+    entryPrice: 100,
+    timestamp: opts.tsMs ?? Date.UTC(2026, 0, 1, 12),
+    isSimulated: opts.isSimulated ?? false,
+    gateBlocked: opts.gateBlocked ?? false,
+    outcomes: {
+      '4h': null,
+      '24h': {
+        price: 101,
+        pnlPct: opts.pnlPct ?? (opts.hit ? 1 : -1),
+        hit: opts.hit ?? false,
+        target: opts.target ?? (opts.hit ? 'TP1' : 'SL'),
+      },
+    },
+  };
+}
+
+/** N records for one pair in a given month, hit pattern from `hits`. */
+function series(
+  pair: string,
+  month: number,
+  hits: boolean[],
+  opts: { direction?: 'BUY' | 'SELL'; timeframe?: string; hour?: number } = {},
+): SignalHistoryRecord[] {
+  return hits.map((h, i) =>
+    mk(`${pair}-${month}-${i}`, {
+      pair,
+      hit: h,
+      direction: opts.direction,
+      timeframe: opts.timeframe,
+      tsMs: Date.UTC(2026, month, 1 + i, opts.hour ?? 12),
+    }),
+  );
+}
+
+describe('computeWrappedStats — real platform year-in-review (replaces seeded LCG)', () => {
+  it('computes real aggregates over a full year of resolved signals', () => {
+    const recs = [
+      // BTC: 6 in January at hour 9, 5 wins / 1 loss
+      ...series('BTCUSD', 0, [true, true, true, false, true, true], { hour: 9 }),
+      // XAU: 12 in January at hour 10, all wins
+      ...series('XAUUSD', 0, [true, true, true, true, true, true, true, true, true, true, true, true], { hour: 10 }),
+      // ETH: 3 in June at hour 14, all losses, SELL
+      ...series('ETHUSD', 5, [false, false, false], { hour: 14, direction: 'SELL' }),
+    ];
+    const w = computeWrappedStats(recs, 2026);
+
+    expect(w.hasEnoughData).toBe(true);
+    expect(w.totalSignals).toBe(21);
+    expect(w.totalWins).toBe(17);
+    expect(w.totalLosses).toBe(4);
+    expect(w.overallWinRate).toBeCloseTo(17 / 21, 3);
+    expect(w.uniquePairs).toBe(3);
+
+    // Best / worst pair by win rate (both clear PAIR_MIN).
+    expect(w.bestPair).toBe('XAUUSD');
+    expect(w.bestPairWinRate).toBeCloseTo(1, 3);
+    expect(w.bestPairCount).toBe(12);
+    expect(w.worstPair).toBe('ETHUSD');
+    expect(w.worstPairWinRate).toBeCloseTo(0, 3);
+
+    // Direction split.
+    expect(w.totalBuy).toBe(18); // BTC + XAU
+    expect(w.totalSell).toBe(3); // ETH
+
+    // Monthly activity.
+    expect(w.monthlyActivity[0]).toBe(18); // Jan: BTC6 + XAU12
+    expect(w.monthlyActivity[5]).toBe(3); // Jun: ETH3
+    expect(w.accuracyTrend[5]).toBe(0); // all ETH losses
+    expect(w.accuracyTrend[0]).toBeCloseTo(17 / 18, 3);
+
+    // Busiest hour = 10 (XAU's 12 beat hour 9's 6 and hour 14's 3).
+    expect(w.busiestHour).toBe(10);
+
+    // Longest consecutive winning streak, chronological across all pairs.
+    // Sorted by ts: only BTC d4 (hour 9) is a loss; everything after is a win.
+    expect(w.longestStreak).toBe(11);
+  });
+
+  it('excludes simulated, gate-blocked, and auto-expired rows and gates below the threshold', () => {
+    const recs = [
+      mk('w', { hit: true }),
+      mk('l', { hit: false }),
+      mk('exp', { hit: false, pnlPct: 0, target: 'expired' }),
+      mk('blk', { hit: true, gateBlocked: true }),
+      mk('sim', { hit: true, isSimulated: true }),
+    ];
+    const w = computeWrappedStats(recs, 2026);
+    expect(w.totalSignals).toBe(2); // only w + l count
+    expect(w.hasEnoughData).toBe(false);
+  });
+
+  it('filters out signals from other years', () => {
+    const inYear = series('BTCUSD', 0, Array.from({ length: 20 }, () => true), { hour: 9 });
+    const recs = [
+      ...inYear,
+      mk('lastYear', { hit: true, tsMs: Date.UTC(2025, 11, 31, 12) }),
+      mk('nextYear', { hit: true, tsMs: Date.UTC(2027, 0, 1, 12) }),
+    ];
+    const w = computeWrappedStats(recs, 2026);
+    expect(w.totalSignals).toBe(20);
+  });
+
+  it('returns an honest empty state with no data', () => {
+    const w = computeWrappedStats([], 2026);
+    expect(w.hasEnoughData).toBe(false);
+    expect(w.totalSignals).toBe(0);
+    expect(w.bestPair).toBe('—');
+    expect(w.monthlyActivity).toHaveLength(12);
+    expect(w.accuracyTrend).toHaveLength(12);
+  });
+
+  it('exposes the threshold constant', () => {
+    expect(WRAPPED_MIN).toBe(20);
+  });
+});

--- a/apps/web/lib/weekly-pulse.ts
+++ b/apps/web/lib/weekly-pulse.ts
@@ -1,0 +1,120 @@
+import { isCountedResolved, readHistoryAsync, type SignalHistoryRecord } from './signal-history';
+
+/**
+ * Minimum resolved signals in the week before the public Weekly Pulse shows
+ * numbers instead of an honest "not enough data yet" state. Mirrors the <5
+ * guard in weekly-digest.ts so the two weekly surfaces behave consistently.
+ */
+export const WEEKLY_PULSE_MIN = 5;
+
+export interface WeeklyPulse {
+  /** Monday 00:00 UTC of the reported week, YYYY-MM-DD. */
+  weekOf: string;
+  isoWeek: number;
+  /**
+   * False until WEEKLY_PULSE_MIN resolved signals exist; the UI shows an honest
+   * empty state instead of small-sample numbers presented as a track record.
+   */
+  hasEnoughData: boolean;
+  /** Resolved, counted signals this week (the win-rate denominator). */
+  totalSignals: number;
+  /** wins / totalSignals as a whole percent. 0 when none. */
+  winRate: number;
+  /** Pair with the highest 24h hit rate this week, or '—' when none. */
+  topAsset: string;
+  /** topAsset's hit rate as a whole percent. */
+  topAccuracy: number;
+  /** Mean confidence of the week's resolved signals, rounded. */
+  avgConfidence: number;
+  /** Resolved-signal counts Mon..Sun (UTC). */
+  dailyBreakdown: [number, number, number, number, number, number, number];
+  generatedAt: string;
+}
+
+export function getISOWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+export function getUtcWeekBounds(now: Date): { weekStart: number; weekEnd: number; monday: Date } {
+  const day = now.getUTCDay(); // 0=Sun
+  const mondayOffset = day === 0 ? 6 : day - 1;
+  const monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - mondayOffset));
+  const weekStart = monday.getTime();
+  const weekEnd = weekStart + 7 * 86400000 - 1;
+  return { weekStart, weekEnd, monday };
+}
+
+/**
+ * Pure, real-data weekly pulse used by /api/report and the public Weekly Pulse
+ * page. Computed from signal_history through the canonical isCountedResolved
+ * predicate (excludes simulated, gate-blocked, and auto-expired rows) so the
+ * public numbers match /track-record. Replaces a mulberry32 PRNG that
+ * fabricated win rate / signal count / top asset unconditionally.
+ */
+export function computeWeeklyPulse(records: SignalHistoryRecord[], now: Date): WeeklyPulse {
+  const { weekStart, weekEnd, monday } = getUtcWeekBounds(now);
+  const week = records.filter(
+    r => r.timestamp >= weekStart && r.timestamp <= weekEnd && isCountedResolved(r),
+  );
+
+  const dailyBreakdown: [number, number, number, number, number, number, number] = [0, 0, 0, 0, 0, 0, 0];
+  const byPair = new Map<string, { hits: number; total: number }>();
+  let wins = 0;
+  let confSum = 0;
+  for (const r of week) {
+    const hit = r.outcomes['24h']!.hit;
+    if (hit) wins++;
+    confSum += r.confidence;
+    const d = new Date(r.timestamp);
+    const idx = d.getUTCDay() === 0 ? 6 : d.getUTCDay() - 1; // Mon=0..Sun=6
+    dailyBreakdown[idx]++;
+    const s = byPair.get(r.pair) ?? { hits: 0, total: 0 };
+    s.total++;
+    if (hit) s.hits++;
+    byPair.set(r.pair, s);
+  }
+
+  const total = week.length;
+  const winRate = total > 0 ? Math.round((wins / total) * 100) : 0;
+  const avgConfidence = total > 0 ? Math.round(confSum / total) : 0;
+
+  // Top asset = highest 24h hit rate; ties broken by larger sample so a lone
+  // 1-for-1 pair can't outrank a pair that won repeatedly.
+  let topAsset = '—';
+  let topAccuracy = 0;
+  let bestRate = -1;
+  let bestTotal = -1;
+  for (const [pair, s] of byPair) {
+    const rate = s.total > 0 ? (s.hits / s.total) * 100 : 0;
+    if (rate > bestRate || (rate === bestRate && s.total > bestTotal)) {
+      bestRate = rate;
+      bestTotal = s.total;
+      topAsset = pair;
+      topAccuracy = Math.round(rate);
+    }
+  }
+
+  return {
+    weekOf: monday.toISOString().slice(0, 10),
+    isoWeek: getISOWeek(now),
+    hasEnoughData: total >= WEEKLY_PULSE_MIN,
+    totalSignals: total,
+    winRate,
+    topAsset,
+    topAccuracy,
+    avgConfidence,
+    dailyBreakdown,
+    generatedAt: now.toISOString(),
+  };
+}
+
+/** Async wrapper: reads this week's signal history and computes the pulse. */
+export async function getWeeklyPulse(now: Date = new Date()): Promise<WeeklyPulse> {
+  const { weekStart } = getUtcWeekBounds(now);
+  const records = await readHistoryAsync({ sinceMs: weekStart });
+  return computeWeeklyPulse(records, now);
+}

--- a/apps/web/lib/wrapped-stats.ts
+++ b/apps/web/lib/wrapped-stats.ts
@@ -1,0 +1,216 @@
+import { isCountedResolved, readHistoryAsync, type SignalHistoryRecord } from './signal-history';
+
+/**
+ * Minimum resolved signals in the year before /wrapped shows numbers instead of
+ * an honest "not enough tracked history yet" state.
+ */
+export const WRAPPED_MIN = 20;
+
+/**
+ * A pair needs at least this many resolved signals to be eligible as the
+ * best/worst performer, so a lone 1-for-1 pair can't claim "100% best pair".
+ */
+const PAIR_MIN = 3;
+
+export interface WrappedStats {
+  year: number;
+  hasEnoughData: boolean;
+  /** Resolved, counted signals tracked in the year. */
+  totalSignals: number;
+  bestPair: string;
+  bestPairCount: number;
+  /** 0..1 */
+  bestPairWinRate: number;
+  worstPair: string;
+  /** 0..1 */
+  worstPairWinRate: number;
+  totalBuy: number;
+  totalSell: number;
+  /** 0..100 */
+  avgConfidence: number;
+  topTimeframe: string;
+  totalWins: number;
+  totalLosses: number;
+  /** 0..1 */
+  overallWinRate: number;
+  /** Longest run of consecutive winning signals, chronological. */
+  longestStreak: number;
+  /** length 12, resolved-signal counts Jan..Dec (UTC). */
+  monthlyActivity: number[];
+  /** length 12, monthly win rate 0..1 (0 when no data that month). */
+  accuracyTrend: number[];
+  /** 0..23 UTC hour with the most signals. */
+  busiestHour: number;
+  uniquePairs: number;
+}
+
+function emptyWrapped(year: number, totalSignals: number): WrappedStats {
+  return {
+    year,
+    hasEnoughData: false,
+    totalSignals,
+    bestPair: '—',
+    bestPairCount: 0,
+    bestPairWinRate: 0,
+    worstPair: '—',
+    worstPairWinRate: 0,
+    totalBuy: 0,
+    totalSell: 0,
+    avgConfidence: 0,
+    topTimeframe: '—',
+    totalWins: 0,
+    totalLosses: 0,
+    overallWinRate: 0,
+    longestStreak: 0,
+    monthlyActivity: Array.from({ length: 12 }, () => 0),
+    accuracyTrend: Array.from({ length: 12 }, () => 0),
+    busiestHour: 0,
+    uniquePairs: 0,
+  };
+}
+
+/**
+ * Pure, real-data "year in review" for TradeClaw's tracked signals. Computed
+ * from signal_history through isCountedResolved (excludes simulated,
+ * gate-blocked, and auto-expired rows). This is a PLATFORM recap — the signals
+ * TradeClaw tracked that year — NOT a per-user trading record (the product has
+ * no per-user trade ledger). Replaces a seeded LCG that fabricated every stat.
+ */
+export function computeWrappedStats(records: SignalHistoryRecord[], year: number): WrappedStats {
+  const yearStart = Date.UTC(year, 0, 1);
+  const yearEnd = Date.UTC(year + 1, 0, 1) - 1;
+  const recs = records
+    .filter(r => r.timestamp >= yearStart && r.timestamp <= yearEnd && isCountedResolved(r))
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  if (recs.length < WRAPPED_MIN) {
+    return emptyWrapped(year, recs.length);
+  }
+
+  let totalWins = 0;
+  let totalBuy = 0;
+  let confSum = 0;
+  let longestStreak = 0;
+  let currentStreak = 0;
+  const byPair = new Map<string, { hits: number; total: number }>();
+  const byTimeframe = new Map<string, number>();
+  const monthlyActivity = Array.from({ length: 12 }, () => 0);
+  const monthlyWins = Array.from({ length: 12 }, () => 0);
+  const hourCounts = Array.from({ length: 24 }, () => 0);
+
+  for (const r of recs) {
+    const hit = r.outcomes['24h']!.hit;
+    if (hit) {
+      totalWins++;
+      currentStreak++;
+      if (currentStreak > longestStreak) longestStreak = currentStreak;
+    } else {
+      currentStreak = 0;
+    }
+    if (r.direction === 'BUY') totalBuy++;
+    confSum += r.confidence;
+
+    const s = byPair.get(r.pair) ?? { hits: 0, total: 0 };
+    s.total++;
+    if (hit) s.hits++;
+    byPair.set(r.pair, s);
+
+    byTimeframe.set(r.timeframe, (byTimeframe.get(r.timeframe) ?? 0) + 1);
+
+    const d = new Date(r.timestamp);
+    const month = d.getUTCMonth();
+    monthlyActivity[month]++;
+    if (hit) monthlyWins[month]++;
+    hourCounts[d.getUTCHours()]++;
+  }
+
+  const total = recs.length;
+  const totalLosses = total - totalWins;
+
+  // Best / worst pair by win rate among pairs with a meaningful sample.
+  let bestPair = '—';
+  let worstPair = '—';
+  let bestRate = -1;
+  let worstRate = Infinity;
+  let bestCount = 0;
+  for (const [pair, s] of byPair) {
+    if (s.total < PAIR_MIN) continue;
+    const rate = s.hits / s.total;
+    if (rate > bestRate || (rate === bestRate && s.total > bestCount)) {
+      bestRate = rate;
+      bestPair = pair;
+      bestCount = s.total;
+    }
+    if (rate < worstRate) {
+      worstRate = rate;
+      worstPair = pair;
+    }
+  }
+  // No pair cleared PAIR_MIN — fall back to the most-traded pair.
+  if (bestPair === '—') {
+    let topCount = -1;
+    for (const [pair, s] of byPair) {
+      if (s.total > topCount) {
+        topCount = s.total;
+        bestPair = pair;
+        worstPair = pair;
+        bestCount = s.total;
+        bestRate = s.hits / s.total;
+        worstRate = bestRate;
+      }
+    }
+  }
+
+  let topTimeframe = '—';
+  let topTfCount = -1;
+  for (const [tf, c] of byTimeframe) {
+    if (c > topTfCount) {
+      topTfCount = c;
+      topTimeframe = tf;
+    }
+  }
+
+  let busiestHour = 0;
+  let busiestCount = -1;
+  for (let h = 0; h < 24; h++) {
+    if (hourCounts[h] > busiestCount) {
+      busiestCount = hourCounts[h];
+      busiestHour = h;
+    }
+  }
+
+  const accuracyTrend = monthlyActivity.map((c, i) => (c > 0 ? monthlyWins[i] / c : 0));
+
+  return {
+    year,
+    hasEnoughData: true,
+    totalSignals: total,
+    bestPair,
+    bestPairCount: bestCount,
+    bestPairWinRate: +bestRate.toFixed(4),
+    worstPair,
+    worstPairWinRate: worstRate === Infinity ? 0 : +worstRate.toFixed(4),
+    totalBuy,
+    totalSell: total - totalBuy,
+    avgConfidence: Math.round(confSum / total),
+    topTimeframe,
+    totalWins,
+    totalLosses,
+    overallWinRate: +(totalWins / total).toFixed(4),
+    longestStreak,
+    monthlyActivity,
+    accuracyTrend,
+    busiestHour,
+    uniquePairs: byPair.size,
+  };
+}
+
+/**
+ * Async wrapper: reads signal history and computes the year recap. Scopes the
+ * DB read to the requested year onward (the current year — the common case —
+ * resolves exactly); computeWrappedStats still bounds to [year, year + 1).
+ */
+export async function getWrappedStats(year: number): Promise<WrappedStats> {
+  const records = await readHistoryAsync({ sinceMs: Date.UTC(year, 0, 1) });
+  return computeWrappedStats(records, year);
+}

--- a/docs/plans/2026-06-15-growth-honesty-backlog.md
+++ b/docs/plans/2026-06-15-growth-honesty-backlog.md
@@ -1,0 +1,79 @@
+# Growth + Honesty Backlog — verified plan (2026-06-15)
+
+Source: a 10-item "leverage ÷ effort" recommendation list. Every claim was verified
+against live code by a 10-agent read-only workflow (run `wf_528f5f82-079`, 2026-06-15)
+before this plan was written. Verdicts below are grounded in `file:line` evidence, not
+the audit's assertions. Several items differ materially from how the audit framed them.
+
+## Verification summary
+
+| # | Item | Verified verdict | New dep | Scope | Gate |
+|---|------|------------------|---------|-------|------|
+| 1 | PRNG-fabricated stats (/wrapped + /api/report + weekly-report.yml) | CONFIRMED (worse) | none | L | caution |
+| 2 | Referral `?ref` → checkout metadata | PARTIAL — only inbound capture missing | none | S–M | caution |
+| 3 | Server-side PostHog (signed_up / conversion / churn / identify) | gap CONFIRMED | **posthog-node** | M | needs-approval |
+| 4 | Navbar CTA (a) + magic-link checkout intent (b) | (a) debatable, (b) CONFIRMED | none | M | caution |
+| 5 | Free-alert dispatch off the 403'd GH-Actions path | PARTIAL — only the free alert is on it | none | M | needs-approval |
+| 6 | Real web-push subscribe + per-signal fan-out | PARTIAL — API real, dispatch dead, store ephemeral | none | L | caution |
+| 7 | Email subs + waitlist → Postgres + lifecycle emails | CONFIRMED — JSON files wiped each deploy | none | L | needs-approval |
+| 8 | Cancellation save flow + win-back | CONFIRMED — straight to Stripe, $0 retained | none | M | needs-approval |
+| 9 | X auto-posting of daily/weekly card | MISLEADING — already automated via Claude Chrome | none | S | caution |
+| 10 | A/B hero + feature flags + activation event | PARTIAL — vanity test, no variant attribution | none (rides #3) | M | caution |
+
+Only **#3** requires a new dependency. **#9 must NOT add an X API client** — that
+contradicts the deliberate Claude-Chrome posting architecture.
+
+## Per-item detail
+
+### #1 — Kill PRNG-fabricated stats  (CONFIRMED, brand + legal critical) — DONE in this PR
+- Evidence: [WrappedClient.tsx:64-129](../../apps/web/app/wrapped/WrappedClient.tsx) (LCG, no real data loaded);
+  [api/report/route.ts:5-75](../../apps/web/app/api/report/route.ts) (mulberry32, never queries DB);
+  [.github/workflows/weekly-report.yml:41-62](../../.github/workflows/weekly-report.yml) (same PRNG → public GitHub Discussions weekly).
+- Honest pattern already exists: [weekly-digest.ts](../../apps/web/lib/weekly-digest.ts) returns empty under 5 real signals; `/api/demo/signals` is correctly labelled synthetic.
+- Fix shipped: new pure aggregators [weekly-pulse.ts](../../apps/web/lib/weekly-pulse.ts) + [wrapped-stats.ts](../../apps/web/lib/wrapped-stats.ts) compute from `signal_history` via `isCountedResolved`, with an `hasEnoughData` gate → honest empty state. `/api/report` + new `/api/wrapped` serve them; WrappedClient/ReportClient consume real data; `/wrapped` reframed platform-wide (no per-user trade ledger exists). `weekly-report.yml` posts only real GitHub metrics + links to the live report.
+
+### #2 — Referral inbound capture  (PARTIAL)
+- Built already: referral tables ([migrations 042–044](../../apps/web/migrations)), `/api/referrals` link generation, checkout accepts `referrerId` → Stripe metadata, webhook records it.
+- Missing: [PricingCards.tsx](../../apps/web/app/pricing/PricingCards.tsx) never reads `?ref` nor forwards `referrerId`.
+- Fix: read `?ref` (useSearchParams; optional cookie), forward `referrerId` to the checkout POST. Add a server-side guard: reject self-referral and validate the code exists.
+
+### #3 — Server-side PostHog  (gap CONFIRMED — NEEDS DEP APPROVAL: `posthog-node`)
+- Today: client-only `posthog-js`; the server `trackEvent('trial_started')` is a no-op; the Stripe webhook has zero instrumentation; no `identify()` anywhere.
+- Fix: add `posthog-node`, server client, `identify()` on user create, instrument webhook (conversion / churn / renewal). Wrap every call in try/catch so analytics never blocks the webhook.
+
+### #4 — Navbar CTA (a) + magic-link checkout intent (b)
+- (a) Debatable: public navbar gives GitHub-star prominence; low confidence it's a bug vs product choice → optional copy tweak.
+- (b) CONFIRMED leak: [magic-link/verify/route.ts](../../apps/web/app/api/auth/magic-link/verify/route.ts) always redirects to `/dashboard`; OAuth preserves `priceId/tier/interval`. Fix: thread checkout intent through magic-link start→verify.
+
+### #5 — Free-alert dispatch resilience  (PARTIAL — NEEDS-APPROVAL + operator)
+- Only the GH-Actions free Telegram alert dies on the 403; Pro broadcast + per-user rules run in-app. Code fix = move free dispatch into the in-app cron (mirror the Pro broadcast); real 403 root cause is a Cloudflare WAF rule for `/api/cron/*` (operator-side).
+
+### #6 — Web-push fan-out  (PARTIAL)
+- Real subscribe (WelcomeClient PushManager + VAPID) but `sendPushToAll()` is dead code; cron sends Expo only; NotificationsClient button is fake; store is ephemeral JSON (same root cause as #7). Fix: wire real per-signal web-push fan-out; move store to Postgres; document VAPID env.
+
+### #7 — Email/waitlist → Postgres + lifecycle  (CONFIRMED — NEEDS-APPROVAL: migration)
+- `/data/*.json` via `fs`, wiped every Railway deploy. Only 3 transactional emails. Fix: Postgres tables + migration; welcome / Pro-activation / inactivity emails.
+
+### #8 — Cancellation save flow  (CONFIRMED — NEEDS-APPROVAL: billing)
+- Cancel → Stripe portal → immediate downgrade, no retention. Fix: custom cancel endpoint with reason + pause/downsell/discount; win-back sequence.
+
+### #9 — ref/UTM in auto-posted social URLs  (MISLEADING → small real fix)
+- Posting is automated via a Claude Chrome agent by design (no X API). Real gap: auto-posted URLs carry UTM but no referral code. Inject `ref` (depends on #2) + UTM. Do NOT add an X API client.
+
+### #10 — Real experiment instrumentation  (PARTIAL — rides on #3)
+- Hero A/B assigns via localStorage, tracks impressions/clicks only; no PostHog flag, no variant attribution, no activation event. Fix after #3: variant property on conversion events + define/instrument an activation event.
+
+## Batching & sequencing
+
+- **Batch 1 — no new dep, shippable now**
+  - PR A: #1 PRNG honesty (this PR). PR B: #2 referral capture + #9 ref-in-URL. PR C: #4b magic-link checkout-intent.
+- **Batch 2 — needs `posthog-node` approval (granted 2026-06-15)**
+  - PR D: #3 server-side analytics → PR E: #10 experiment instrumentation.
+- **Batch 3 — needs approval (migration / billing / infra + operator)**
+  - PR F: #7 email→Postgres + lifecycle. PR G: #6 web-push fan-out + store→Postgres. PR H: #8 cancellation save flow. PR I: #5 free-alert resilience (paired with operator WAF).
+
+## Execution discipline
+- One concern per PR; each in an isolated git worktree off `main` (root checkout stays on `main`, integration-target only).
+- Type-check + relevant tests green before each PR. Next.js here has breaking changes vs. training data — read the bundled docs before writing Next code (`apps/web/AGENTS.md`).
+- `packages/agent/dist` is force-tracked; never `git add -A` — stage explicit source paths only.
+- Hard halts: #5/#7/#8 (migration/billing/infra/operator) do not proceed without explicit approval.


### PR DESCRIPTION
## Why

Two public surfaces fabricated trading statistics with a PRNG and presented them as real performance:

- **/wrapped** — a seeded LCG (`seededRandom`/`buildStats`) invented total signals, win rate, best pair, streaks, monthly activity, etc. No real data was ever loaded.
- **/api/report** (the Weekly Pulse, also rendered at `/report`) — `mulberry32` seeded by ISO week invented win rate (60–80%), signal count, top asset, daily breakdown. It never queried the database.
- **`.github/workflows/weekly-report.yml`** — the same PRNG, republished weekly to **public GitHub Discussions**.

On a trading product, fabricated accuracy numbers are a brand and legal exposure. This continues the Phase 6 honesty arc.

## What changed

Real aggregation from `signal_history` through the canonical `isCountedResolved` predicate (excludes simulated / gate-blocked / auto-expired rows), gated by `hasEnoughData` so each surface shows an honest empty state below threshold — mirroring the existing `weekly-digest.ts` `<5` guard.

- **New pure, tested aggregators**: `lib/weekly-pulse.ts` (`computeWeeklyPulse`) and `lib/wrapped-stats.ts` (`computeWrappedStats`).
- **`/api/report`** now serves the real weekly pulse; **new `/api/wrapped`** serves the real year recap (DB read scoped to the requested year).
- **ReportClient** + **WrappedClient** consume real data and render honest empty states (no fabricated numbers, no broken `/signal/—-H1-BUY` links).
- **`/wrapped` reframed platform-wide**: the product has no per-user trade ledger, so "your trading year" was itself a lie. It now reports *TradeClaw's tracked signals* for the year. Removed the localStorage fallback that cached synthetic stats.
- **`weekly-report.yml`** posts only real GitHub metrics (stars/forks/contributors) and links to the live `/report` for signal numbers — no invented stats.

Client components never import the server-only data modules; they fetch via `/api/*`.

## Test plan

- [x] `apps/web` type-check: **0 errors** (after building workspace deps).
- [x] Full `jest` suite green — **1420+ tests**, including **12 new** unit tests for the two aggregators (window/year bounds, `isCountedResolved` exclusions, top-asset tie-break, longest-streak, `hasEnoughData` gate, empty/zero-data).
- [x] `eslint` apps/web: **0 errors**.
- [ ] Manual: visit `/report` and `/wrapped` on prod-like data — confirm numbers reflect real resolved signals and the empty state shows under threshold.

## Notes

- Code-reviewed (no CRITICAL/HIGH). One reviewer MEDIUM addressed (year-scoped DB read in `getWrappedStats`). `/api/wrapped` is intentionally dynamic (reads `?year=`) and uses `Cache-Control` for CDN caching rather than `revalidate`.
- Plan: `docs/plans/2026-06-15-growth-honesty-backlog.md` (Batch 1, item #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)