### PR TITLE
docs(adr): signal-worker extraction decision + unwired feature-flag scaffold

### DIFF
--- a/docs/adr/0001-extract-signal-engine-into-scheduled-worker.md
+++ b/docs/adr/0001-extract-signal-engine-into-scheduled-worker.md
@@ -1,0 +1,76 @@
+# ADR 0001: Extract the signal engine into a dedicated scheduled worker
+
+- Status: Proposed
+- Date: 2026-06-28
+- Deciders: TradeClaw maintainers
+- Source: Weekly improvement report recommendation (extract the signal engine into a dedicated scheduled worker; add feature flags; instrument the alert to retained funnel)
+
+## Context
+
+Signal generation today runs as scheduled GitHub Actions cron workflows that call Next.js API routes on the production web app:
+
+- `.github/workflows/signal-alerts.yml` runs every 5 minutes and POSTs `https://tradeclaw.win/api/cron/signals`, then fans out immediate Telegram alerts.
+- `.github/workflows/push-signals.yml` runs every 15 minutes and POSTs `https://tradeclaw.win/api/cron/push-signals` to trigger Expo push notifications.
+- Additional schedules exist for `daily-track-record`, `signal-log`, and `telegram-broadcast`.
+
+This couples the signal compute path to the web request lifecycle and to GitHub Actions scheduling. Consequences:
+
+- Signal compute shares resources and failure modes with user-facing web traffic. A slow signal pass can degrade the app, and an app deploy can disrupt signal timing.
+- Scheduling, retries, concurrency control, and timeouts are spread across many workflow YAML files rather than owned by one component.
+- There is no first-class place to run the engine in shadow mode, compare outputs, or roll a change out gradually.
+- The acquisition funnel (alert to click to signup to subscription to retained) is not instrumented end to end, so the impact of signal changes on conversion and retention is not measurable.
+
+This is a live trading and payments product. Any migration must be reversible and must not change trading, signal math, or Stripe behaviour during cutover.
+
+## Decision
+
+Adopt a phased plan to move signal generation out of the in-app cron route and into a dedicated scheduled worker, gated by feature flags, with the conversion funnel instrumented before and during the migration.
+
+1. Worker boundary. Stand up a dedicated worker (a small long-running service or a scheduled job) that owns signal generation by consuming the existing `@tradeclaw/signals` package directly, instead of going through the web API route. The web app keeps serving reads.
+2. Feature-flag the cutover. Introduce environment-driven flags so the worker can run OFF by default, then in shadow mode (compute alongside the legacy path and compare, without acting), then as the source of truth. A scaffold for these flags lands with this ADR at `packages/core/src/flags/feature-flags.ts` and is intentionally unwired.
+3. Funnel instrumentation. Emit a consistent event for each funnel stage (alert delivered, alert click, signup, subscription, retained) keyed by a stable identifier, so each signal-engine change can be evaluated against downstream conversion and retention. Instrumentation is gated by its own flag so it can ship dark and be enabled per environment.
+4. Reversibility. The legacy GitHub Actions cron path stays in place and authoritative until the worker has run in shadow mode long enough to confirm output parity. Cutover and rollback are a flag flip, not a deploy.
+
+## Scope guardrails
+
+- No change to trading, signal, or Stripe logic in this ADR or its accompanying scaffold. The signal math in `@tradeclaw/signals` is reused verbatim.
+- The flag module shipped alongside this ADR is additive and unwired: it is not imported by any runtime code and is not exported from `packages/core/src/index.ts`.
+- Each later phase (worker bootstrap, shadow compare, instrumentation, cutover) is a separate change behind its own flag.
+
+## Flags introduced by the scaffold
+
+Defined in `packages/core/src/flags/feature-flags.ts`. All default to OFF.
+
+| Flag | Env var | Purpose |
+| --- | --- | --- |
+| `signalWorkerEnabled` | `TRADECLAW_FF_SIGNAL_WORKER` | Route signal generation through the extracted worker instead of the in-app cron route. |
+| `signalWorkerShadowMode` | `TRADECLAW_FF_SIGNAL_WORKER_SHADOW` | Run the worker alongside the legacy path to compare outputs before cutover. |
+| `funnelInstrumentation` | `TRADECLAW_FF_FUNNEL_INSTRUMENTATION` | Emit the alert to retained funnel analytics events. |
+
+## Consequences
+
+Positive:
+
+- Signal compute is isolated from web request load and from app deploys.
+- Scheduling, retries, and concurrency are owned by one component instead of many workflow files.
+- Gradual rollout and instant rollback via flags reduce migration risk on a live trading product.
+- The funnel becomes measurable, so signal-engine changes can be judged on conversion and retention, not just on signal accuracy.
+
+Negative or costs:
+
+- One more deployable component to operate and monitor.
+- A temporary period running both paths (legacy cron plus shadow worker) costs extra compute and needs an output-parity check.
+- Flags add configuration surface that must be documented and kept tidy after cutover.
+
+## Alternatives considered
+
+- Keep the in-app cron route and only add instrumentation. Rejected as the primary fix: it leaves signal compute coupled to web traffic and to GitHub Actions scheduling, which is the root concern in the report.
+- Move scheduling to an external scheduler but keep the API route as the compute path. Rejected: it changes the trigger without decoupling compute from the web lifecycle.
+- Big-bang cutover with no shadow mode. Rejected: unacceptable risk for a live trading and payments product; no safe rollback.
+
+## Follow-ups (not in this change)
+
+- Choose the worker runtime and deployment target (the repo already runs on Railway, Fly, and Docker; pick one host for the worker).
+- Wire the flag resolver at the relevant boundary and add unit tests for `resolveAllFlags`.
+- Define the funnel event schema and the stable identifier that joins alert to subscription to retained.
+- Add an output-parity check for the shadow phase.

