### PR TITLE
fix(auth): preserve checkout intent through the magic-link sign-in flow

### DIFF
--- a/apps/web/app/api/auth/magic-link/start/route.ts
+++ b/apps/web/app/api/auth/magic-link/start/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { countRecentMagicLinkEmails, issueMagicLink } from '../../../../../lib/magic-link';
+import { buildVerifyIntentQuery } from '../../../../../lib/magic-link-redirect';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -7,7 +8,14 @@ export const dynamic = 'force-dynamic';
 const RATE_LIMIT_WINDOW_SECONDS = 60;
 
 export async function POST(req: NextRequest) {
-  const { email } = (await req.json().catch(() => ({}))) as { email?: string };
+  const body = (await req.json().catch(() => ({}))) as {
+    email?: string;
+    priceId?: string;
+    tier?: string;
+    interval?: string;
+    next?: string;
+  };
+  const email = body.email;
   const normalized = (email ?? '').toLowerCase().trim();
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
     return NextResponse.json({ error: 'Invalid email' }, { status: 400 });
@@ -34,7 +42,11 @@ export async function POST(req: NextRequest) {
 
   const { raw } = await issueMagicLink(normalized);
   const base = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://tradeclaw.win';
-  const link = `${base}/api/auth/magic-link/verify?token=${encodeURIComponent(raw)}`;
+  // Carry any checkout intent through the link so /verify can resume checkout
+  // instead of dropping the user on /dashboard. All values are sanitized here
+  // and re-sanitized at verify time (the link query is attacker-visible).
+  const intentQuery = buildVerifyIntentQuery(body);
+  const link = `${base}/api/auth/magic-link/verify?token=${encodeURIComponent(raw)}${intentQuery}`;
 
   const sendRes = await fetch('https://api.resend.com/emails', {
     method: 'POST',

--- a/apps/web/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/app/api/auth/magic-link/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { consumeMagicLink } from '../../../../../lib/magic-link';
+import { resolveMagicLinkTarget } from '../../../../../lib/magic-link-redirect';
 // TODO(magic-link): swap to upsertUserProfile once magic-link supports a
 // display name on the verify form. Until then magic-link users get
 // displayName/avatarUrl/authProvider all null, which the navbar handles
@@ -40,7 +41,21 @@ export async function GET(req: NextRequest) {
 
   const user = await upsertUserByEmail(result.email);
   const sessionToken = createSessionToken(user.id);
-  const res = NextResponse.redirect(new URL('/dashboard', origin));
+
+  // Resume any checkout intent carried on the link instead of always landing on
+  // /dashboard (mirrors the Google OAuth callback). Re-sanitized inside.
+  const sp = req.nextUrl.searchParams;
+  const target = resolveMagicLinkTarget(
+    {
+      priceId: sp.get('priceId'),
+      tier: sp.get('tier'),
+      interval: sp.get('interval'),
+      next: sp.get('next'),
+    },
+    origin,
+  );
+
+  const res = NextResponse.redirect(target);
   res.cookies.set(USER_SESSION_COOKIE, sessionToken, sessionCookieOptions());
   return res;
 }

--- a/apps/web/app/signin/page.tsx
+++ b/apps/web/app/signin/page.tsx
@@ -162,7 +162,15 @@ function SigninInner() {
       const res = await fetch('/api/auth/magic-link/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: emailInput }),
+        // Forward any checkout intent so the emailed link resumes checkout
+        // after sign-in instead of dropping the user on /dashboard.
+        body: JSON.stringify({
+          email: emailInput,
+          ...(priceId ? { priceId } : {}),
+          ...(tier ? { tier } : {}),
+          ...(interval ? { interval } : {}),
+          ...(next ? { next } : {}),
+        }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));

--- a/apps/web/lib/__tests__/magic-link-redirect.test.ts
+++ b/apps/web/lib/__tests__/magic-link-redirect.test.ts
@@ -1,0 +1,79 @@
+import {
+  sanitizeIntent,
+  buildVerifyIntentQuery,
+  resolveMagicLinkTarget,
+} from '../magic-link-redirect';
+
+const ORIGIN = 'https://tradeclaw.win';
+
+describe('sanitizeIntent', () => {
+  it('keeps recognized checkout intent values', () => {
+    expect(
+      sanitizeIntent({ priceId: 'price_ABC123', tier: 'pro', interval: 'monthly', next: '/pricing?resume=checkout' }),
+    ).toEqual({ priceId: 'price_ABC123', tier: 'pro', interval: 'monthly', next: '/pricing?resume=checkout' });
+  });
+
+  it('drops unrecognized tier / interval and malformed priceId', () => {
+    expect(
+      sanitizeIntent({ priceId: 'evil; DROP TABLE', tier: 'gold', interval: 'lifetime', next: undefined }),
+    ).toEqual({});
+  });
+
+  it('rejects open-redirect next values (scheme-relative and absolute)', () => {
+    expect(sanitizeIntent({ next: '//evil.com/phish' }).next).toBeUndefined();
+    expect(sanitizeIntent({ next: 'https://evil.com' }).next).toBeUndefined();
+    expect(sanitizeIntent({ next: '/dashboard' }).next).toBe('/dashboard');
+  });
+});
+
+describe('buildVerifyIntentQuery', () => {
+  it('returns an &-prefixed query of sanitized params', () => {
+    const q = buildVerifyIntentQuery({ tier: 'pro', interval: 'annual' });
+    expect(q.startsWith('&')).toBe(true);
+    const params = new URLSearchParams(q.slice(1));
+    expect(params.get('tier')).toBe('pro');
+    expect(params.get('interval')).toBe('annual');
+  });
+
+  it('is empty when there is no usable intent', () => {
+    expect(buildVerifyIntentQuery({})).toBe('');
+    expect(buildVerifyIntentQuery({ tier: 'gold', next: '//evil.com' })).toBe('');
+  });
+});
+
+describe('resolveMagicLinkTarget', () => {
+  it('bounces a priceId checkout payload through /signin so its auto-checkout fires', () => {
+    const t = new URL(resolveMagicLinkTarget({ priceId: 'price_X1', next: '/pricing' }, ORIGIN));
+    expect(t.pathname).toBe('/signin');
+    expect(t.searchParams.get('priceId')).toBe('price_X1');
+    expect(t.searchParams.get('next')).toBe('/pricing');
+  });
+
+  it('bounces a tier=pro + interval payload through /signin', () => {
+    const t = new URL(resolveMagicLinkTarget({ tier: 'pro', interval: 'monthly' }, ORIGIN));
+    expect(t.pathname).toBe('/signin');
+    expect(t.searchParams.get('tier')).toBe('pro');
+    expect(t.searchParams.get('interval')).toBe('monthly');
+  });
+
+  it('honors a safe next when there is no checkout payload', () => {
+    expect(resolveMagicLinkTarget({ next: '/pricing?resume=checkout&interval=annual' }, ORIGIN)).toBe(
+      `${ORIGIN}/pricing?resume=checkout&interval=annual`,
+    );
+  });
+
+  it('falls back to /dashboard for an unsafe next and no payload', () => {
+    expect(resolveMagicLinkTarget({ next: '//evil.com/x' }, ORIGIN)).toBe(`${ORIGIN}/dashboard`);
+  });
+
+  it('falls back to /dashboard with no intent', () => {
+    expect(resolveMagicLinkTarget({}, ORIGIN)).toBe(`${ORIGIN}/dashboard`);
+  });
+
+  it('does not treat tier=pro WITHOUT a valid interval as a checkout payload', () => {
+    // No interval → not a payload → honor next instead of bouncing to /signin.
+    expect(resolveMagicLinkTarget({ tier: 'pro', next: '/dashboard/billing' }, ORIGIN)).toBe(
+      `${ORIGIN}/dashboard/billing`,
+    );
+  });
+});

--- a/apps/web/lib/magic-link-redirect.ts
+++ b/apps/web/lib/magic-link-redirect.ts
@@ -1,0 +1,87 @@
+import { safeNext } from './oauth-state';
+
+/**
+ * Checkout-intent carried through the magic-link flow so a user who started a
+ * purchase, then chose "email me a sign-in link", lands back on checkout
+ * instead of a generic dashboard. Mirrors the priceId/tier/interval/next that
+ * the Google OAuth state blob already preserves.
+ */
+export interface MagicLinkIntent {
+  priceId?: string | null;
+  tier?: string | null;
+  interval?: string | null;
+  next?: string | null;
+}
+
+export interface SanitizedIntent {
+  priceId?: string;
+  tier?: string;
+  interval?: string;
+  next?: string;
+}
+
+const TIERS = new Set(['pro', 'elite']);
+const INTERVALS = new Set(['monthly', 'annual']);
+// Stripe price ids look like `price_…`; the checkout route re-validates the
+// price→tier mapping, this is just a cheap shape guard before it travels.
+const PRICE_ID_RE = /^price_[A-Za-z0-9]+$/;
+
+/**
+ * Drop anything that isn't a recognized checkout intent value. `next` is run
+ * through the shared safeNext (same-origin relative paths only) so the magic
+ * link can never become an open redirect.
+ */
+export function sanitizeIntent(intent: MagicLinkIntent): SanitizedIntent {
+  const out: SanitizedIntent = {};
+  if (typeof intent.priceId === 'string' && PRICE_ID_RE.test(intent.priceId)) {
+    out.priceId = intent.priceId;
+  }
+  if (typeof intent.tier === 'string' && TIERS.has(intent.tier)) {
+    out.tier = intent.tier;
+  }
+  if (typeof intent.interval === 'string' && INTERVALS.has(intent.interval)) {
+    out.interval = intent.interval;
+  }
+  const n = safeNext(intent.next ?? undefined);
+  if (n) out.next = n;
+  return out;
+}
+
+/**
+ * Query-string fragment (with a leading '&') of sanitized intent params, for
+ * appending to the emailed verify link. Empty string when there is no intent.
+ */
+export function buildVerifyIntentQuery(intent: MagicLinkIntent): string {
+  const s = sanitizeIntent(intent);
+  const p = new URLSearchParams();
+  if (s.priceId) p.set('priceId', s.priceId);
+  if (s.tier) p.set('tier', s.tier);
+  if (s.interval) p.set('interval', s.interval);
+  if (s.next) p.set('next', s.next);
+  const qs = p.toString();
+  return qs ? `&${qs}` : '';
+}
+
+/**
+ * Post-verify redirect target, mirroring the Google OAuth callback exactly:
+ * a checkout payload (priceId, or tier=pro + interval) bounces through /signin
+ * — whose client effect fires the checkout POST once the session cookie is set
+ * — otherwise honor a safe `next`, else /dashboard. All values are re-sanitized
+ * here because the verify link query is attacker-visible.
+ */
+export function resolveMagicLinkTarget(intent: MagicLinkIntent, origin: string): string {
+  const s = sanitizeIntent(intent);
+  const hasCheckoutPayload =
+    !!s.priceId || (s.tier === 'pro' && (s.interval === 'monthly' || s.interval === 'annual'));
+
+  if (hasCheckoutPayload) {
+    const target = new URL('/signin', origin);
+    if (s.priceId) target.searchParams.set('priceId', s.priceId);
+    if (s.tier) target.searchParams.set('tier', s.tier);
+    if (s.interval) target.searchParams.set('interval', s.interval);
+    if (s.next) target.searchParams.set('next', s.next);
+    return target.toString();
+  }
+  if (s.next) return new URL(s.next, origin).toString();
+  return new URL('/dashboard', origin).toString();
+}


### PR DESCRIPTION
## Why

A user who started a Pro/Elite purchase, hit the sign-in wall, then chose **"email me a sign-in link"** was always redirected to `/dashboard` after clicking the link — the checkout intent was silently dropped. The OAuth (Google/GitHub) flow already resumes checkout via its signed `state` blob; magic-link did not. This is a leak at the highest-value step of the funnel.

## What changed

- **New pure, tested helper** `lib/magic-link-redirect.ts`:
  - `sanitizeIntent` — whitelists `tier` (`pro`/`elite`) and `interval` (`monthly`/`annual`), shape-checks `priceId` (`price_…`), and runs `next` through the shared `safeNext` (same-origin relative paths only → **no open redirect**).
  - `resolveMagicLinkTarget` — mirrors the Google OAuth callback exactly: a checkout payload (`priceId`, or `tier=pro` + `interval`) bounces through `/signin` so its existing client effect fires the checkout POST once the session cookie is set; otherwise a safe `next`; otherwise `/dashboard`.
- `magic-link/start` forwards the validated intent into the emailed verify link (`buildVerifyIntentQuery`).
- `magic-link/verify` redirects to the resolved target (re-sanitized — the link query is attacker-visible) instead of always `/dashboard`.
- The signin page's magic-link form forwards `priceId/tier/interval/next` it already reads from the URL.

No DB migration: intent travels via the (same-origin-validated) verify link rather than a new `magic_link_tokens` column.

## Security

Auth/redirect code. The only meaningful surface is open redirect, and it's closed: `safeNext` rejects `//` and absolute URLs, `verify` re-sanitizes the attacker-visible query, and `priceId` is re-validated downstream by the checkout route's price→tier check. Intent values are whitelisted. Tests assert `//evil.com` and `https://evil.com` are rejected.

## Test plan

- [x] `apps/web` type-check: **0 errors**.
- [x] Full `jest` green — **1431 tests**, including **11 new** helper cases (sanitize/whitelist, open-redirect rejection, OAuth-mirror branches, default `/dashboard`).
- [x] `eslint` apps/web: **0 errors**.
- [ ] Manual: pricing → Start Trial (logged out) → "email me a sign-in link" → click link → lands on checkout, not `/dashboard`.

## Notes

Plan: `docs/plans/2026-06-15-growth-honesty-backlog.md` (Batch 1, item #4b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)