### PR TITLE
fix(track-record): charge real per-row execution cost on the public equity curve

### DIFF
--- a/apps/web/app/api/signals/equity/route.test.ts
+++ b/apps/web/app/api/signals/equity/route.test.ts
@@ -126,11 +126,34 @@ describe('GET /api/signals/equity summary metrics', () => {
     // blowup is what produced the unrunnable +800%/-69% curve).
     expect(body.summary.riskPerTradePct).toBe(1.0);
     expect(body.summary.hardRCap).toBe(8);
-    expect(body.summary.roundTripCostPct).toBe(0.02);
+    // BTCUSD with no recorded cost → model fallback: crypto RT = 0.40% notional.
+    // riskPct = 1% (entry 100, SL 99), so cost in R = 0.40 / 1 = 0.40R.
+    expect(body.summary.roundTripCostPct).toBe(0.4);
+    expect(body.summary.avgCostR).toBe(0.4);
     // R-stats keep the RAW 19R (engine quality is undistorted)…
     expect(body.summary.avgRWin).toBe(19);
-    // …but the equity path is bounded: 8R × 1% − 0.02% cost = +7.98% on one trade.
-    expect(body.summary.totalReturn).toBeCloseTo(7.98, 2);
+    // …but the equity path is bounded: (8R − 0.40R) × 1% = +7.60% on one trade.
+    expect(body.summary.totalReturn).toBeCloseTo(7.60, 2);
+  });
+
+  it("deducts each row's real recorded round-trip cost, not a flat rate", async () => {
+    // Identical +2R win (entry 100, SL 99 → riskPct 1%), differing only in the
+    // recorded cost. Cost in R = cost%_notional ÷ riskPct, so the curve diverges.
+    primeSlice([
+      record({ id: 'cheap-fx', pair: 'EURUSD', entryPrice: 100, sl: 99, costEstimatePct: 0.04, outcomes: { '4h': null, '24h': { price: 102, pnlPct: 2, hit: true } } }),
+    ]);
+    let res = await GET(makeReq('/api/signals/equity'));
+    let body = await res.json();
+    expect(body.summary.avgCostR).toBe(0.04);
+    expect(body.summary.totalReturn).toBeCloseTo(1.96, 2); // (2 − 0.04) × 1%
+
+    primeSlice([
+      record({ id: 'pricey-crypto', pair: 'BTCUSD', entryPrice: 100, sl: 99, costEstimatePct: 0.4, outcomes: { '4h': null, '24h': { price: 102, pnlPct: 2, hit: true } } }),
+    ]);
+    res = await GET(makeReq('/api/signals/equity'));
+    body = await res.json();
+    expect(body.summary.avgCostR).toBe(0.4);
+    expect(body.summary.totalReturn).toBeCloseTo(1.60, 2); // (2 − 0.40) × 1%
   });
 
   it('computes expectancyR from the sized-trade population, not the full-population win-rate', async () => {

--- a/apps/web/app/api/signals/equity/route.ts
+++ b/apps/web/app/api/signals/equity/route.ts
@@ -3,6 +3,7 @@ import { isCountedResolved, type SignalHistoryRecord } from '../../../../lib/sig
 import { PRO_PREMIUM_MIN_CONFIDENCE } from '../../../../lib/tier';
 import { getResolvedSlice, parseScope, type SignalScope } from '../../../../lib/signal-slice';
 import { parseCategoryFilter, symbolsForCategory } from '../../../lib/symbol-config';
+import { costModelFor } from '@tradeclaw/strategies';
 
 export type EquityScope = SignalScope;
 
@@ -20,15 +21,23 @@ const STARTING_EQUITY = 10_000;
 const RISK_PER_TRADE_PCT = 1.0;
 
 /**
- * Round-trip transaction cost deducted from each trade's pnl, in percent.
- * 2bps is the realistic blended cost for a SELECTIVE subscriber executing
- * via a major retail venue (FX 1-2bps, crypto 5-10bps with rebates, indices
- * 1-3bps). The engine's full firehose is ~100 trades/day; a 5bps blended
- * cost compounds to ~78% drag over 3,000 trades and overwhelms the +0.06R
- * gross expectancy. 2bps reflects that a real subscriber both pays less per
- * trade (size sensitivity) and trades less than the engine prints.
+ * Per-trade round-trip cost is the REAL recorded cost for each signal
+ * (cost_estimate_pct, migration 051 = 2×(fee+slippage) of notional per
+ * @tradeclaw/strategies costModelFor, funding excluded). This replaces the
+ * prior flat 0.02% blended guess, which undercharged crypto ~20x (real crypto
+ * RT ≈ 0.40% vs metals ≈ 0.10%, FX ≈ 0.04%) and made the public equity curve
+ * materially more optimistic than a subscriber's true result. Pre-051 rows
+ * with no recorded cost fall back to the model cost for their asset class.
  */
-const ROUND_TRIP_COST_PCT = 0.02;
+function roundTripCostNotionalPct(
+  record: Pick<SignalHistoryRecord, 'pair' | 'costEstimatePct'>,
+): number {
+  if (record.costEstimatePct != null && record.costEstimatePct > 0) {
+    return record.costEstimatePct;
+  }
+  const c = costModelFor(record.pair);
+  return 2 * (c.feePctPerSide + c.slippagePctPerSide);
+}
 
 /**
  * Hard cap on per-trade R-multiple for equity sizing. Bounds single-trade
@@ -72,8 +81,13 @@ export interface EquitySummary {
   breakEvenWinRate: number | null;
   /** Sizing assumption surfaced to the UI so the chart caption can quote the methodology. */
   riskPerTradePct: number;
-  /** Round-trip cost deducted per trade, in percent. */
+  /** Realized average per-trade round-trip cost as % of notional, computed from
+   *  each row's real recorded cost (cost_estimate_pct) — NOT a flat guess. */
   roundTripCostPct: number;
+  /** Realized average per-trade cost in R (cost%_notional ÷ riskPct). This is
+   *  what the equity path actually deducts; the notional % above understates the
+   *  impact because tight stops magnify the R cost. Null when no sized trades. */
+  avgCostR: number | null;
   /** Hard R-cap applied to per-trade sizing — bounds single-trade equity contribution. */
   hardRCap: number;
 }
@@ -154,6 +168,9 @@ function computeEquityCurve(
   let winRCount = 0;
   let lossRSum = 0;
   let lossRCount = 0;
+  // Realized cost accumulators — averaged over sized trades for the summary.
+  let costRSum = 0;
+  let costNotionalSum = 0;
 
   for (const r of sorted) {
     const rawPnl = r.outcomes['24h']!.pnlPct;
@@ -186,10 +203,15 @@ function computeEquityCurve(
     const effectiveRCap = rCap !== null ? Math.min(rCap, HARD_R_CAP) : HARD_R_CAP;
     const rMultipleSized = Math.max(-effectiveRCap, Math.min(effectiveRCap, rMultiple));
 
-    // Fixed-fractional equity change: RISK_PER_TRADE_PCT × R, minus blended
-    // round-trip cost. Loss tail is bounded near -(RISK_PER_TRADE_PCT + cost%);
-    // wins compound at rMultiple × RISK_PER_TRADE_PCT.
-    const tradeReturnPct = rMultipleSized * RISK_PER_TRADE_PCT - ROUND_TRIP_COST_PCT;
+    // Fixed-fractional equity change: RISK_PER_TRADE_PCT × R, minus this row's
+    // REAL round-trip cost. 1R == riskPct of price == RISK_PER_TRADE_PCT% of
+    // equity, so the notional cost converts to R as cost%_notional ÷ riskPct.
+    // Loss tail ≈ -(RISK_PER_TRADE_PCT + costR×RISK); wins compound at R×RISK.
+    const costNotionalPct = roundTripCostNotionalPct(r);
+    const tradeCostR = costNotionalPct / riskPct;
+    costRSum += tradeCostR;
+    costNotionalSum += costNotionalPct;
+    const tradeReturnPct = (rMultipleSized - tradeCostR) * RISK_PER_TRADE_PCT;
     equity *= 1 + tradeReturnPct / 100;
     sizedTrades++;
 
@@ -233,6 +255,8 @@ function computeEquityCurve(
 
   const avgRWin = winRCount > 0 ? +(winRSum / winRCount).toFixed(2) : null;
   const avgRLoss = lossRCount > 0 ? +(lossRSum / lossRCount).toFixed(2) : null;
+  const avgCostR = sizedTrades > 0 ? +(costRSum / sizedTrades).toFixed(3) : null;
+  const avgRoundTripNotionalPct = sizedTrades > 0 ? +(costNotionalSum / sizedTrades).toFixed(3) : 0;
   const winRateFraction = sorted.length > 0 ? wins / sorted.length : 0;
   // Expectancy(R) = p(win) * avgRWin + p(loss) * avgRLoss. It MUST use the same
   // population the R-averages come from — the sized-trade subset (rows with SL).
@@ -264,7 +288,8 @@ function computeEquityCurve(
       expectancyR,
       breakEvenWinRate,
       riskPerTradePct: RISK_PER_TRADE_PCT,
-      roundTripCostPct: ROUND_TRIP_COST_PCT,
+      roundTripCostPct: avgRoundTripNotionalPct,
+      avgCostR,
       hardRCap: HARD_R_CAP,
     },
   };

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -28,6 +28,7 @@ interface EquitySummary {
   breakEvenWinRate: number | null;
   riskPerTradePct?: number;
   roundTripCostPct?: number;
+  avgCostR?: number | null;
   hardRCap?: number;
 }
 
@@ -410,11 +411,11 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
           <p className="text-[11px] text-zinc-600 mt-0.5">
             {isPro
               ? summary
-                ? `Full Pro track record. ${summary.riskPerTradePct}% risk per trade, fixed-fractional${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R per trade` : ''}, after ${summary.roundTripCostPct}% round-trip costs. Resolved against Binance/Yahoo OHLCV.`
+                ? `Full Pro track record. ${summary.riskPerTradePct}% risk per trade, fixed-fractional${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R per trade` : ''}, after real per-symbol round-trip costs (avg ${summary.roundTripCostPct}% ≈ ${summary.avgCostR ?? '—'}R/trade). Resolved against Binance/Yahoo OHLCV.`
                 : 'Full Pro track record. Resolved against Binance/Yahoo OHLCV.'
               : isBroadcast
                 ? summary
-                  ? `Gate-approved broadcast subset — decisions recorded since 2026-06-10. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after ${summary.roundTripCostPct}% round-trip costs.`
+                  ? `Gate-approved broadcast subset — decisions recorded since 2026-06-10. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after real per-symbol round-trip costs (avg ${summary.roundTripCostPct}% ≈ ${summary.avgCostR ?? '—'}R/trade).`
                   : 'Gate-approved broadcast subset — decisions recorded since 2026-06-10.'
                 : summary
                   ? `Free-tier slice — last ${FREE_HISTORY_DAYS} days on free symbols only. Subset of what Pro subscribers see. ${summary.riskPerTradePct}% risk per trade${summary.hardRCap !== undefined ? `, capped at ${summary.hardRCap}R` : ''} after costs.`

--- a/apps/web/lib/stat-hints.ts
+++ b/apps/web/lib/stat-hints.ts
@@ -14,7 +14,7 @@ export const STAT_HINTS = {
   totalReturnLinear:
     'Sum of per-signal % outcomes (raw market price-to-price). Reads "if every signal printed at exact entry/exit, this is what the trades summed to." Not a sized return — see the equity card below for the position-sized version.',
   totalReturnCompounded:
-    'Compounded equity from $10,000 with 1% risk per trade (fixed-fractional sizing), per-trade R-multiple capped at 8R (above P99 of the live distribution — clips only unrealistic single-trade outliers), and 0.02% round-trip costs deducted (2bps blended, realistic for selective execution at a major retail venue). Differs from the raw price-to-price sum at the top of the page.',
+    "Compounded equity from $10,000 with 1% risk per trade (fixed-fractional sizing), per-trade R-multiple capped at 8R (above P99 of the live distribution — clips only unrealistic single-trade outliers), and each trade's REAL recorded round-trip cost deducted (per-symbol: ~0.40% crypto, ~0.10% metals, ~0.04% FX of notional — not a flat blended guess). Differs from the raw price-to-price sum at the top of the page.",
   avgPnl: 'Total return ÷ resolved signals. The average outcome of one trade in this window.',
 
   // ── Win-rate flavours ────────────────────────────────────────

--- a/docs/plans/2026-06-26-real-cost-track-record.md
+++ b/docs/plans/2026-06-26-real-cost-track-record.md
@@ -1,0 +1,56 @@
+# Real per-row cost on the public track record
+
+Date: 2026-06-26
+Branch: worktree-real-cost-track-record (off origin/main)
+
+## Goal
+
+Make the public equity/track-record curve charge each trade's REAL recorded
+round-trip cost instead of a flat 0.02%. The flat constant undercharged crypto
+~20x and made the published curve materially more optimistic than a subscriber's
+true result. This is a compliance/honesty fix, not an edge change.
+
+## Evidence
+
+`scripts/research/recost-segment.ts` run against production signal_history
+(3,796 counted trades, 2026-06-26):
+
+- Real average cost = 0.4466 R/trade = 22.3x the live curve's flat 0.02R charge.
+- Net expectancy = -0.4317 R/trade (gross only +0.0149R). Published curve
+  shows ~-42.5%; honest net is ~-100%.
+- No asset-class x band cell clears its own cost at n>=100. Selectivity does
+  not rescue net edge. (Edge-source pivot tracked separately — see Deferred.)
+
+## Change (one concern: re-cost the public curve honestly)
+
+`apps/web/app/api/signals/equity/route.ts`
+- Replace the flat `ROUND_TRIP_COST_PCT = 0.02` with `roundTripCostNotionalPct(row)`:
+  use `row.costEstimatePct` (migration 051, the real recorded cost), falling back
+  to `costModelFor(pair)` round-trip (2×(fee+slippage)) for pre-051 rows.
+- Per-trade: `tradeCostR = costNotionalPct / riskPct`;
+  `tradeReturnPct = (rMultipleSized - tradeCostR) × RISK_PER_TRADE_PCT`.
+- Summary: `roundTripCostPct` now = realized average notional cost %; add
+  `avgCostR` = realized average per-trade cost in R (the honest impact number).
+
+`apps/web/app/components/equity-curve.tsx`
+- `EquitySummary` interface: add `avgCostR`.
+- Caption: "after real per-symbol round-trip costs (avg X% ≈ Y R/trade)".
+
+`apps/web/lib/stat-hints.ts`
+- `totalReturnCompounded`: drop the false "0.02% round-trip costs (2bps blended)"
+  claim; state the real per-symbol cost.
+
+Out of scope (no drive-by): `TrackRecordClient.tsx` generic copy is being edited
+on the active compliance-copy branch; leave it to avoid a merge conflict.
+
+## Verification
+
+- `npm run typecheck` (web) green.
+- `npx jest apps/web/app/api/signals/equity/route.test.ts` green, including new
+  per-row-cost tests (cheap FX 0.04% vs crypto 0.40% diverge; fallback by class).
+
+## Deferred (separate workstream)
+
+BTC-daily momentum + signal-flip sleeve — the one validated, cost-clearing
+strategy. Needs its own plan doc + forward validation before any public claim.
+Do NOT bundle with this commit.

--- a/scripts/research/recost-segment.ts
+++ b/scripts/research/recost-segment.ts
@@ -1,0 +1,318 @@
+/**
+ * Read-only edge experiment: re-cost the track record at the REAL per-row cost
+ * and segment net expectancy by asset class x band.
+ *
+ * WHY: the live equity curve (apps/web/app/api/signals/equity/route.ts:31,192)
+ * deducts a FLAT 0.02% per trade. The repo already records each row's real
+ * round-trip cost (`cost_estimate_pct`, migration 051) which is ~0.40% on
+ * crypto, ~0.10% on metals, ~0.04% on FX. The flat constant undercharges
+ * crypto ~20x, so the published -42.5% curve is the OPTIMISTIC version. This
+ * script answers the only question that matters before any strategy bet:
+ * at the real cost, does ANY asset-class x band subset clear its own cost?
+ *
+ * It mutates nothing. It only reads signal_history.
+ *
+ * Run (needs a Postgres connection — local checkout has none):
+ *   1. Put DATABASE_PUBLIC_URL=postgresql://... in apps/web/.env.local
+ *      (Railway dashboard -> Postgres -> Variables -> DATABASE_PUBLIC_URL), OR
+ *   2. railway login && railway run -- npx tsx scripts/research/recost-segment.ts
+ *
+ *   npx tsx scripts/research/recost-segment.ts [--days N] [--min-n N] [--json path]
+ */
+import fs from 'fs';
+import path from 'path';
+import { config as loadEnv } from 'dotenv';
+import { Pool } from 'pg';
+
+// Load env from the usual local spots (first hit wins per key). Prefer the
+// PUBLIC Railway URL — the internal DATABASE_URL hostname only resolves inside
+// Railway's network, not from a local machine.
+for (const p of ['apps/web/.env.local', '.env.local', 'apps/web/.env', '.env']) {
+  const abs = path.resolve(process.cwd(), p);
+  if (fs.existsSync(abs)) loadEnv({ path: abs });
+}
+
+// ── Constants mirrored from the live engine (cited, kept inline so this script
+//    runs standalone via tsx without the Next module graph) ──────────────────
+
+/** equity/route.ts:20 — each trade risks 1% of equity. 1R == 1% of equity. */
+const RISK_PER_TRADE_PCT = 1.0;
+/** equity/route.ts:44 — per-trade R cap for sizing (stat R stays uncapped). */
+const HARD_R_CAP = 8;
+/** equity/route.ts:11 — starting paper equity. */
+const STARTING_EQUITY = 10_000;
+/** equity/route.ts:31 — the FLAT cost the public curve uses today (% equity). */
+const PUBLISHED_FLAT_COST_PCT = 0.02;
+/** tier.ts:143 — premium band threshold. */
+const PRO_PREMIUM_MIN_CONFIDENCE = 85;
+
+type AssetClass = 'crypto' | 'metals' | 'fx' | 'stocks/cmdty';
+type Band = 'all' | 'standard' | 'premium';
+
+/**
+ * Round-trip cost as % of NOTIONAL by asset class — fallback for rows where
+ * cost_estimate_pct is null (pre-051). Mirrors backtest-options.ts:32-50
+ * costModelFor: crypto 2*(0.05+0.15)=0.40, metals 2*0.05=0.10, FX 2*0.02=0.04.
+ */
+const FALLBACK_RT_COST_PCT: Record<AssetClass, number> = {
+  crypto: 0.40,
+  metals: 0.10,
+  fx: 0.04,
+  'stocks/cmdty': 0.04, // costModelFor treats non-crypto/non-metal as FX cost
+};
+
+const FX_SET = new Set(['EURUSD', 'GBPUSD', 'USDJPY', 'AUDUSD', 'USDCAD', 'NZDUSD', 'USDCHF']);
+
+function assetClassFor(symbol: string): AssetClass {
+  const s = symbol.toUpperCase();
+  if (/XAU|XAG/.test(s)) return 'metals';
+  if (/BTC|ETH|SOL|BNB|XRP|ADA|DOGE|DOT|LINK|AVAX/.test(s) || /USDT$/.test(s)) return 'crypto';
+  if (FX_SET.has(s)) return 'fx';
+  return 'stocks/cmdty';
+}
+
+interface Row {
+  pair: string;
+  confidence: number;
+  entry_price: number;
+  sl: number | null;
+  cost_estimate_pct: number | null;
+  created_at: string;
+  pnl_pct: number | null;
+  hit: boolean | null;
+  target: string | null;
+}
+
+interface Trade {
+  ts: number;
+  assetClass: AssetClass;
+  confidence: number;
+  /** sized (capped) R-multiple */
+  rSized: number;
+  /** raw (uncapped) R-multiple — for honest gross stats */
+  rRaw: number;
+  /** real round-trip cost expressed in R (cost%_notional / riskPct) */
+  costR: number;
+  isWin: boolean;
+}
+
+interface CellStats {
+  n: number;
+  winRatePct: number;
+  grossExpectancyR: number;
+  netExpectancyR: number;
+  avgCostR: number;
+  netReturnPct: number;
+  maxDrawdownPct: number;
+  conclusive: boolean;
+}
+
+function connString(): string {
+  const s = process.env.DATABASE_PUBLIC_URL || process.env.DATABASE_URL;
+  if (!s) {
+    console.error(
+      'No DATABASE_PUBLIC_URL or DATABASE_URL set.\n' +
+        'Add DATABASE_PUBLIC_URL=postgresql://... to apps/web/.env.local (Railway -> Postgres -> Variables),\n' +
+        'or run via: railway login && railway run -- npx tsx scripts/research/recost-segment.ts',
+    );
+    process.exit(1);
+  }
+  return s;
+}
+
+function isLocal(cs: string): boolean {
+  return /@(localhost|127\.0\.0\.1)[:/]/.test(cs);
+}
+
+/** Mirror lib/signal-history.ts isCountedResolved for a raw outcome row. */
+function isCounted(r: Row): boolean {
+  if (r.pnl_pct === null || r.hit === null) return false;
+  // auto-expire placeholder: pnl 0 and not a hit
+  if (r.pnl_pct === 0 && !r.hit) return false;
+  if (r.target === 'expired') return false;
+  return true;
+}
+
+function toTrade(r: Row): Trade | null {
+  if (!isCounted(r)) return null;
+  if (r.sl === null || r.entry_price <= 0) return null;
+  const riskPct = (Math.abs(r.entry_price - r.sl) / r.entry_price) * 100;
+  if (riskPct <= 0) return null;
+
+  const rRaw = (r.pnl_pct as number) / riskPct;
+  const rSized = Math.max(-HARD_R_CAP, Math.min(HARD_R_CAP, rRaw));
+  const assetClass = assetClassFor(r.pair);
+  const costPctNotional =
+    r.cost_estimate_pct != null && r.cost_estimate_pct > 0
+      ? r.cost_estimate_pct
+      : FALLBACK_RT_COST_PCT[assetClass];
+  // cost in R: 1R == riskPct of price == 1% of equity. cost%_notional / riskPct
+  // converts a notional cost into the same R units the equity path compounds.
+  const costR = costPctNotional / riskPct;
+
+  return {
+    ts: new Date(r.created_at).getTime(),
+    assetClass,
+    confidence: Number(r.confidence),
+    rSized,
+    rRaw,
+    costR,
+    isWin: !!r.hit,
+  };
+}
+
+function bandOf(t: Trade, band: Band): boolean {
+  if (band === 'all') return true;
+  if (band === 'premium') return t.confidence >= PRO_PREMIUM_MIN_CONFIDENCE;
+  return t.confidence < PRO_PREMIUM_MIN_CONFIDENCE;
+}
+
+function computeCell(trades: Trade[], minN: number): CellStats {
+  const n = trades.length;
+  if (n === 0) {
+    return { n: 0, winRatePct: 0, grossExpectancyR: 0, netExpectancyR: 0, avgCostR: 0, netReturnPct: 0, maxDrawdownPct: 0, conclusive: false };
+  }
+  const sorted = [...trades].sort((a, b) => a.ts - b.ts);
+  let wins = 0;
+  let grossSum = 0;
+  let netSum = 0;
+  let costSum = 0;
+  let equity = STARTING_EQUITY;
+  let peak = STARTING_EQUITY;
+  let maxDd = 0;
+
+  for (const t of sorted) {
+    if (t.isWin) wins++;
+    grossSum += t.rRaw;
+    // net R uses the SIZED R (what the equity path actually compounds) minus cost
+    const netR = t.rSized - t.costR;
+    netSum += netR;
+    costSum += t.costR;
+    // tradeReturnPct (% equity) == netR * RISK_PER_TRADE_PCT (1R == 1% equity)
+    const tradeReturnPct = netR * RISK_PER_TRADE_PCT;
+    equity *= 1 + tradeReturnPct / 100;
+    if (equity > peak) peak = equity;
+    const dd = peak > 0 ? ((peak - equity) / peak) * 100 : 0;
+    if (dd > maxDd) maxDd = dd;
+  }
+
+  return {
+    n,
+    winRatePct: +((wins / n) * 100).toFixed(1),
+    grossExpectancyR: +(grossSum / n).toFixed(4),
+    netExpectancyR: +(netSum / n).toFixed(4),
+    avgCostR: +(costSum / n).toFixed(4),
+    netReturnPct: +((equity / STARTING_EQUITY - 1) * 100).toFixed(2),
+    maxDrawdownPct: +maxDd.toFixed(2),
+    conclusive: n >= minN,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const getArg = (name: string): string | undefined => {
+    const i = args.indexOf(name);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const days = getArg('--days') ? Number(getArg('--days')) : null;
+  const minN = getArg('--min-n') ? Number(getArg('--min-n')) : 100;
+  const jsonPath = getArg('--json');
+
+  const cs = connString();
+  const pool = new Pool({
+    connectionString: cs,
+    ssl: isLocal(cs) ? false : { rejectUnauthorized: false },
+    connectionTimeoutMillis: 10_000,
+    max: 4,
+  });
+
+  const where = ['is_simulated = FALSE', 'outcome_24h IS NOT NULL', 'COALESCE(gate_blocked, FALSE) = FALSE'];
+  if (days) where.push(`created_at >= NOW() - INTERVAL '${days} days'`);
+  const sql = `
+    SELECT pair, confidence, entry_price, sl, cost_estimate_pct, created_at,
+           (outcome_24h->>'pnlPct')::float  AS pnl_pct,
+           (outcome_24h->>'hit')::boolean   AS hit,
+           (outcome_24h->>'target')         AS target
+    FROM signal_history
+    WHERE ${where.join(' AND ')}
+    ORDER BY created_at ASC`;
+
+  const { rows } = await pool.query<Row>(sql);
+  await pool.end();
+
+  const trades: Trade[] = [];
+  let droppedNoSl = 0;
+  let droppedNotCounted = 0;
+  for (const r of rows) {
+    if (!isCounted(r)) { droppedNotCounted++; continue; }
+    const t = toTrade(r);
+    if (!t) { droppedNoSl++; continue; }
+    trades.push(t);
+  }
+
+  const classes: AssetClass[] = ['crypto', 'metals', 'fx', 'stocks/cmdty'];
+  const bands: Band[] = ['all', 'standard', 'premium'];
+
+  // Headline: all-symbols re-costed vs published flat-2bps, to quantify the undercharge.
+  const allCell = computeCell(trades, minN);
+  const publishedEquivCostR = PUBLISHED_FLAT_COST_PCT / RISK_PER_TRADE_PCT; // 0.02R
+  const realAvgCostR = allCell.avgCostR;
+
+  console.log('\n=== RE-COST + SEGMENT (read-only) ===');
+  console.log(`rows fetched: ${rows.length} | counted trades: ${trades.length} | dropped (not counted): ${droppedNotCounted} | dropped (no SL / unsized): ${droppedNoSl}`);
+  console.log(`window: ${days ? days + ' days' : 'all history'} | conclusive threshold: n >= ${minN}`);
+  console.log(`\nCost reality check (ALL symbols, ALL band):`);
+  console.log(`  published flat cost  : ${publishedEquivCostR.toFixed(4)} R/trade  (0.02% equity)`);
+  console.log(`  REAL avg cost        : ${realAvgCostR.toFixed(4)} R/trade  (${(realAvgCostR / publishedEquivCostR).toFixed(1)}x the published charge)`);
+  console.log(`  gross expectancy     : ${allCell.grossExpectancyR.toFixed(4)} R/trade`);
+  console.log(`  NET expectancy       : ${allCell.netExpectancyR.toFixed(4)} R/trade  ${allCell.netExpectancyR > 0 ? 'POSITIVE' : 'negative'}`);
+  console.log(`  net return / maxDD   : ${allCell.netReturnPct}% / -${allCell.maxDrawdownPct}%`);
+
+  console.log(`\nPer asset-class x band (net expectancy R after REAL cost):`);
+  const header = ['class', 'band', 'n', 'win%', 'grossR', 'NETr', 'costR', 'netRet%', 'maxDD%', 'flag'];
+  console.log(header.map((h, i) => h.padStart(i < 2 ? 13 : 9)).join(' '));
+
+  const results: Array<{ assetClass: AssetClass; band: Band } & CellStats> = [];
+  for (const c of classes) {
+    for (const b of bands) {
+      const cell = computeCell(trades.filter(t => t.assetClass === c && bandOf(t, b)), minN);
+      results.push({ assetClass: c, band: b, ...cell });
+      const flag = cell.n === 0 ? '—' : !cell.conclusive ? 'thin' : cell.netExpectancyR > 0 ? 'CLEARS COST' : 'net-neg';
+      const cells = [
+        c.padStart(13),
+        b.padStart(13),
+        String(cell.n).padStart(9),
+        String(cell.winRatePct).padStart(9),
+        cell.grossExpectancyR.toFixed(3).padStart(9),
+        cell.netExpectancyR.toFixed(3).padStart(9),
+        cell.avgCostR.toFixed(3).padStart(9),
+        String(cell.netReturnPct).padStart(9),
+        String(cell.maxDrawdownPct).padStart(9),
+        flag.padStart(9),
+      ];
+      console.log(cells.join(' '));
+    }
+  }
+
+  const survivors = results.filter(r => r.conclusive && r.netExpectancyR > 0);
+  console.log(`\n=== VERDICT ===`);
+  if (survivors.length === 0) {
+    console.log('No asset-class x band cell clears its own cost at n >= ' + minN + '.');
+    console.log('Selectivity does not rescue net edge at real cost — escalate to a different edge source.');
+  } else {
+    console.log('Subsets that CLEAR their real cost (net-positive, n >= ' + minN + '):');
+    for (const s of survivors.sort((a, b) => b.netExpectancyR - a.netExpectancyR)) {
+      console.log(`  ${s.assetClass}/${s.band}: net ${s.netExpectancyR.toFixed(4)} R/trade, n=${s.n}, win ${s.winRatePct}%, netRet ${s.netReturnPct}%`);
+    }
+  }
+
+  if (jsonPath) {
+    fs.writeFileSync(jsonPath, JSON.stringify({ window: days, minN, all: allCell, cells: results }, null, 2));
+    console.log(`\nWrote ${jsonPath}`);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What
Replace the flat 0.02% round-trip cost on the public equity / track-record curve with each row REAL recorded round-trip cost (`cost_estimate_pct`, migration 051; fallback `costModelFor` by asset class for pre-051 rows).

## Why
Production re-cost (`scripts/research/recost-segment.ts`, 3,796 counted trades, 2026-06-26):
- Real avg cost 0.4466R/trade = 22.3x the flat 0.02R charge.
- Net expectancy -0.43R/trade (gross +0.0149R). The published -42.5% understated the true loss by ~an order of magnitude (honest net is roughly -100%).
- No asset-class x band cell clears its own cost at n>=100 — selectivity does not rescue net edge.

Compliance/honesty fix, not an edge change. The flat constant made the public track record materially more optimistic than the real subscriber result.

## Changes
- `apps/web/app/api/signals/equity/route.ts`: per-row cost (`roundTripCostNotionalPct`); `tradeCostR = cost_notional / riskPct`; `summary.roundTripCostPct` now realized avg notional %, add `summary.avgCostR`.
- `apps/web/app/components/equity-curve.tsx`: caption shows "after real per-symbol round-trip costs (avg X% = Y R/trade)".
- `apps/web/lib/stat-hints.ts`: drop the false flat-2bps claim.
- `scripts/research/recost-segment.ts`: the read-only diagnostic behind this change.
- `docs/plans/2026-06-26-real-cost-track-record.md`.

## Out of scope
- `TrackRecordClient.tsx` generic copy (active on the compliance-copy branch; avoided to prevent a merge conflict).
- BTC-daily momentum sleeve (separate workstream; the only validated cost-clearing edge).

## Test plan
- [x] `apps/web` tsc --noEmit exit 0
- [x] equity route jest 5/5 (incl. new per-row-cost test: FX 0.04% vs crypto 0.40% diverge; fallback by class)
- [ ] Visual check of /track-record equity card caption after deploy (expect honest avg cost; curve correctly uglier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
