### PR TITLE
chore(repo): ignore generated graphify-out to keep git status clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ apps/web/data/performance-metrics.json
 __pycache__/
 *.pyc
 apps/web/data/*.db
+
+# graphify knowledge-graph output (generated, ~8MB)
+graphify-out/

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-06-22T05:30:00+08:00
+updated: 2026-06-24T05:31:00+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -8,26 +8,17 @@ description: >
   Goal: viral GitHub repo, thousands of stars.
 
 ai_improvement_last_run:
-  at: 2026-06-22T05:30:00+08:00
+  at: 2026-06-24T05:31:00+08:00
   agent: CEO Zaky recurring Product + Engineering repository improvement agent
-  scope: docs-only post-metrics verification checkpoint refresh for the unchanged remote-aligned feature branch and dirty tree
+  scope: docs-only graphify-out ignore hygiene; generated review output now excluded from status noise
   notes: >
     Current checkout remains fix/track-record-compliance-copy at 528cd3c8,
     aligned with origin/fix/track-record-compliance-copy (ahead/behind 0/0).
-    Local main remains da2afa06 ahead of origin/main. Fresh fetch plus merge-base
-    probe kept origin/main changed paths at zero and dirty/origin overlap at zero.
-    Refreshed the existing docs/ai-improvement source-review metrics packet,
-    handoff, verification matrix, README, implementation log, STATE.yaml, and the
-    central board with the 05:30 verification checkpoint rather than adding new
-    runtime work. Dirty set remains 13 paths (12 tracked modified files plus
-    untracked source-review-metrics.md); pre-checkpoint tracked shortstat before
-    this run's tracking edits was 12 files / 1,879 insertions / 226 deletions.
-    Verification snapshot: targeted app ESLint exit 0, npm run typecheck:web exit 0,
-    targeted Jest 2 suites / 22 tests pass in 1.76s with --forceExit, npm run build
-    --workspace=apps/web exit 0 with Next.js 16.2.6, 332/332 static pages, and known warnings only,
-    entrypoint syntax/help markers pass, package parse passes, and focused
-    source/test/config pygount reports 1,419 files / 144,113 code / 16,085 comments.
-    Code changes: none this run.
+    The live working tree before the docs refresh showed only the pre-existing
+    .gitignore modification. Added graphify-out/ to .gitignore so generated
+    graphify knowledge-graph output stays out of future status/dirty-tree review.
+    Verified git status, git diff, git ls-files graphify-out, and git
+    check-ignore. Code changes: .gitignore only this run.
 
 tasks:
   - id: TC-001

--- a/docs/ai-improvement/implementation-log.md
+++ b/docs/ai-improvement/implementation-log.md
@@ -1,5 +1,60 @@
 # TradeClaw AI Improvement Implementation Log
 
+## 2026-06-24 05:31 MPST (+0800) — graphify-out ignore hygiene (docs/tracking only)
+
+Scope: recurring CEO Zaky repository improvement agent run for `C:/Ai/tradeclaw` on the Mini `gpt-5.4-mini` tier, daily schedule `27 5 * * *`.
+
+Decision: kept the low-risk `.gitignore` hygiene change that ignores generated `graphify-out/` output so future status scans do not pick up the graphify cache folder. The live working tree before the docs refresh showed only the pre-existing `.gitignore` modification. Code changes: `.gitignore` only.
+
+External source applied: continuous-improvement — re-scanned live status and verified the change before reporting.
+External source applied: ponytail — chose the smallest safe fix by ignoring generated output instead of touching the generated tree itself.
+External source applied: graphify — treated `graphify-out/` as generated knowledge-graph output that should stay out of the repo status surface.
+
+Files inspected / context read:
+- `C:/Ai/tradeclaw/.gitignore`
+- `C:/Ai/tradeclaw/STATE.yaml`
+- `C:/Ai/_zaky_ai_board/KANBAN.md`
+- current `git status --short --branch --untracked-files=all`
+- `git diff -- .gitignore`
+- `git ls-files graphify-out | wc -l`
+- `git check-ignore -v graphify-out/graph.html graphify-out/manifest.json graphify-out/GRAPH_REPORT.md`
+
+Files changed / artifacts updated this run:
+- `.gitignore`
+- `docs/ai-improvement/implementation-log.md`
+- `STATE.yaml`
+- `C:/Ai/_zaky_ai_board/KANBAN.md`
+
+Application/runtime behavior changes: none. Code changes: `.gitignore` only.
+
+Verification run and results:
+
+```text
+timestamp: 2026-06-24 05:31 MPST (+0800)
+
+git status --short --branch --untracked-files=all
+-> ## fix/track-record-compliance-copy...origin/fix/track-record-compliance-copy
+->  M .gitignore
+
+git diff -- .gitignore
+-> diff --git a/.gitignore b/.gitignore
+-> added graphify-out/ ignore rule under the generated-data section
+
+git ls-files graphify-out | wc -l
+-> 0
+
+git check-ignore -v graphify-out/graph.html graphify-out/manifest.json graphify-out/GRAPH_REPORT.md
+-> .gitignore:32:graphify-out/ ...
+```
+
+Final static/read-back verification after tracking-doc updates:
+
+- Re-read `docs/ai-improvement/implementation-log.md`, `STATE.yaml`, and `KANBAN.md` after the final writes; the inserted 2026-06-24 tradeclaw row was still present and the following 2026-06-22 MobileIB0TelegramApp row remained intact.
+- `git status --short --branch --untracked-files=all` -> `## fix/track-record-compliance-copy...origin/fix/track-record-compliance-copy`; modified files now shown were `.gitignore`, `STATE.yaml`, and `docs/ai-improvement/implementation-log.md`.
+- `git diff --shortstat` -> `3 files changed, 66 insertions(+), 17 deletions(-)`.
+- `git diff --check` -> exit `0`; only the expected LF->CRLF warning for `docs/ai-improvement/implementation-log.md`, no whitespace-error lines.
+- `git diff --no-index --check -- /dev/null C:/Ai/_zaky_ai_board/KANBAN.md` -> exit `1` expected; only the expected LF->CRLF warning for `C:/Ai/_zaky_ai_board/KANBAN.md`, no whitespace-error lines.
+
 ## 2026-06-22 05:30 MPST (+0800) — post-metrics verification checkpoint refresh (docs-only)
 
 Scope: recurring CEO Zaky repository improvement agent run for `C:/Ai/tradeclaw` on the Mini `gpt-5.4-mini` tier, daily schedule `27 5 * * *`.


### PR DESCRIPTION
## Summary
Repo hygiene from the 2026-06-24 daily standup run. Adds `graphify-out/` (generated ~8MB knowledge-graph cache) to `.gitignore` so it stops surfacing in `git status` / dirty-tree reviews, and logs the run in the AI-improvement tracking docs.

## Changes
- `.gitignore` — ignore generated `graphify-out/` output
- `STATE.yaml` — refresh `ai_improvement_last_run` checkpoint (2026-06-24)
- `docs/ai-improvement/implementation-log.md` — dated entry for the hygiene change

## Verification
- `git ls-files graphify-out` → 0 tracked files (nothing already committed gets removed)
- `git check-ignore -v graphify-out/...` → matches the new rule
- `git diff --check` → clean (only expected LF→CRLF warning on Windows autocrlf)
- No application/runtime code touched

## Risk
Low. Docs + ignore-rule only; no source or build changes.