--- a/packages/core/src/flags/feature-flags.ts
+++ b/packages/core/src/flags/feature-flags.ts
@@ -1,0 +1,105 @@
+// @tradeclaw/core — feature flag registry (scaffold)
+//
+// Self-contained, dependency-free feature-flag definitions and a pure resolver.
+//
+// STATUS: UNWIRED SCAFFOLD. This module is intentionally NOT exported from
+// `packages/core/src/index.ts` and is NOT referenced by any runtime code yet.
+// It exists to support the rollout plan in
+// `docs/adr/0001-extract-signal-engine-into-scheduled-worker.md`: gate the
+// signal-worker extraction behind a flag and gate the alert->click->signup->
+// subscription->retained funnel instrumentation behind a flag, so each can be
+// switched on per-environment without a code change.
+//
+// Design notes:
+//  - No external dependencies and no global (`process`) reference. The resolver
+//    takes an env map as an argument, so callers pass `process.env` (or any
+//    record) at the boundary. This keeps the module pure and trivially testable.
+//  - Adding a flag = add one entry to `FEATURE_FLAGS`. The key union is derived
+//    from that object, so the type system stays in sync automatically.
+
+/** A single feature-flag definition. */
+export interface FeatureFlagDefinition {
+  /** Stable identifier used in code and logs. */
+  readonly key: string;
+  /** Human-readable purpose of the flag. */
+  readonly description: string;
+  /** Environment variable that overrides the default at runtime. */
+  readonly envVar: string;
+  /** Value used when the env var is unset or unparseable. */
+  readonly defaultValue: boolean;
+}
+
+/**
+ * The flag registry. Defaults are OFF so the scaffold never changes behaviour
+ * until an operator opts in via the documented environment variable.
+ */
+export const FEATURE_FLAGS = {
+  /** Route signal generation through the dedicated scheduled worker instead of
+   *  the in-app GitHub Actions cron -> Next.js API route path. */
+  signalWorkerEnabled: {
+    key: 'signalWorkerEnabled',
+    description:
+      'Run signal generation in the extracted scheduled worker instead of the in-app cron route.',
+    envVar: 'TRADECLAW_FF_SIGNAL_WORKER',
+    defaultValue: false,
+  },
+  /** Run the legacy in-app cron path and the extracted worker side by side and
+   *  compare outputs, without acting on the worker result. Migration safety. */
+  signalWorkerShadowMode: {
+    key: 'signalWorkerShadowMode',
+    description:
+      'Run the extracted worker in shadow mode alongside the legacy path to compare outputs before cutover.',
+    envVar: 'TRADECLAW_FF_SIGNAL_WORKER_SHADOW',
+    defaultValue: false,
+  },
+  /** Emit the alert->click->signup->subscription->retained funnel events. */
+  funnelInstrumentation: {
+    key: 'funnelInstrumentation',
+    description:
+      'Emit alert->click->signup->subscription->retained funnel analytics events.',
+    envVar: 'TRADECLAW_FF_FUNNEL_INSTRUMENTATION',
+    defaultValue: false,
+  },
+} as const satisfies Record<string, FeatureFlagDefinition>;
+
+/** Canonical flag keys. Derived from the registry so they stay in sync. */
+export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
+
+/** A minimal env source. `process.env` satisfies this shape. */
+export type EnvSource = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Parse an environment string into a boolean.
+ * Truthy: "1", "true", "yes", "on" (case-insensitive). Everything else is false.
+ * `undefined` or empty returns `undefined` so the caller can fall back to the default.
+ */
+export function parseBooleanEnv(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '') return undefined;
+  return (
+    normalized === '1' ||
+    normalized === 'true' ||
+    normalized === 'yes' ||
+    normalized === 'on'
+  );
+}
+
+/**
+ * Resolve a single flag against an env source, falling back to its default.
+ * Pure: no global state, no I/O.
+ */
+export function resolveFlag(flag: FeatureFlagKey, env: EnvSource): boolean {
+  const def = FEATURE_FLAGS[flag];
+  const fromEnv = parseBooleanEnv(env[def.envVar]);
+  return fromEnv === undefined ? def.defaultValue : fromEnv;
+}
+
+/** Resolve every flag against an env source. */
+export function resolveAllFlags(env: EnvSource): Record<FeatureFlagKey, boolean> {
+  const out = {} as Record<FeatureFlagKey, boolean>;
+  for (const key of Object.keys(FEATURE_FLAGS) as FeatureFlagKey[]) {
+    out[key] = resolveFlag(key, env);
+  }
+  return out;
+}

