### PR TITLE
docs(research): kill BTC daily-momentum sleeve — fails fresh reproduction

### DIFF
--- a/docs/plans/2026-06-26-btc-daily-momentum-sleeve.md
+++ b/docs/plans/2026-06-26-btc-daily-momentum-sleeve.md
@@ -1,0 +1,115 @@
+# BTC daily-momentum sleeve — pre-registration + plan
+
+Date: 2026-06-26
+Branch: worktree-btc-daily-sleeve (off main @ df8adeb4)
+Status: Phase 0 (pre-registration). Committed BEFORE any fresh-fold re-run so the
+symbol/spec/gate cannot be cherry-picked after seeing results.
+
+## Why this exists
+
+After real costs the firehose has no net edge ([[engine-no-net-edge]]). The ONE
+strategy in the research corpus that clears real cost is BTCUSD daily 28-day
+time-series momentum with a signal-flip exit:
++0.0198R net, PF 1.62, Sharpe 1.35, maxDD 5.97%, n=100 over ~6yr
+(`daily-momentum-validation` f4.json, `results.BTCUSD.full['signal-flip'].costed`).
+
+This is MARGINAL and post-hoc. BTC is the single survivor of a 10-way symbol
+search; the broad +24.9% aggregate is fluke-driven (SOL +189%, AVAX +102%
+launch-era; ex-fluke mean −5.25%, fold stability 0.375). BTC's own folds are
+only 2/4 positive (fold1 +16.7%, fold4 +1.7% up; fold2 −4.7%, fold3 −4.3% down).
+Win rate is 23% — all edge is right-tail. Therefore the backtest CANNOT justify a
+public claim. Only a live forward record can. This plan builds a shadow harness
+that runs the sleeve live, records it privately, and surfaces it publicly ONLY
+after a pre-frozen forward gate clears (~18–24 months at ~16 crosses/yr; it may
+never clear). The harness is reusable for vetting any future strategy.
+
+## FROZEN sleeve spec (v1) — do not change without a new dated pre-registration
+
+- Symbol universe: `{ BTCUSD }` ONLY. DOT is the sole future basket candidate
+  (validated set, not a launch-era fluke) but is explicitly OUT of v1 — adding it
+  now is a second post-hoc pick.
+- Entry: `dailyMomentumEntry` — 28-day trailing-SMA time-series momentum, fires
+  only on a fresh momentum cross (`packages/strategies/src/entry/daily-momentum.ts`).
+- Exit: `signal-flip` — ride to the opposite-direction cross; SL floor at
+  ATR(14)×2.5; NO take-profit (`run-backtest.ts` signal-flip path).
+- Timeframe: D1, decided on CLOSED bars only (drop the last possibly-open bar).
+- Cost model: `CRYPTO_PERP_COSTS` (fee 0.05%/side + slippage 0.15%/side +
+  funding 0.01%/8h; `backtest-options.ts:32-36`).
+- Sizing: 1% risk/trade fixed-fractional, `HARD_R_CAP=8`, real per-row cost —
+  identical to the live equity route shipped in #136.
+
+## FROZEN forward gate — graded ONLY on the live shadow record (+ sealed slice), never in-sample folds
+
+All must hold before ANY public surfacing:
+1. Sample: n ≥ 30 forward signal-flip round trips (`THIN_CELL_MIN_TRADES=30`).
+2. Window: ≥ 4 weeks of live shadow evidence (so n≥30 cannot cluster in one tick).
+3. Net edge: forward per-trade expectancy > 0 after REAL per-row cost.
+4. Drawdown: forward maxDD ≤ 6.0% (within the backtest envelope).
+5. Stability: positive expectancy on BOTH the live shadow record AND the sealed
+   held-out slice (two independent out-of-sample reads agreeing).
+
+Until all five hold, the sleeve lives only in the private shadow store and NO
+public claim, badge, or curve is made.
+
+## Validation approach (chosen): live-forward-only
+
+The full 6-year backfill is the in-sample reference and a determinism/drift gate
+(must reproduce expectancy 0.019771, PF 1.62, n=100 byte-for-byte). The real
+out-of-sample test is the LIVE shadow record from day one — the recent folds are
+thin and flat, so a fresh sealed tail would be weak; live-forward is the honest
+test. An `--as-of` sealed-slice capability is added for a secondary read, but the
+governing OOS evidence is the live shadow record.
+
+## Phases (one commit per layer; no public surface touched until Phase 5)
+
+- Phase 0 — pre-register (THIS doc). No code.
+- Phase 1 — validation: add `--as-of <ISO>` held-out slice to the validator;
+  backfill BTC D1; re-run; diff the BTC signal-flip cell byte-for-byte vs the
+  committed result (drift gate); run the validator unit test.
+  Files: `scripts/research/daily-momentum-validation.ts`,
+  `scripts/research/__tests__/daily-momentum-validation.test.ts`.
+- Phase 2 — strategy wiring: new TS daily cron route + GitHub workflow
+  (`5 0 * * *`, after D1 close) reusing `requireCronAuth`+`recordSignalRun`;
+  fetch `getOHLCV('BTCUSD','D1')`, drop the open bar, run the entry; build a
+  persistent position-state store for the signal-flip hold (none exists today).
+  NOT a preset (preset dispatch exits on ATR geometry per-tick, can't model
+  signal-flip). NOT the Python scanner (intraday-only). TS only.
+  Files: `apps/web/app/api/cron/daily-momentum/route.ts`,
+  `.github/workflows/daily-momentum.yml`, `apps/web/lib/daily-momentum-position.ts`.
+- Phase 3 — shadow recording: clone the router-shadow mode gate
+  (`TRADECLAW_DAILY_MOMENTUM_MODE`, default `shadow`); a dedicated
+  `shadow_signals` Postgres table keyed `strategyId='daily-momentum-btc'`;
+  a flip-exit resolver off the run-backtest signal-flip path. NEVER writes
+  `signal_history` (which has no strategy filter in `getResolvedSlice` →
+  anything there leaks straight onto the public curve). Fire-and-forget.
+  Files: `apps/web/lib/daily-momentum-shadow.ts`,
+  `apps/web/lib/daily-momentum-shadow-log.ts`,
+  `apps/web/migrations/0NN_shadow_signals.sql`.
+- Phase 4 — measurement: private authed net-R view over `shadow_signals` using
+  the live equity math; public scopes still exclude it.
+- Phase 5 — public surfacing (GATED, operator-flipped): ONLY after the forward
+  gate clears; under a DEDICATED scope (not folded into scope=pro, which would
+  move the headline numbers). Add `daily-momentum` to the StrategyId union /
+  router / PRO_STRATEGIES at this point.
+
+## Risks (kept visible, not hidden)
+
+- Overfit/survivorship: BTC is the post-hoc winner of a 10-way search.
+- Fold stability 2/4; the headline is carried by 2 of 6 years; recent folds flat.
+- 23% win rate — a choppy BTC year produces many small losses and no big trend;
+  the live curve can look nothing like the backtest.
+- ~18–24 months to n≥30; the claim is earned slowly or not at all.
+- Signal-flip is a backtest abstraction; the live position-state store + closed-
+  bar guard must be correct or live parity breaks (lookahead).
+- Funding is a sign-agnostic upper bound; a multi-day short hold in a positive-
+  funding regime can flip net edge — re-cost at the real venue before grading.
+
+## Do not do
+
+- Do NOT register the sleeve as a preset (can't honor signal-flip).
+- Do NOT edit the Python scanner (intraday-only, wrong engine).
+- Do NOT write the sleeve to `signal_history` during shadow (leaks to public).
+- Do NOT re-run scoped to `--symbols BTCUSD` before this doc is committed.
+- Do NOT reuse the 4h/24h TP/SL resolver for the multi-week flip hold.
+- Do NOT let `mode=active` silently surface; go-live is an explicit operator step.
+- Do NOT add DOT or any second symbol to v1.

--- a/docs/plans/2026-06-26-btc-daily-momentum-sleeve.md
+++ b/docs/plans/2026-06-26-btc-daily-momentum-sleeve.md
@@ -2,8 +2,42 @@
 
 Date: 2026-06-26
 Branch: worktree-btc-daily-sleeve (off main @ df8adeb4)
-Status: Phase 0 (pre-registration). Committed BEFORE any fresh-fold re-run so the
-symbol/spec/gate cannot be cherry-picked after seeing results.
+Status: KILLED at Phase 1 (2026-06-26). The pre-registered drift/reproduction
+check FAILED — see "Phase 1 outcome" below. The sleeve is NOT built. This doc is
+retained as the honest decision record. Phase 0 pre-registration was committed
+BEFORE the re-run, so the kill is a clean, non-cherry-picked result.
+
+## Phase 1 outcome: KILLED — the edge does not reproduce
+
+A fresh 6-year Binance BTC D1 backfill (2020-06-26 → 2026-06-25, 2191 bars) re-run
+through the SAME validator + config inverts the committed result on a ~2-week
+window shift:
+
+| metric (signal-flip, costed) | committed 2026-06-12 | fresh 2026-06-26 |
+|---|---|---|
+| window | 2020-06-12 → 2026-06-10 | 2020-06-26 → 2026-06-25 |
+| trades | 100 | 99 |
+| win rate | 23% | 18.2% |
+| total return | +20.58% | −8.70% |
+| expectancy | +0.0198 | −0.0090 |
+| profit factor | 1.62 | 0.67 |
+| Sharpe | +1.35 | −1.28 |
+| max drawdown | 5.97% | 12.68% |
+
+VERDICT: NEGATIVE across all three exit configs. Decisively: even at ZERO cost the
+fresh window is negative (totalReturn −2.05%, Sharpe −0.25) — not a cost story; the
+raw 28d momentum signal itself has no edge on current BTC data. A real edge does
+not flip from Sharpe +1.35 to −1.28 on a two-week window shift; the committed
++0.0198R was a window-fragile artifact carried by a few right-tail trades (23% win
+rate). This confirms the overfit/survivorship risk this spec flagged.
+
+Conclusion: there is NO deployable single-asset timing edge — not even the one
+candidate that appeared to clear costs. The shadow harness is NOT built. Honest
+paths remaining: a funding-carry pivot (structurally different; failed its own gate,
+needs a maker-cost re-spec) or repositioning the product off raw P&L.
+
+Fresh evidence: docs/research/experiments/daily-momentum-validation-BTCUSD-D1-f4.json
+(this run). Phases 1-5 below are retained for context but NOT executed.
 
 ## Why this exists
 

--- a/docs/research/experiments/daily-momentum-validation-BTCUSD-D1-f4.json
+++ b/docs/research/experiments/daily-momentum-validation-BTCUSD-D1-f4.json
@@ -1,0 +1,573 @@
+{
+  "meta": {
+    "runAt": "2026-06-26T08:53:53.999Z"
+  },
+  "spec": {
+    "strategy": "daily-momentum",
+    "entryModule": "dailyMomentumEntry",
+    "lookback": 28,
+    "timeframe": "D1",
+    "folds": 4,
+    "barHours": 24,
+    "costs": {
+      "feePctPerSide": 0.05,
+      "slippagePctPerSide": 0.15,
+      "fundingPctPer8h": 0.01
+    },
+    "configs": [
+      {
+        "id": "signal-flip",
+        "label": "signal-flip (ride to opposite cross, SL floor)",
+        "exitMode": "signal-flip",
+        "geometry": {
+          "mode": "atr",
+          "period": 14,
+          "slMult": 2.5,
+          "tpRMultiple": 2
+        }
+      },
+      {
+        "id": "geometry-2R",
+        "label": "geometry exit @ 2R (LIVE_GEOMETRY)",
+        "exitMode": "geometry",
+        "geometry": {
+          "mode": "atr",
+          "period": 14,
+          "slMult": 2.5,
+          "tpRMultiple": 2
+        }
+      },
+      {
+        "id": "geometry-4R",
+        "label": "geometry exit @ 4R (wide target)",
+        "exitMode": "geometry",
+        "geometry": {
+          "mode": "atr",
+          "period": 14,
+          "slMult": 2.5,
+          "tpRMultiple": 4
+        }
+      }
+    ],
+    "symbols": [
+      "BTCUSD"
+    ],
+    "deployableBar": {
+      "meanCostedReturnAndExpectancy": "> 0",
+      "symbolsPositiveAndAdequate": "≥ majority (> half), each with ≥ 30 trades",
+      "foldStability": "> 50% of (symbol × fold) cells positive",
+      "thinFloor": 30
+    },
+    "perSymbolWindow": {
+      "BTCUSD": {
+        "candleCount": 2191,
+        "firstBar": "2020-06-26T00:00:00.000Z",
+        "lastBar": "2026-06-25T00:00:00.000Z"
+      }
+    },
+    "caveats": [
+      "folds are contiguous sub-periods (stability inspection, not walk-forward optimization); daily-momentum has NO fitted parameters, so this is across-time stability, not in-sample/out-of-sample tuning",
+      "per-fold indicator warmup restarts at the fold boundary (the 28-bar momentum lookback + the 14-bar ATR), and a position open at fold end force-closes at the last bar — short folds therefore carry fewer trades than the full range",
+      "cost model = crypto perp (fee 0.05%/side + slippage 0.15%/side + funding 0.01%/8h); funding is a sign-agnostic upper bound, so a directional carry could be cheaper than modeled (costs are conservative, not optimistic)",
+      "THIN CELLS: any config×symbol cell with fewer than 30 trades is flagged ⚠THIN — below that count the standard error of the mean dominates, so the cell's return/expectancy is insufficient evidence",
+      "FOLD-STABILITY THIN WEAKNESS: foldStability is the fraction of (symbol × fold) cells with positive costed return, and it counts THIN fold cells (< 30 trades) as if adequate — a positive-but-underpowered fold inflates it. aggregate.<config>.foldCellsThin / foldCellsTotal exposes how many of the cells behind the number were thin, so the stability read can be discounted accordingly (the gate threshold is unchanged — this is a transparency field, not a new gate)",
+      "INFLATING FLUKES: aggregate.<config>.flukeSymbols lists symbols whose extreme positive costed return (≥ +100% absolute, or ≥ 5× the cross-symbol median) inflate meanCostedReturn; meanCostedReturnExFlukes is the mean with them removed. A positive mean driven by one or two flukes is why a config can be MARGINAL (not positive) — read the ex-flukes mean alongside the headline mean",
+      "signal-flip exit rides the trend to the opposite-direction momentum cross with the ATR SL as a floor and NO take-profit (tpRMultiple is ignored in this mode); geometry-2R/4R use the ATR TP/SL ladder",
+      "totalReturn is the compounded fractional return at flat 10%-of-balance allocation; expectancy is the per-trade mean pnlPct (position-size-neutral) — the deployable bar reads BOTH",
+      "lookback is the specced 28-day default — NO tuning; a one-off lookback sensitivity, if reported, is labeled as such and is not the headline"
+    ]
+  },
+  "aggregate": {
+    "signal-flip": {
+      "config": "signal-flip",
+      "symbolsTotal": 1,
+      "symbolsPositiveAndAdequate": 0,
+      "symbolsPositiveRaw": 0,
+      "symbolsThin": 0,
+      "meanCostedReturn": -0.087005,
+      "meanZeroCostReturn": -0.020481,
+      "meanExpectancy": -0.008951,
+      "meanFrictionDrag": 0.066524,
+      "meanTrades": 99,
+      "foldStability": 0.5,
+      "foldCellsThin": 4,
+      "foldCellsTotal": 4,
+      "flukeSymbols": [],
+      "meanCostedReturnExFlukes": -0.087005,
+      "verdict": "NEGATIVE",
+      "verdictReasons": [
+        "mean cost-adjusted return -8.70% / expectancy -0.895% not both > 0",
+        "only 0/1 symbols positive-and-adequate (need ≥1)",
+        "fold stability 50% ≤ 50% (not robust across time)"
+      ],
+      "label": "signal-flip (ride to opposite cross, SL floor)"
+    },
+    "geometry-2R": {
+      "config": "geometry-2R",
+      "symbolsTotal": 1,
+      "symbolsPositiveAndAdequate": 0,
+      "symbolsPositiveRaw": 0,
+      "symbolsThin": 0,
+      "meanCostedReturn": -0.148705,
+      "meanZeroCostReturn": -0.100733,
+      "meanExpectancy": -0.041951,
+      "meanFrictionDrag": 0.047972,
+      "meanTrades": 37,
+      "foldStability": 0.25,
+      "foldCellsThin": 4,
+      "foldCellsTotal": 4,
+      "flukeSymbols": [],
+      "meanCostedReturnExFlukes": -0.148705,
+      "verdict": "NEGATIVE",
+      "verdictReasons": [
+        "mean cost-adjusted return -14.87% / expectancy -4.195% not both > 0",
+        "only 0/1 symbols positive-and-adequate (need ≥1)",
+        "fold stability 25% ≤ 50% (not robust across time)"
+      ],
+      "label": "geometry exit @ 2R (LIVE_GEOMETRY)"
+    },
+    "geometry-4R": {
+      "config": "geometry-4R",
+      "symbolsTotal": 1,
+      "symbolsPositiveAndAdequate": 0,
+      "symbolsPositiveRaw": 0,
+      "symbolsThin": 1,
+      "meanCostedReturn": -0.213705,
+      "meanZeroCostReturn": -0.167173,
+      "meanExpectancy": -0.090643,
+      "meanFrictionDrag": 0.046532,
+      "meanTrades": 26,
+      "foldStability": 0,
+      "foldCellsThin": 4,
+      "foldCellsTotal": 4,
+      "flukeSymbols": [],
+      "meanCostedReturnExFlukes": -0.213705,
+      "verdict": "NEGATIVE",
+      "verdictReasons": [
+        "mean cost-adjusted return -21.37% / expectancy -9.064% not both > 0",
+        "only 0/1 symbols positive-and-adequate (need ≥1)",
+        "mean 26 trades/symbol below the 30-trade floor",
+        "fold stability 0% ≤ 50% (not robust across time)"
+      ],
+      "label": "geometry exit @ 4R (wide target)"
+    }
+  },
+  "results": {
+    "BTCUSD": {
+      "candleCount": 2191,
+      "firstBar": "2020-06-26T00:00:00.000Z",
+      "lastBar": "2026-06-25T00:00:00.000Z",
+      "full": {
+        "signal-flip": {
+          "costed": {
+            "totalTrades": 99,
+            "winRate": 0.1818,
+            "totalReturn": -0.087005,
+            "expectancy": -0.008951,
+            "profitFactor": 0.673,
+            "maxDrawdown": 0.1268,
+            "sharpeRatio": -1.282,
+            "avgCostPct": 0.7121,
+            "reason": null
+          },
+          "zeroCost": {
+            "totalTrades": 99,
+            "winRate": 0.2121,
+            "totalReturn": -0.020481,
+            "expectancy": -0.00183,
+            "profitFactor": 0.912,
+            "maxDrawdown": 0.0831,
+            "sharpeRatio": -0.251,
+            "avgCostPct": 0,
+            "reason": null
+          },
+          "frictionDrag": 0.066524
+        },
+        "geometry-2R": {
+          "costed": {
+            "totalTrades": 37,
+            "winRate": 0.2973,
+            "totalReturn": -0.148705,
+            "expectancy": -0.041951,
+            "profitFactor": 0.567,
+            "maxDrawdown": 0.1688,
+            "sharpeRatio": -1.487,
+            "avgCostPct": 1.48,
+            "reason": null
+          },
+          "zeroCost": {
+            "totalTrades": 37,
+            "winRate": 0.2973,
+            "totalReturn": -0.100733,
+            "expectancy": -0.027151,
+            "profitFactor": 0.683,
+            "maxDrawdown": 0.1415,
+            "sharpeRatio": -0.95,
+            "avgCostPct": 0,
+            "reason": null
+          },
+          "frictionDrag": 0.047972
+        },
+        "geometry-4R": {
+          "costed": {
+            "totalTrades": 26,
+            "winRate": 0.1154,
+            "totalReturn": -0.213705,
+            "expectancy": -0.090643,
+            "profitFactor": 0.287,
+            "maxDrawdown": 0.2293,
+            "sharpeRatio": -2.745,
+            "avgCostPct": 2.2035,
+            "reason": null
+          },
+          "zeroCost": {
+            "totalTrades": 26,
+            "winRate": 0.1154,
+            "totalReturn": -0.167173,
+            "expectancy": -0.068608,
+            "profitFactor": 0.37,
+            "maxDrawdown": 0.1894,
+            "sharpeRatio": -2.003,
+            "avgCostPct": 0,
+            "reason": null
+          },
+          "frictionDrag": 0.046532
+        }
+      },
+      "folds": [
+        {
+          "label": "fold1",
+          "from": "2020-06-26",
+          "to": "2021-12-24",
+          "candleCount": 547,
+          "byConfig": {
+            "signal-flip": {
+              "costed": {
+                "totalTrades": 24,
+                "winRate": 0.1667,
+                "totalReturn": -0.047409,
+                "expectancy": -0.019984,
+                "profitFactor": 0.432,
+                "maxDrawdown": 0.0736,
+                "sharpeRatio": -1.432,
+                "avgCostPct": 0.6388,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 24,
+                "winRate": 0.1667,
+                "totalReturn": -0.032703,
+                "expectancy": -0.013597,
+                "profitFactor": 0.557,
+                "maxDrawdown": 0.0654,
+                "sharpeRatio": -0.943,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.014706
+            },
+            "geometry-2R": {
+              "costed": {
+                "totalTrades": 11,
+                "winRate": 0.2727,
+                "totalReturn": -0.055165,
+                "expectancy": -0.048868,
+                "profitFactor": 0.591,
+                "maxDrawdown": 0.1017,
+                "sharpeRatio": -0.711,
+                "avgCostPct": 1.0873,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 11,
+                "winRate": 0.2727,
+                "totalReturn": -0.043799,
+                "expectancy": -0.037995,
+                "profitFactor": 0.658,
+                "maxDrawdown": 0.0968,
+                "sharpeRatio": -0.547,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.011366
+            },
+            "geometry-4R": {
+              "costed": {
+                "totalTrades": 7,
+                "winRate": 0.1429,
+                "totalReturn": -0.107351,
+                "expectancy": -0.159892,
+                "profitFactor": 0.102,
+                "maxDrawdown": 0.1195,
+                "sharpeRatio": -2.958,
+                "avgCostPct": 1.8229,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 7,
+                "winRate": 0.1429,
+                "totalReturn": -0.095725,
+                "expectancy": -0.141664,
+                "profitFactor": 0.125,
+                "maxDrawdown": 0.1094,
+                "sharpeRatio": -2.59,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.011626
+            }
+          }
+        },
+        {
+          "label": "fold2",
+          "from": "2021-12-25",
+          "to": "2023-06-24",
+          "candleCount": 547,
+          "byConfig": {
+            "signal-flip": {
+              "costed": {
+                "totalTrades": 28,
+                "winRate": 0.1786,
+                "totalReturn": -0.034875,
+                "expectancy": -0.012346,
+                "profitFactor": 0.653,
+                "maxDrawdown": 0.053,
+                "sharpeRatio": -0.809,
+                "avgCostPct": 0.6421,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 28,
+                "winRate": 0.1786,
+                "totalReturn": -0.017401,
+                "expectancy": -0.005925,
+                "profitFactor": 0.806,
+                "maxDrawdown": 0.0438,
+                "sharpeRatio": -0.377,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.017474
+            },
+            "geometry-2R": {
+              "costed": {
+                "totalTrades": 9,
+                "winRate": 0.1111,
+                "totalReturn": -0.092408,
+                "expectancy": -0.106798,
+                "profitFactor": 0.107,
+                "maxDrawdown": 0.0924,
+                "sharpeRatio": -3.789,
+                "avgCostPct": 1.56,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 9,
+                "winRate": 0.1111,
+                "totalReturn": -0.079435,
+                "expectancy": -0.091198,
+                "profitFactor": 0.137,
+                "maxDrawdown": 0.0794,
+                "sharpeRatio": -3.292,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.012973
+            },
+            "geometry-4R": {
+              "costed": {
+                "totalTrades": 9,
+                "winRate": 0.1111,
+                "totalReturn": -0.080455,
+                "expectancy": -0.091989,
+                "profitFactor": 0.225,
+                "maxDrawdown": 0.0805,
+                "sharpeRatio": -2.209,
+                "avgCostPct": 1.5833,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 9,
+                "winRate": 0.1111,
+                "totalReturn": -0.067139,
+                "expectancy": -0.076156,
+                "profitFactor": 0.274,
+                "maxDrawdown": 0.0671,
+                "sharpeRatio": -1.833,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.013316
+            }
+          }
+        },
+        {
+          "label": "fold3",
+          "from": "2023-06-25",
+          "to": "2024-12-22",
+          "candleCount": 547,
+          "byConfig": {
+            "signal-flip": {
+              "costed": {
+                "totalTrades": 20,
+                "winRate": 0.25,
+                "totalReturn": 0.105737,
+                "expectancy": 0.052163,
+                "profitFactor": 3.069,
+                "maxDrawdown": 0.0344,
+                "sharpeRatio": 1.218,
+                "avgCostPct": 0.8755,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 20,
+                "winRate": 0.35,
+                "totalReturn": 0.124915,
+                "expectancy": 0.060918,
+                "profitFactor": 3.903,
+                "maxDrawdown": 0.0279,
+                "sharpeRatio": 1.38,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.019178
+            },
+            "geometry-2R": {
+              "costed": {
+                "totalTrades": 9,
+                "winRate": 0.4444,
+                "totalReturn": -0.009461,
+                "expectancy": -0.00967,
+                "profitFactor": 0.839,
+                "maxDrawdown": 0.042,
+                "sharpeRatio": -0.218,
+                "avgCostPct": 1.3233,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 9,
+                "winRate": 0.4444,
+                "totalReturn": 0.002332,
+                "expectancy": 0.003563,
+                "profitFactor": 1.043,
+                "maxDrawdown": 0.039,
+                "sharpeRatio": 0.076,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.011793
+            },
+            "geometry-4R": {
+              "costed": {
+                "totalTrades": 7,
+                "winRate": 0.2857,
+                "totalReturn": -0.038205,
+                "expectancy": -0.054451,
+                "profitFactor": 0.42,
+                "maxDrawdown": 0.0593,
+                "sharpeRatio": -0.994,
+                "avgCostPct": 1.78,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 7,
+                "winRate": 0.2857,
+                "totalReturn": -0.026045,
+                "expectancy": -0.036651,
+                "profitFactor": 0.533,
+                "maxDrawdown": 0.05,
+                "sharpeRatio": -0.69,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.01216
+            }
+          }
+        },
+        {
+          "label": "fold4",
+          "from": "2024-12-23",
+          "to": "2026-06-25",
+          "candleCount": 550,
+          "byConfig": {
+            "signal-flip": {
+              "costed": {
+                "totalTrades": 24,
+                "winRate": 0.2083,
+                "totalReturn": 0.019337,
+                "expectancy": 0.008273,
+                "profitFactor": 1.399,
+                "maxDrawdown": 0.0308,
+                "sharpeRatio": 0.53,
+                "avgCostPct": 0.7688,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 24,
+                "winRate": 0.25,
+                "totalReturn": 0.038212,
+                "expectancy": 0.01596,
+                "profitFactor": 1.991,
+                "maxDrawdown": 0.0233,
+                "sharpeRatio": 0.967,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.018875
+            },
+            "geometry-2R": {
+              "costed": {
+                "totalTrades": 8,
+                "winRate": 0.375,
+                "totalReturn": 0.011962,
+                "expectancy": 0.016008,
+                "profitFactor": 1.233,
+                "maxDrawdown": 0.0317,
+                "sharpeRatio": 0.3,
+                "avgCostPct": 1.8662,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 8,
+                "winRate": 0.375,
+                "totalReturn": 0.027162,
+                "expectancy": 0.034671,
+                "profitFactor": 1.649,
+                "maxDrawdown": 0.0209,
+                "sharpeRatio": 0.654,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.0152
+            },
+            "geometry-4R": {
+              "costed": {
+                "totalTrades": 6,
+                "winRate": 0.1667,
+                "totalReturn": -0.019219,
+                "expectancy": -0.030832,
+                "profitFactor": 0.635,
+                "maxDrawdown": 0.0386,
+                "sharpeRatio": -0.439,
+                "avgCostPct": 2.525,
+                "reason": null
+              },
+              "zeroCost": {
+                "totalTrades": 6,
+                "winRate": 0.1667,
+                "totalReturn": -0.004265,
+                "expectancy": -0.005582,
+                "profitFactor": 0.898,
+                "maxDrawdown": 0.0309,
+                "sharpeRatio": -0.077,
+                "avgCostPct": 0,
+                "reason": null
+              },
+              "frictionDrag": 0.014954
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What
Pre-registers a BTC daily-momentum + signal-flip sleeve, then KILLS it at Phase 1 on a failed reproduction check. Docs-only; no engine code.

## Finding
A fresh 6yr Binance BTC D1 backfill re-run through the same validator inverts the committed result on a ~2-week window shift:

| signal-flip, costed | committed 2026-06-12 | fresh 2026-06-26 |
|---|---|---|
| total return | +20.58% | -8.70% |
| expectancy | +0.0198 | -0.0090 |
| profit factor | 1.62 | 0.67 |
| Sharpe | +1.35 | -1.28 |
| win rate | 23% | 18.2% |

Decisive: negative even at ZERO cost (-2.05%, Sharpe -0.25). The raw 28d momentum signal has no edge on current BTC data; the committed +0.0198R was a window-fragile right-tail artifact (23% win rate), not a real edge. No deployable single-asset timing edge exists.

## Why this is in the repo
Honesty trail: Phase 0 pre-registration was committed BEFORE the re-run, so the kill is clean and non-cherry-picked. The shadow harness was NOT built (would have burned an 18-24mo live test on a negative strategy).

## Files
- docs/plans/2026-06-26-btc-daily-momentum-sleeve.md (pre-registration + KILLED outcome)
- docs/research/experiments/daily-momentum-validation-BTCUSD-D1-f4.json (fresh evidence)

## Remaining honest paths (not in this PR)
- Funding-carry pivot (structurally different; failed its own gate, needs maker-cost re-spec).
- Reposition the product off raw P&L.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
