### PR TITLE
feat(referrals): capture inbound ?ref through to checkout + UTM-tag social posts

### DIFF
--- a/apps/web/app/api/cron/social/daily/route.ts
+++ b/apps/web/app/api/cron/social/daily/route.ts
@@ -26,12 +26,16 @@ export async function GET(req: NextRequest) {
   const pnlStr = `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`;
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://tradeclaw.win';
   const imageUrl = `${baseUrl}/api/og/summary?period=daily&date=${today}`;
+  // UTM-tag the outbound link so social-driven signups are attributable in
+  // analytics. (First-party auto-posts have no individual referrer, so a
+  // user-to-user ref code is not used here — that belongs on user share links.)
+  const trackUrl = `${baseUrl}/track-record?utm_source=x&utm_medium=social&utm_campaign=daily_summary`;
   const copy = [
     `Today on TradeClaw: ${s.total} signals resolved`,
     `${s.wins}W / ${s.losses}L (${winRate}%)`,
     `P/L: ${pnlStr}%`,
     '',
-    `Track live: ${baseUrl}/track-record`,
+    `Track live: ${trackUrl}`,
     '#TradeClaw #Trading #Signals',
   ].join('\n');
 

--- a/apps/web/app/api/cron/social/weekly/route.ts
+++ b/apps/web/app/api/cron/social/weekly/route.ts
@@ -37,7 +37,9 @@ export async function GET(req: NextRequest) {
   if (s.worstSymbol && s.worstSymbol !== s.bestSymbol && s.worstPnlPct !== null) {
     lines.push(`Worst: ${s.worstSymbol} (${s.worstPnlPct >= 0 ? '+' : ''}${s.worstPnlPct.toFixed(2)}%)`);
   }
-  lines.push('', `Full breakdown: ${baseUrl}/track-record`, '#TradeClaw #WeeklyRecap #Trading');
+  // UTM-tag the outbound link for first-party channel attribution (see daily route).
+  const trackUrl = `${baseUrl}/track-record?utm_source=x&utm_medium=social&utm_campaign=weekly_recap`;
+  lines.push('', `Full breakdown: ${trackUrl}`, '#TradeClaw #WeeklyRecap #Trading');
 
   const copy = lines.join('\n');
   const post = await enqueueSummaryPost('weekly_summary', copy, imageUrl, {

--- a/apps/web/app/api/stripe/checkout/__tests__/route.test.ts
+++ b/apps/web/app/api/stripe/checkout/__tests__/route.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../../../lib/stripe', () => ({
 
 jest.mock('../../../../../lib/db', () => ({
   getUserById: jest.fn(),
+  getUserByReferralCode: jest.fn(),
   updateUserStripeCustomerId: jest.fn().mockResolvedValue(undefined),
 }));
 
@@ -26,7 +27,7 @@ import {
   resolveTierFromPriceId,
   resolveStripePriceId,
 } from '../../../../../lib/stripe';
-import { getUserById, updateUserStripeCustomerId } from '../../../../../lib/db';
+import { getUserById, getUserByReferralCode, updateUserStripeCustomerId } from '../../../../../lib/db';
 import { readSessionFromRequest } from '../../../../../lib/user-session';
 import { POST } from '../route';
 
@@ -34,15 +35,50 @@ const mockedGetStripe = getStripe as jest.MockedFunction<typeof getStripe>;
 const mockedResolveTier = resolveTierFromPriceId as jest.MockedFunction<typeof resolveTierFromPriceId>;
 const mockedResolvePrice = resolveStripePriceId as jest.MockedFunction<typeof resolveStripePriceId>;
 const mockedGetUserById = getUserById as jest.MockedFunction<typeof getUserById>;
+const mockedGetUserByReferralCode = getUserByReferralCode as jest.MockedFunction<typeof getUserByReferralCode>;
 const mockedUpdateCustomerId = updateUserStripeCustomerId as jest.MockedFunction<typeof updateUserStripeCustomerId>;
 const mockedReadSession = readSessionFromRequest as jest.MockedFunction<typeof readSessionFromRequest>;
 
-function makeRequest(body: Record<string, unknown>): NextRequest {
+function makeRequest(body: Record<string, unknown>, cookie?: string): NextRequest {
   return new NextRequest('http://localhost/api/stripe/checkout', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...(cookie ? { cookie } : {}) },
     body: JSON.stringify(body),
   });
+}
+
+function userRecord(id: string) {
+  return {
+    id,
+    email: `${id}@example.com`,
+    stripeCustomerId: 'cus_x' as string | null,
+    tier: 'free' as const,
+    tierExpiresAt: null,
+    telegramUserId: null,
+    displayName: null,
+    avatarUrl: null,
+    authProvider: null,
+    referralCode: null,
+    referredBy: null,
+  };
+}
+
+/** Wire up an authed Pro-monthly checkout and return the Stripe sessions.create spy. */
+function setupAuthedProUser(userId: string): jest.Mock {
+  mockedReadSession.mockReturnValue({ userId, issuedAt: Date.now() });
+  mockedResolvePrice.mockReturnValueOnce('price_pro_monthly');
+  mockedResolveTier.mockReturnValueOnce('pro');
+  mockedGetUserById.mockResolvedValueOnce(userRecord(userId));
+  const sessionsCreate = jest.fn().mockResolvedValue({
+    id: 'cs_ref',
+    url: 'https://checkout.stripe.com/c/pay/cs_ref',
+    customer: 'cus_x',
+  });
+  mockedGetStripe.mockReturnValue({
+    checkout: { sessions: { create: sessionsCreate } },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  return sessionsCreate;
 }
 
 describe('POST /api/stripe/checkout', () => {
@@ -229,5 +265,55 @@ describe('POST /api/stripe/checkout', () => {
     expect(res.status).toBe(500);
     expect(body.url).toBeUndefined();
     expect(body.error).toBe('Stripe down');
+  });
+
+  it('resolves the tc_ref cookie to the referrer user id in checkout metadata', async () => {
+    const sessionsCreate = setupAuthedProUser('buyer-1');
+    mockedGetUserByReferralCode.mockResolvedValueOnce(userRecord('referrer-9'));
+
+    const res = await POST(makeRequest({ tier: 'pro', interval: 'monthly' }, 'tc_ref=ABCD1234'));
+    expect(res.status).toBe(200);
+    expect(mockedGetUserByReferralCode).toHaveBeenCalledWith('ABCD1234');
+    expect(sessionsCreate.mock.calls[0][0].metadata).toEqual({
+      tier: 'pro',
+      userId: 'buyer-1',
+      referrerId: 'referrer-9',
+    });
+  });
+
+  it('drops a self-referral (cookie code resolves to the buyer)', async () => {
+    const sessionsCreate = setupAuthedProUser('buyer-1');
+    mockedGetUserByReferralCode.mockResolvedValueOnce(userRecord('buyer-1'));
+
+    const res = await POST(makeRequest({ tier: 'pro', interval: 'monthly' }, 'tc_ref=BEEF0001'));
+    expect(res.status).toBe(200);
+    expect(sessionsCreate.mock.calls[0][0].metadata.referrerId).toBe('');
+  });
+
+  it('ignores an unknown referral code (no referrer recorded)', async () => {
+    const sessionsCreate = setupAuthedProUser('buyer-1');
+    mockedGetUserByReferralCode.mockResolvedValueOnce(null);
+
+    const res = await POST(makeRequest({ tier: 'pro', interval: 'monthly' }, 'tc_ref=DEADBEEF'));
+    expect(res.status).toBe(200);
+    expect(sessionsCreate.mock.calls[0][0].metadata.referrerId).toBe('');
+  });
+
+  it('does not look up a referral when no tc_ref cookie is present', async () => {
+    const sessionsCreate = setupAuthedProUser('buyer-1');
+
+    const res = await POST(makeRequest({ tier: 'pro', interval: 'monthly' }));
+    expect(res.status).toBe(200);
+    expect(mockedGetUserByReferralCode).not.toHaveBeenCalled();
+    expect(sessionsCreate.mock.calls[0][0].metadata.referrerId).toBe('');
+  });
+
+  it('ignores a malformed referral code without a DB lookup', async () => {
+    const sessionsCreate = setupAuthedProUser('buyer-1');
+
+    const res = await POST(makeRequest({ tier: 'pro', interval: 'monthly' }, 'tc_ref=GHIJKLMN'));
+    expect(res.status).toBe(200);
+    expect(mockedGetUserByReferralCode).not.toHaveBeenCalled();
+    expect(sessionsCreate.mock.calls[0][0].metadata.referrerId).toBe('');
   });
 });

--- a/apps/web/app/api/stripe/checkout/route.ts
+++ b/apps/web/app/api/stripe/checkout/route.ts
@@ -3,6 +3,7 @@ import type Stripe from 'stripe';
 import { getStripe, resolveTierFromPriceId, resolveStripePriceId } from '../../../../lib/stripe';
 import {
   getUserById,
+  getUserByReferralCode,
   updateUserStripeCustomerId,
 } from '../../../../lib/db';
 import { readSessionFromRequest } from '../../../../lib/user-session';
@@ -28,7 +29,6 @@ export async function POST(request: NextRequest) {
       priceId?: unknown;
       tier?: unknown;
       interval?: unknown;
-      referrerId?: unknown;
     };
     const rawPriceId = body.priceId;
     const tier = normalizeTier(body.tier);
@@ -99,6 +99,20 @@ export async function POST(request: NextRequest) {
       stripeCustomerId = user.stripeCustomerId;
     }
 
+    // Referral attribution. The pricing page stores the inbound ?ref code in the
+    // tc_ref cookie; we resolve it to the referrer's user id SERVER-SIDE so the
+    // client can never inject an arbitrary referrerId (gift/impersonation), and
+    // we drop self-referrals. The webhook records metadata.referrerId as the
+    // referred_by user id, so an unknown/invalid code resolves to '' (no reward).
+    let referrerId = '';
+    const refCode = request.cookies.get('tc_ref')?.value?.trim().toUpperCase();
+    if (refCode && /^[0-9A-F]{1,32}$/.test(refCode)) {
+      const referrer = await getUserByReferralCode(refCode);
+      if (referrer && referrer.id !== userId) {
+        referrerId = referrer.id;
+      }
+    }
+
     const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: 'subscription',
       payment_method_types: ['card'],
@@ -106,7 +120,7 @@ export async function POST(request: NextRequest) {
       success_url: `${BASE_URL}/welcome?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${BASE_URL}/pricing`,
       client_reference_id: userId,
-      metadata: { tier: resolvedTier, userId, referrerId: typeof body.referrerId === 'string' ? body.referrerId : '' },
+      metadata: { tier: resolvedTier, userId, referrerId },
       subscription_data: {
         metadata: { userId, tier: resolvedTier },
         trial_period_days: 7,

--- a/apps/web/app/pricing/PricingCards.tsx
+++ b/apps/web/app/pricing/PricingCards.tsx
@@ -248,6 +248,24 @@ export function PricingCards() {
   const [resuming, setResuming] = useState(false);
   const [resumeError, setResumeError] = useState<string | null>(null);
 
+  // Referral capture: persist the inbound ?ref code to the tc_ref cookie so it
+  // survives the signin round-trip and the later checkout POST. The checkout
+  // route resolves the code → referrer server-side (a code, never a user id, is
+  // exposed to the client). Without this, referral links land on /pricing?ref=…
+  // and the code is silently dropped, so the reward plumbing never fires.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const raw = new URLSearchParams(window.location.search).get('ref');
+    const code = raw ? raw.toUpperCase() : null;
+    // Match the server's referral-code shape (uppercase hex) so a code the
+    // client stores is one the checkout route can actually resolve.
+    if (code && /^[0-9A-F]{1,32}$/.test(code)) {
+      const maxAge = 60 * 60 * 24 * 30; // 30 days
+      const secure = window.location.protocol === 'https:' ? '; secure' : '';
+      document.cookie = `tc_ref=${encodeURIComponent(code)}; path=/; max-age=${maxAge}; samesite=lax${secure}`;
+    }
+  }, []);
+
   // Post-signin resume: when a logged-out user clicks "Start Trial",
   // we redirect them to /signin?next=/pricing?resume=checkout&interval=…
   // After signin lands them back here we re-fire the checkout POST so the

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -182,6 +182,20 @@ export async function getUserByEmail(email: string): Promise<UserRecord | null> 
 }
 
 /**
+ * Resolve a referral code (the value behind /pricing?ref=…) to the referring
+ * user. Codes are stored uppercase hex (generateReferralCode), so the caller
+ * is expected to normalize to uppercase before lookup. Returns null for an
+ * unknown code — the checkout flow then simply records no referral.
+ */
+export async function getUserByReferralCode(code: string): Promise<UserRecord | null> {
+  const row = await queryOne<UserRow>(
+    `SELECT ${USER_COLUMNS} FROM users WHERE referral_code = $1`,
+    [code],
+  );
+  return row ? toUserRecord(row) : null;
+}
+
+/**
  * Find-or-create a user by email. Used by the passwordless session flow so
  * first-time visitors get a row on their first signin attempt.
  */


### PR DESCRIPTION
## Why

Referral links (`/pricing?ref=CODE`) were a **dead flywheel**. The reward plumbing was already fully built — `referral_rewards`/`referral_revenue` tables (migrations 042–044), the checkout route accepting a `referrerId` into Stripe metadata, and the webhook recording `referred_by` + a reward — but the **inbound `?ref` was never captured**. Visitors landed on `/pricing?ref=CODE` and the code was silently dropped, so every referred signup was attributed to no one.

## What changed

**Referral capture (#2)** — secure, server-resolved:

- `PricingCards` reads the inbound `?ref` (uppercase-hex validated) and stores it in a `tc_ref` cookie (`samesite=lax`, `secure` on https) so it survives the signin round-trip and the later checkout POST.
- The **checkout route** reads `tc_ref` server-side, resolves it to the referrer via a new `getUserByReferralCode`, and sets `metadata.referrerId` to the resolved **user id**. The client only ever exposes a *code*, never a user id, so it cannot inject an arbitrary `referrerId` (gift/impersonation). Self-referrals are dropped at checkout **and** the webhook (defense-in-depth). The previously-trusted `body.referrerId` is removed.

**Social UTM (#9)**:

- Auto-posted daily/weekly cards UTM-tag their `/track-record` link (`utm_source=x&utm_medium=social&utm_campaign=…`) so social-driven signups are attributable. First-party auto-posts have no individual referrer, so a user-to-user `ref=` code is intentionally **not** used there — that belongs on user-facing share links (logged as follow-up).

## Security

Reviewed by the security agent — **no CRITICAL/HIGH**. The shift from trusting a client-supplied user id to resolving a code server-side is the correct design. Lookup is parameterized; `referral_code` is already `UNIQUE` + indexed (`idx_users_referral_code`, migration 043). Two LOW review items addressed (client regex tightened to the hex shape; `secure` flag added on https).

## Test plan

- [x] `apps/web` type-check: **0 errors**.
- [x] Full `jest` green, including **5 new** checkout-route referral cases: cookie→referrer resolution, self-referral drop, unknown code, no cookie, malformed code (no DB lookup).
- [x] `eslint` apps/web: **0 errors**.
- [ ] Manual: visit `/pricing?ref=<validcode>` → start checkout → confirm the Stripe session metadata carries the referrer's user id; self-referral records nothing.

## Notes

Plan: `docs/plans/2026-06-15-growth-honesty-backlog.md` (Batch 1, items #2 + #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)