### PR TITLE
fix(track-record): headline net expectancy so the card stops contradicting the curve

### DIFF
--- a/apps/web/app/api/signals/equity/route.test.ts
+++ b/apps/web/app/api/signals/equity/route.test.ts
@@ -178,6 +178,27 @@ describe('GET /api/signals/equity summary metrics', () => {
     // Coherent expectancy uses the sized population: 0.5*(+2R) + 0.5*(-1R) = +0.5R.
     // The old full-population formula would have returned 0.667*2 + 0.333*-1 = +1.0R.
     expect(body.summary.expectancyR).toBe(0.5);
+    // Net expectancy subtracts the real per-trade cost (BTCUSD model = 0.40R):
+    // +0.50R gross − 0.40R cost = +0.10R net.
+    expect(body.summary.netExpectancyR).toBe(0.1);
+  });
+
+  it('net expectancy subtracts real cost, exposing a gross-positive engine as net-negative', async () => {
+    // Gross expectancy is a thin +0.25R, but BTCUSD's real round-trip cost
+    // (0.40R at a 1% stop) drags net expectancy below zero — the engine-has-no-
+    // net-edge reality the public equity curve must reflect.
+    primeSlice([
+      record({ id: 'win-1R', pair: 'BTCUSD', entryPrice: 100, sl: 99, outcomes: { '4h': null, '24h': { price: 101, pnlPct: 1, hit: true } } }),
+      record({ id: 'loss-half-R', pair: 'BTCUSD', entryPrice: 100, sl: 99, outcomes: { '4h': null, '24h': { price: 99.5, pnlPct: -0.5, hit: false } } }),
+    ]);
+
+    const res = await GET(makeReq('/api/signals/equity'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.summary.expectancyR).toBe(0.25);     // gross: 0.5*(+1R) + 0.5*(-0.5R)
+    expect(body.summary.avgCostR).toBe(0.4);          // BTCUSD model cost
+    expect(body.summary.netExpectancyR).toBe(-0.15);  // 0.25 − 0.40 → net-negative
   });
 
   it('summaryOnly=1 drops the points array but keeps summary + rollingWinRates', async () => {

--- a/apps/web/app/api/signals/equity/route.ts
+++ b/apps/web/app/api/signals/equity/route.ts
@@ -75,8 +75,11 @@ export interface EquitySummary {
   avgRWin: number | null;
   /** Average R-multiple of losing trades (signed, typically ~-1). Null when no SL data on any loser. */
   avgRLoss: number | null;
-  /** Expectancy in R per trade: winRate * avgRWin + lossRate * avgRLoss. The break-even line for win-rate context. */
+  /** GROSS expectancy in R per trade: winRate * avgRWin + lossRate * avgRLoss. Pre-cost — engine quality only. */
   expectancyR: number | null;
+  /** NET expectancy in R per trade: gross expectancyR minus avgCostR. This is the per-trade edge that actually
+   *  compounds the equity curve; it can be negative even when gross expectancy is positive. Null when either input is null. */
+  netExpectancyR: number | null;
   /** Win-rate that would make expectancy = 0 given the observed avgRWin / avgRLoss. */
   breakEvenWinRate: number | null;
   /** Sizing assumption surfaced to the UI so the chart caption can quote the methodology. */
@@ -273,6 +276,14 @@ function computeEquityCurve(
   const breakEvenWinRate = avgRWin !== null && avgRLoss !== null && avgRWin - avgRLoss !== 0
     ? +(((-avgRLoss) / (avgRWin - avgRLoss)) * 100).toFixed(1)
     : null;
+  // Net expectancy = gross expectancy minus the real per-trade cost in R. Subtract
+  // the SAME 2dp cost the card's breakdown sub-line shows, so the headline net always
+  // equals (displayed gross − displayed cost) exactly — no ±0.01R drift from avgCostR's
+  // 3rd decimal. (avgCostR itself stays 3dp for the precise caption disclosure.) A
+  // gross-positive engine can read net-negative here — the honest signal the curve reflects.
+  const netExpectancyR = expectancyR !== null && avgCostR !== null
+    ? +(expectancyR - +avgCostR.toFixed(2)).toFixed(2)
+    : null;
 
   return {
     points,
@@ -286,6 +297,7 @@ function computeEquityCurve(
       avgRWin,
       avgRLoss,
       expectancyR,
+      netExpectancyR,
       breakEvenWinRate,
       riskPerTradePct: RISK_PER_TRADE_PCT,
       roundTripCostPct: avgRoundTripNotionalPct,

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -25,6 +25,7 @@ interface EquitySummary {
   avgRWin: number | null;
   avgRLoss: number | null;
   expectancyR: number | null;
+  netExpectancyR?: number | null;
   breakEvenWinRate: number | null;
   riskPerTradePct?: number;
   roundTripCostPct?: number;
@@ -381,6 +382,11 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
     ? `${formatDate(points[0].timestamp)} – ${formatDate(points[points.length - 1].timestamp)}`
     : null;
 
+  // Headline expectancy prefers NET (gross − real cost) so it agrees in sign with
+  // the equity curve — a green +0.01R gross beside a -100% curve reads as broken.
+  // Falls back to gross only when cost wasn't available.
+  const expectancyShown = summary ? (summary.netExpectancyR ?? summary.expectancyR) : null;
+
   const isPro = scope === 'pro';
   const isBroadcast = scope === 'broadcast';
 
@@ -598,20 +604,25 @@ export function EquityCurve({ period = 'all', scope = 'pro', category = 'all', b
             </div>
             <div className="bg-white/[0.02] rounded-lg py-2 px-3">
               <div className="text-[9px] text-zinc-600 uppercase tracking-wider mb-0.5 inline-flex items-center gap-1">
-                Expectancy
+                Expectancy (net)
                 <InfoHint text={STAT_HINTS.expectancyR} label="What expectancy means" />
               </div>
               <div className={`text-xs font-mono font-semibold tabular-nums ${
-                summary.expectancyR !== null && summary.expectancyR > 0
+                expectancyShown != null && expectancyShown > 0
                   ? 'text-emerald-400'
-                  : summary.expectancyR !== null && summary.expectancyR < 0
+                  : expectancyShown != null && expectancyShown < 0
                     ? 'text-red-400'
                     : 'text-zinc-300'
               }`}>
-                {summary.expectancyR !== null
-                  ? `${summary.expectancyR >= 0 ? '+' : ''}${summary.expectancyR.toFixed(2)}R`
+                {expectancyShown != null
+                  ? `${expectancyShown >= 0 ? '+' : ''}${expectancyShown.toFixed(2)}R`
                   : '—'}
               </div>
+              {summary.netExpectancyR != null && summary.expectancyR !== null && summary.avgCostR != null && (
+                <div className="text-[9px] text-zinc-600 mt-0.5 font-mono">
+                  {summary.expectancyR >= 0 ? '+' : ''}{summary.expectancyR.toFixed(2)}R gross − {summary.avgCostR.toFixed(2)}R cost
+                </div>
+              )}
             </div>
           </div>
           {/* R-stat denominator note — avg R per win/loss, expectancy and the

--- a/apps/web/lib/stat-hints.ts
+++ b/apps/web/lib/stat-hints.ts
@@ -55,7 +55,7 @@ export const STAT_HINTS = {
   avgRLoss:
     'Average R-multiple of losing trades. Should sit near -1.0R when stops fill cleanly. Values closer to 0 indicate slippage in your favor; further from 0 indicates gap losses worse than -1R.',
   expectancyR:
-    'Expected R per trade: winRate × avgRWin + lossRate × avgRLoss. Positive expectancy is the only thing that matters long-run — win rate alone is misleading. +0.10R means each signal is worth about 10% of the risked amount on average.',
+    'Expected R per trade AFTER real round-trip cost: (winRate × avgRWin + lossRate × avgRLoss) − average cost in R. The tile shows the NET figure; the sub-line breaks out gross expectancy minus cost. Net is what actually compounds the equity curve — gross alone ignores fees/slippage and overstates the edge. A positive gross with a negative net means costs eat the edge, which is exactly why the curve can fall while gross looks fine. Positive NET expectancy is the only thing that matters long-run.',
   breakEvenWinRate:
     'Win-rate the system needs to break even given its observed avgRWin and avgRLoss. If actual win-rate exceeds this, the system has positive expectancy — even if the win-rate is below 50%.',
 


### PR DESCRIPTION
## Problem

After #136 shipped real per-symbol cost on the public equity curve, the Pro track-record card became internally contradictory: the **Expectancy** tile showed **gross** +0.01R (green, positive) right next to a **net** −100% equity curve. Gross-positive beside net-catastrophic reads as broken or dishonest — exactly the confusion the honesty work is meant to remove.

Root cause: the R-stat tiles (`avgRWin`, `avgRLoss`, `expectancyR`) are computed from the **raw, pre-cost** R-multiple (by design, so engine quality isn't distorted by the cap), while the equity curve subtracts each trade's **real cost**. Nothing on the card bridged the two.

## Change

Make the headline expectancy coherent with the curve, without touching any of the honest math:

- **`route.ts`** — add `summary.netExpectancyR = gross expectancyR − avgCostR` (null-safe). Computed from the same 2dp cost the card's sub-line shows, so `net == gross − cost` exactly (no ±0.01R drift from `avgCostR`'s 3rd decimal).
- **`equity-curve.tsx`** — the tile now reads **"Expectancy (net)"** and shows the net figure (which agrees in sign with the curve), with a `+X.XXR gross − Y.YYR cost` breakdown sub-line. Falls back to gross if cost is unavailable.
- **`stat-hints.ts`** — expectancy tooltip explains net vs gross and why a positive gross with negative net means costs eat the edge.

## What is deliberately NOT changed

This is the opposite of a "make it look better" change. **Gross `expectancyR`, the cost model, `HARD_R_CAP`, smoothing default, and the equity compounding math are all untouched.** The new headline is strictly more conservative (gross − cost). On live data it reads ≈ **−0.43R/trade**, which is the honest no-net-edge result.

## Verification

- `jest apps/web/app/api/signals/equity/route.test.ts` — **6/6 pass**, incl. a new test proving a gross-positive engine reads net-negative after cost (+0.25R gross − 0.40R cost = −0.15R net).
- `npm run typecheck:web` — **clean**.
- Adversarial review (typescript-reviewer): **APPROVED**, confirmed not a dishonest-knob change; the one MEDIUM (sub-line/headline rounding drift) is fixed in this PR.

## Deferred follow-up

`TrackRecordClient` per-category comparison rows still show gross `expectancyR`. Not a regression (always was gross), but labeling is now inconsistent with the net headline. Separate data path (`CategorySnapshot`) — tracked as a follow-up, out of scope here.