--- a/packages/core/src/flags/feature-flags.ts
+++ b/packages/core/src/flags/feature-flags.ts
@@ -66,15 +66,16 @@ export const FEATURE_FLAGS = {
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
 
 /** A minimal env source. `process.env` satisfies this shape. */
-export type EnvSource = Readonly<Record<string, string | undefined>>;
+export type EnvSource = Readonly<Record<string, unknown>>;
 
 /**
  * Parse an environment string into a boolean.
  * Truthy: "1", "true", "yes", "on" (case-insensitive). Everything else is false.
- * `undefined` or empty returns `undefined` so the caller can fall back to the default.
+ * `undefined`, `null`, non-string, or empty values return `undefined` so the caller can fall back to the default.
  */
-export function parseBooleanEnv(raw: string | undefined): boolean | undefined {
-  if (raw === undefined) return undefined;
+export function parseBooleanEnv(raw: unknown): boolean | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'string') return undefined;
   const normalized = raw.trim().toLowerCase();
   if (normalized === '') return undefined;
   return (
@@ -89,14 +90,14 @@ export function parseBooleanEnv(raw: string | undefined): boolean | undefined {
  * Resolve a single flag against an env source, falling back to its default.
  * Pure: no global state, no I/O.
  */
-export function resolveFlag(flag: FeatureFlagKey, env: EnvSource): boolean {
+export function resolveFlag(flag: FeatureFlagKey, env?: EnvSource | null): boolean {
   const def = FEATURE_FLAGS[flag];
-  const fromEnv = parseBooleanEnv(env[def.envVar]);
+  const fromEnv = parseBooleanEnv(env?.[def.envVar]);
   return fromEnv === undefined ? def.defaultValue : fromEnv;
 }
 
 /** Resolve every flag against an env source. */
-export function resolveAllFlags(env: EnvSource): Record<FeatureFlagKey, boolean> {
+export function resolveAllFlags(env?: EnvSource | null): Record<FeatureFlagKey, boolean> {
   const out = {} as Record<FeatureFlagKey, boolean>;
   for (const key of Object.keys(FEATURE_FLAGS) as FeatureFlagKey[]) {
     out[key] = resolveFlag(key, env);


### PR DESCRIPTION
## What

Implements the single lowest-risk, highest-leverage item from the weekly improvement report: "extract the signal engine into a dedicated scheduled worker; add feature flags; instrument the alert->click->signup->subscription->retained funnel."

Because this is a live trading + payments product, this PR ships **documentation + an unwired scaffold only** and touches **no trading, signal, or Stripe logic**.

Two new files:
- `docs/adr/0001-extract-signal-engine-into-scheduled-worker.md` - ADR recording the phased plan to move signal generation out of the in-app GitHub Actions cron -> Next.js API route path (`signal-alerts.yml`, `push-signals.yml`) into a dedicated scheduled worker, gated by feature flags, with the conversion funnel instrumented before cutover. Grounded in the repo's current cron architecture.
- `packages/core/src/flags/feature-flags.ts` - one self-contained, dependency-free feature-flag module (typed registry + pure resolver). Defaults all OFF. Reads an injected env map, so it has zero global/`process` typing dependency.

## Safety

- **Additive only**: both files are new. No existing file is edited or deleted (`git diff --stat origin/main` is empty for tracked files).
- **Unwired**: the flag module is NOT exported from `packages/core/src/index.ts` and has no importers, so it changes no runtime behaviour.
- **No new dependencies.**
- **Non-breaking.**

## Verification

- `git diff --stat origin/main` confirms zero modifications to existing tracked files; only the two new files are added.
- Grep confirms the flag module has no importers (stays unwired).
- TypeScript is ^5 across the workspace, so the `as const satisfies` syntax used is supported.
- Full build/typecheck not run: the isolated worktree has no `node_modules` (per task constraints). Module validated by static review.

Draft for maintainer review. Source: weekly improvement report.