### PR TITLE
blog: draft for week of 2026-06-29

### DIFF
--- a/apps/web/content/blog/draft-2026-06-29.mdx
+++ b/apps/web/content/blog/draft-2026-06-29.mdx
@@ -1,0 +1,38 @@
+---
+title: "TradeClaw Python SDK: Automate Trading Signals Without the Boilerplate"
+excerpt: "The TradeClaw Python SDK lets you pull live signals, set up webhook listeners, and integrate technical analysis into your own apps with a single pip install. Here's what's coming and how to get ready."
+date: "2026-06-29"
+readTime: "8 min"
+tags: ["Python", "SDK", "Developer", "Automation"]
+metaDescription: "TradeClaw's Python SDK (pip install tradeclaw) brings live signal access, webhook support, and technical analysis automation to Python developers. Preview the API and roadmap."
+keywords: ["tradeclaw python sdk", "python trading signals library", "pip install tradeclaw", "trading automation python", "python webhook trading signals"]
+---
+
+## Why Python Developers Need a Dedicated Trading Signal Library
+
+TODO: Explain the gap between raw exchange APIs and actionable signals. Most Python devs cobble together CCXT + pandas-ta + custom webhook code. The SDK closes that gap with a single, typed interface that handles auth, rate-limiting, and signal parsing out of the box — so you spend your time acting on signals, not plumbing them.
+
+## What the TradeClaw Python SDK Delivers
+
+TODO: Cover the three pillars — live signal fetching, webhook listener helpers, and indicator access (RSI, MACD, EMA, Bollinger Bands). Show the planned `pip install tradeclaw` install command and basic import. Highlight typed `Signal` dataclasses and IDE autocomplete. Contrast with the raw REST API for readers who have already tried it.
+
+## Your First Signal in Five Lines of Python
+
+TODO: Walk through the quickstart: authenticate with API key, pick a symbol + interval, call `client.signals.get_latest("BTCUSDT", "1h")`, print the signal. Include expected output format showing direction, confidence score, and active indicators. Note the difference between REST polling and WebSocket streaming (roadmap).
+
+## Webhook Integration: React to Signals in Real Time
+
+TODO: Show how the SDK wraps incoming webhook payloads into typed dataclasses — no raw JSON parsing, full IDE autocomplete. Cover the async listener pattern with a short code example. Mention the roadmap item for a visual webhook retry UI that pairs with this.
+
+## Backtesting and Historical Signal Replay
+
+TODO: Explain how the SDK will expose historical signal data tied to the PostgreSQL live signal storage roadmap item (142 votes, high priority). Show a loop pattern for replay testing. Note the current workaround using the REST API's historical endpoint for early adopters who don't want to wait.
+
+## Roadmap to v1.0 and How to Influence It
+
+TODO: Link to the TradeClaw roadmap page. Highlight the 134 community votes driving SDK priority. Explain the public issue tracker and how to upvote or comment to shape the API surface. Give a rough release window based on current roadmap status.
+
+<TrialCTA
+  headline="Get early SDK access — start your free 7-day TradeClaw Pro trial."
+  pitch="TradeClaw Pro gives you live signals via REST and webhooks today, and Python SDK access the moment it ships. $29/mo after the trial, cancel anytime."
+/>


### PR DESCRIPTION
## Summary

Draft scaffold for the week of 2026-06-29. Closes/linked to #141 (blog topic candidates).

**Draft scaffold. Body needs writing before merge.**

---

## Chosen Topic

**TradeClaw Python SDK: Automate Trading Signals Without the Boilerplate**
*File:* `apps/web/content/blog/draft-2026-06-29.mdx`

### Outline (from #141)

- Why existing options fall short: CCXT gives prices but not signals; pandas-ta gives indicators but no delivery layer; combining both requires heavy custom wiring
- What the SDK surface will look like: typed `Signal` dataclass, `client.signals.get_latest(symbol, interval)`, async webhook listener helpers, IDE autocomplete throughout
- Quickstart in 5 lines: `pip install tradeclaw`, auth with API key, fetch `BTCUSDT 1h`, print signal with direction + confidence score + active indicators
- Webhook integration: SDK wraps incoming payloads into typed objects — no raw JSON parsing, pairs with the planned visual webhook retry UI (roadmap)
- Historical signal replay: tied to the PostgreSQL live signal storage roadmap item; loop pattern for backtesting without a separate data warehouse
- SDK vs. direct REST API: when to use each (rapid prototyping vs. production pipeline vs. CLI scripting)
- Roadmap to v1.0: 134 community votes driving priority; how to upvote and comment on GitHub issues to shape the API surface

**Keywords:** `tradeclaw python sdk` · `python trading signals library` · `pip install tradeclaw`
**Target read time:** 7 min (placeholder set to 8 min — update after writing)

---

## What This PR Adds

- `apps/web/content/blog/draft-2026-06-29.mdx` — frontmatter complete, six `##` section headings in place, each with a `TODO:` placeholder body. `<TrialCTA>` at the bottom, no imports needed (auto-exposed via `mdx-components.tsx`).

No existing posts were modified.

---

## Pre-Merge Checklist

- [ ] Body written (replace all `TODO:` placeholders)
- [ ] `readTime` updated to reflect actual word count
- [ ] Title finalized (edit frontmatter `title` field if needed)
- [ ] `draft-` prefix removed from filename (rename to the final slug, e.g. `tradeclaw-python-sdk.mdx`)

---

*Related issue: #141 — Blog topics week of 2026-06-29*

---
_Generated by [Claude Code](https://claude.ai/code/session_019p9352ZjnyewyFUEHLrXvF)_