### PR TITLE
feat(experiment): make the hero A/B a real experiment + add an activation event

### DIFF
--- a/apps/web/components/landing/ab-hero.tsx
+++ b/apps/web/components/landing/ab-hero.tsx
@@ -13,6 +13,7 @@ import { Star, Radio, CheckCircle2 } from "lucide-react";
 import { AnimatedChartHero } from "../animated-chart-hero";
 import { TradeClawIconArtwork } from "../brand/tradeclaw-icon-artwork";
 import { useHeroPrices, formatPairPrice } from "../../lib/hooks/use-hero-prices";
+import { trackEvent, registerSuperProperties } from "../../lib/analytics";
 
 const GITHUB_URL = "https://github.com/naimkatiman/tradeclaw";
 
@@ -463,6 +464,11 @@ export function ABHero() {
     setTimeout(() => {
       setVariant(v);
       trackImpression(v);
+      // Stamp the variant on every subsequent PostHog event (conversions,
+      // activation, pageviews) so the test measures business outcomes by
+      // variant, not just hero clicks. Plus a real server-visible impression.
+      registerSuperProperties({ hero_variant: v });
+      trackEvent('hero_viewed', { variant: v });
       setMounted(true);
     }, 0);
 

--- a/apps/web/lib/__tests__/onboarding-state.test.ts
+++ b/apps/web/lib/__tests__/onboarding-state.test.ts
@@ -1,4 +1,6 @@
 // apps/web/lib/__tests__/onboarding-state.test.ts
+jest.mock('../analytics', () => ({ trackEvent: jest.fn() }));
+
 import {
   getOnboardingState,
   markStepDone,
@@ -6,6 +8,9 @@ import {
   resetOnboarding,
   type OnboardingState,
 } from '../onboarding-state';
+import { trackEvent } from '../analytics';
+
+const mockedTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>;
 
 const STEPS = ['saw-signal', 'opened-detail', 'set-alert'] as const;
 
@@ -20,7 +25,10 @@ beforeAll(() => {
     },
   });
 });
-beforeEach(() => { Object.keys(store).forEach(k => delete store[k]); });
+beforeEach(() => {
+  Object.keys(store).forEach(k => delete store[k]);
+  mockedTrackEvent.mockClear();
+});
 
 describe('onboarding state', () => {
   it('returns all steps incomplete on first call', () => {
@@ -51,5 +59,23 @@ describe('onboarding state', () => {
     markStepDone('saw-signal');
     resetOnboarding();
     expect(getOnboardingState()['saw-signal']).toBe(false);
+  });
+
+  it('fires the activation event once when opened-detail transitions to done', () => {
+    markStepDone('opened-detail');
+    expect(mockedTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockedTrackEvent).toHaveBeenCalledWith('activated', { step: 'opened-detail' });
+  });
+
+  it('does not re-fire activation when opened-detail is marked again', () => {
+    markStepDone('opened-detail');
+    markStepDone('opened-detail');
+    expect(mockedTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire activation for other onboarding steps', () => {
+    markStepDone('saw-signal');
+    markStepDone('set-alert');
+    expect(mockedTrackEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -11,7 +11,9 @@ export type AnalyticsEvent =
   | 'signal_viewed'
   | 'subscription_clicked'
   | 'checkout_started'
-  | 'trial_started';
+  | 'trial_started'
+  | 'hero_viewed'
+  | 'activated';
 
 export function trackEvent(
   event: AnalyticsEvent,
@@ -23,6 +25,27 @@ export function trackEvent(
 
   try {
     posthog.capture(event, properties ?? {});
+  } catch {
+    // Swallow analytics errors so they never break user-facing features
+  }
+}
+
+/**
+ * Register PostHog super properties — persisted on this browser and attached to
+ * EVERY subsequent event. Used to stamp the hero A/B variant onto all downstream
+ * events (pageviews, subscription_clicked, checkout_started, activated, …) so
+ * the experiment measures conversion + activation by variant, not just hero
+ * clicks. No-op when analytics is unconfigured; never throws.
+ */
+export function registerSuperProperties(
+  properties: Record<string, string | number | boolean | null>,
+): void {
+  if (typeof window === 'undefined') return;
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+  if (!posthog.__loaded) return;
+
+  try {
+    posthog.register(properties);
   } catch {
     // Swallow analytics errors so they never break user-facing features
   }

--- a/apps/web/lib/onboarding-state.ts
+++ b/apps/web/lib/onboarding-state.ts
@@ -1,4 +1,6 @@
 // apps/web/lib/onboarding-state.ts
+import { trackEvent } from './analytics';
+
 const STORAGE_KEY = 'tc-onboarding-v1';
 
 export type OnboardingStep = 'saw-signal' | 'opened-detail' | 'set-alert';
@@ -23,11 +25,20 @@ export function getOnboardingState(): OnboardingState {
 
 export function markStepDone(step: OnboardingStep): void {
   const state = getOnboardingState();
+  const wasDone = state[step];
   state[step] = true;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch {
     // Storage unavailable — silent
+  }
+
+  // Activation = the first time a user opens a real signal's detail (engaged
+  // with the core value). Fire once, on the false→true transition, so the hero
+  // A/B experiment can measure activation rate by variant (the hero_variant
+  // super property rides along on this event).
+  if (step === 'opened-detail' && !wasDone) {
+    trackEvent('activated', { step });
   }
 }
 


### PR DESCRIPTION
## Why

The hero A/B test ([`ab-hero.tsx`](apps/web/components/landing/ab-hero.tsx)) was a **vanity test**: variant assignment and impression/click counts lived in `localStorage` only, **no variant was attached to any conversion event**, and **no activation event existed**. It could tell you which hero got clicked — never which hero produced trials, paid conversions, or engaged users. Prior audits flagged exactly this (2026-05-13 user-journey #5; 2026-06-13 phase6a "N=1 winning badge").

## What changed

- **`analytics.ts`** — new `registerSuperProperties()` and two events (`hero_viewed`, `activated`).
- **`ab-hero`** — on variant assignment, registers `hero_variant` as a PostHog **super property** (persisted on the browser, attached to *every* subsequent event: pageviews, `subscription_clicked`, `checkout_started`, `trial_started`, `activated`) and captures a real `hero_viewed`. The existing localStorage tracking is kept so `/ab-stats` keeps working.
- **`onboarding-state`** — fires `activated` **once**, on the `opened-detail` `false→true` transition: the first time a user opens a real signal's detail. That's the closest instrumentable proxy for "acted on a signal" (the product has no trade ledger). The `hero_variant` super property attributes activation to the variant.

**Net effect:** the experiment now measures trial/paid **conversion** and **activation rate** by hero variant in PostHog — real business outcomes, not hero clicks. Builds on the server analytics in #125.

## Scope note

Variant *assignment* stays `localStorage`-based (not PostHog feature flags) — attribution via the super property is what turns the test real and is the high-value, low-risk change. Flag-based assignment (cross-device cohorts) is a sensible later iteration.

## Test plan

- [x] `apps/web` type-check: **0 errors**.
- [x] Full `jest` green — **1423 tests**, including **3 new** activation cases (`opened-detail` fires once / does not re-fire / other steps don't fire).
- [x] `eslint` apps/web: **0 errors**.
- [ ] Manual: with PostHog configured, load `/`, then convert — confirm `subscription_clicked` / `checkout_started` / `activated` events carry `hero_variant`.

## Notes

Plan: `docs/plans/2026-06-15-growth-honesty-backlog.md` (Batch 2, item #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)