### PR TITLE
docs: release/experiment receipts + Strategy Audit pilot pack

### DIFF
--- a/.experiments/2026-07-04-strategy-audit-pilot.md
+++ b/.experiments/2026-07-04-strategy-audit-pilot.md
@@ -1,0 +1,38 @@
+# Experiment — TradeClaw Strategy Audit paid pilot
+
+## Definition
+
+| Field | Value |
+|---|---|
+| Experiment name | TradeClaw Strategy Audit paid pilot |
+| Lane | trading |
+| Repo | naimkatiman/tradeclaw |
+| Owner | naimkatiman |
+| Feature flag (if any) | none |
+| Start date | 2026-07-04 |
+| Stop date (hard stop — decide even if inconclusive) | 2026-07-18 |
+
+## Hypothesis
+
+If we sell fixed-price historical strategy-audit reports (5 pilot slots at $79–$199), then retail strategy owners will pay for them without live execution existing, because the audit's value is in the historical evidence and written verdict, not in automated trade placement.
+
+Offer research and pricing rationale: see `docs/tradeclaw-strategy-audit-patch/docs/MONETIZATION_STRATEGY_AUDIT.md` (not restated here).
+
+## Metrics
+
+- Primary metric (one only): paid pilots (count of pilot slots paid for within the window)
+- Pass threshold (exact number): 3 paid
+- Guardrail metric (what must NOT get worse): human production time per report stays under 45 minutes
+- Segment (who is measured): pilot customers who pay for a slot between start and stop date (max 5 slots)
+
+## Result
+
+Fill after stop date. Do not leave open past the stop date.
+
+- Observed primary metric:
+- Guardrail status:
+- Evidence links (dashboards, exports, screenshots):
+
+## Decision
+
+One of: **ship** / **iterate** / **kill**. State the decision and the single next action.

--- a/.experiments/2026-07-04-strategy-audit-pilot.md
+++ b/.experiments/2026-07-04-strategy-audit-pilot.md
@@ -27,7 +27,15 @@ Offer research and pricing rationale: see `docs/tradeclaw-strategy-audit-patch/d
 
 ## Result
 
-Fill after stop date. Do not leave open past the stop date.
+<!-- TODO:
+Required Data:
+- Observed primary metric: Count of paid pilot slots.
+  Verification arithmetic: Sum of payments received / price per slot ($79-$199) = total paid.
+- Guardrail status: Human production time per report.
+  Verification arithmetic: Total human production time / total reports generated = average time (must be < 45 minutes).
+Examples & Narrative:
+- E.g., "Observed primary metric: 4 paid slots ($556 total revenue). Guardrail status: 35 minutes average production time."
+-->
 
 - Observed primary metric:
 - Guardrail status:

--- a/.experiments/EXPERIMENT_TEMPLATE.md
+++ b/.experiments/EXPERIMENT_TEMPLATE.md
@@ -1,0 +1,38 @@
+# Experiment
+
+> One file per experiment. Copy to `.experiments/<YYYY-MM-DD>-<slug>.md`. No experiment record = no claim of learning.
+
+## Definition
+
+| Field | Value |
+|---|---|
+| Experiment name | |
+| Lane | trading / quran / workflow / infra |
+| Repo | |
+| Owner | |
+| Feature flag (if any) | |
+| Start date | |
+| Stop date (hard stop — decide even if inconclusive) | |
+
+## Hypothesis
+
+State as: "If we [change], then [segment] will [measurable behavior], because [reasoning]."
+
+## Metrics
+
+- Primary metric (one only):
+- Pass threshold (exact number):
+- Guardrail metric (what must NOT get worse):
+- Segment (who is measured):
+
+## Result
+
+Fill after stop date. Do not leave open past the stop date.
+
+- Observed primary metric:
+- Guardrail status:
+- Evidence links (dashboards, exports, screenshots):
+
+## Decision
+
+One of: **ship** / **iterate** / **kill**. State the decision and the single next action.

--- a/.releases/2026-07-04-current-state.md
+++ b/.releases/2026-07-04-current-state.md
@@ -1,0 +1,49 @@
+# Release Receipt — 2026-07-04 current-state snapshot
+
+> This is a **state snapshot**, not a release. It records what is actually shipped in the repo as of the commit below, so future receipts have an honest baseline. Release-specific fields are marked "n/a (state snapshot)".
+
+## Identity
+
+| Field | Value |
+|---|---|
+| Repo | naimkatiman/tradeclaw |
+| Version / tag | **Inconsistent — see "Version discrepancy" below** |
+| Commit SHA | b8ad24d5c419dd848493be9a2c9fdf8ace1e0458 |
+| Environment | n/a (state snapshot) |
+| Released at (UTC) | n/a (state snapshot; snapshot taken 2026-07-04) |
+| Owner | naimkatiman |
+
+### Version discrepancy
+
+Three version sources disagree. All three are stated here; none is silently picked as canonical:
+
+- `package.json` (repo root): `0.1.0`
+- `CHANGELOG.md` latest entry: `[0.5.0] — 2026-05-09`
+- Newest git tag: `v0.4.0`
+
+Follow-up (not done in this snapshot): reconcile the three on the next real release and record the chosen version in that release's receipt.
+
+## What shipped (current state, verified in-repo)
+
+- User-visible impact: AI trading signals dashboard (Next.js 14 + PostgreSQL) with backtest UI, Telegram alerting, and market-data hub integration is the shipped surface; live broker execution is not.
+- RoboForex R StocksTrader bridge is **scaffold/interface-only**: `apps/web/lib/execution/rstockstrader-bridge.ts` throws `"rstockstrader-bridge: not implemented yet"` (implementation deferred to `docs/plans/2026-05-08-demo-roboforex-rstockstrader.md`).
+- `SIGNAL_ENGINE_PRESET` currently **labels emitted signals only** — the live engine still generates with the `classic` profile regardless of preset; per-preset live generation is not wired (README, "Strategy presets" section).
+- Feature flags changed: n/a (state snapshot)
+- Migrations run: n/a (state snapshot)
+
+## Verification
+
+- Tests run: n/a (state snapshot — no release performed)
+- Security scans run: n/a (state snapshot)
+- Manual verification performed: facts above verified directly against the worktree at commit b8ad24d5 — `package.json` version field, `CHANGELOG.md` headings, `git tag` output, `rstockstrader-bridge.ts` throw site, README "Strategy presets" section.
+
+## Risk
+
+- Known risks accepted: version discrepancy above may mislead consumers of CHANGELOG/tags until reconciled; execution bridge advertised in plans but not implemented.
+- Rollback command: n/a (state snapshot — nothing deployed by this receipt)
+- Monitoring link: n/a (state snapshot)
+
+## Sign-off
+
+- [x] All fields above are filled (no blanks — "n/a (state snapshot)" used explicitly)
+- [x] Rollback command was verified to exist (n/a — nothing deployed by this receipt)

--- a/.releases/RELEASE_RECEIPT_TEMPLATE.md
+++ b/.releases/RELEASE_RECEIPT_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Release Receipt
+
+> One receipt per release/deploy. Copy this file to `.releases/<YYYY-MM-DD>-<version-or-slug>.md`, fill every field, commit it with the release. A release without a receipt did not happen.
+
+## Identity
+
+| Field | Value |
+|---|---|
+| Repo | |
+| Version / tag | |
+| Commit SHA | |
+| Environment | production / staging / preview |
+| Released at (UTC) | |
+| Owner | |
+
+## What shipped
+
+- User-visible impact (one sentence, outcome not mechanism):
+- Feature flags changed (name, old value, new value):
+- Migrations run (file names, or "none"):
+
+## Verification
+
+- Tests run (exact commands + result):
+- Security scans run (tool + result, or "none"):
+- Manual verification performed:
+
+## Risk
+
+- Known risks accepted at release time:
+- Rollback command (exact, copy-pasteable):
+- Monitoring link (dashboard/logs to watch after release):
+
+## Sign-off
+
+- [ ] All fields above are filled (no blanks — use "none" explicitly)
+- [ ] Rollback command was verified to exist (not just guessed)

--- a/docs/strategy-audit/README.md
+++ b/docs/strategy-audit/README.md
@@ -1,0 +1,52 @@
+# Strategy Audit — pilot operations pack
+
+Operational reference for running the TradeClaw Strategy Audit paid pilot. This file links to existing assets; it does not duplicate them.
+
+## Existing assets (canonical, do not fork)
+
+- Sample report (what the customer receives): [`packages/strategy-audit-agent/examples/sample-report.md`](../../packages/strategy-audit-agent/examples/sample-report.md)
+- Intake shape (machine-readable audit request): [`packages/strategy-audit-agent/examples/audit-request.json`](../../packages/strategy-audit-agent/examples/audit-request.json)
+- Offer research and pricing rationale: [`docs/tradeclaw-strategy-audit-patch/docs/MONETIZATION_STRATEGY_AUDIT.md`](../tradeclaw-strategy-audit-patch/docs/MONETIZATION_STRATEGY_AUDIT.md)
+- Experiment record (pass/fail criteria, dates): [`.experiments/2026-07-04-strategy-audit-pilot.md`](../../.experiments/2026-07-04-strategy-audit-pilot.md)
+
+## Intake checklist
+
+Do not start an audit until the customer has supplied all of the following:
+
+- [ ] Written strategy rules — entry, exit, and position-sizing rules in plain language. "I buy dips" is not enough; rules must be precise enough to backtest.
+- [ ] Market and timeframe — which instrument(s) and which candle timeframe the strategy trades (e.g. BTC/USD on 4h).
+- [ ] Assumptions — starting capital, fee/slippage assumptions if the customer has them, and any constraints (long-only, max concurrent positions, session hours).
+- [ ] The date range they care about, or explicit agreement to the default lookback used in the sample report.
+
+Anything missing: ask once, in one message, before doing any work. The intake maps onto the fields in `audit-request.json` above.
+
+## Delivery message template
+
+Plain text, sent with the finished report:
+
+```
+Hi <name>,
+
+Your TradeClaw Strategy Audit is attached.
+
+It covers: <strategy name> on <market/timeframe>, tested over <date range>,
+under the assumptions you provided (<capital / fees / constraints>).
+
+How to read it: start with the verdict section, then the trade-by-trade
+table if you want to dig into specific entries and exits.
+
+Important: this audit is a historical analysis only. It is not financial
+advice, and past performance does not guarantee or predict future results.
+No live trading was performed, and nothing in the report is a recommendation
+to trade.
+
+If any rule in the report does not match what you meant, reply within 7 days
+and I will re-run that part once at no charge.
+
+Thanks,
+<sender>
+```
+
+## Public-repo rule
+
+No prospect names, no contact info, no lead lists, and no per-customer revenue detail in this directory or anywhere else in this repo. Aggregate pilot outcomes belong in the experiment record only.


### PR DESCRIPTION
Adds proof-receipt infrastructure and the Strategy Audit pilot operations pack. Docs only — no code, no payment integration.

## What changed and why

- `.releases/RELEASE_RECEIPT_TEMPLATE.md` and `.experiments/EXPERIMENT_TEMPLATE.md` — standing templates so every future release and experiment leaves a committed record.
- `.releases/2026-07-04-current-state.md` — first receipt, an honest state snapshot of what is actually shipped. Records the three-way version discrepancy without picking a winner (package.json `0.1.0`, CHANGELOG latest `[0.5.0] — 2026-05-09`, newest git tag `v0.4.0`), that `apps/web/lib/execution/rstockstrader-bridge.ts` is scaffold-only (throws "not implemented yet"), and that `SIGNAL_ENGINE_PRESET` only labels emitted signals (per-preset live generation not wired, per README "Strategy presets"). Release-specific fields are "n/a (state snapshot)".
- `.experiments/2026-07-04-strategy-audit-pilot.md` — Strategy Audit paid pilot: 5 slots at $79–$199, primary metric paid pilots, pass at 3 paid, guardrail under 45 minutes human production time per report, window 2026-07-04 to 2026-07-18. References the existing offer research at `docs/tradeclaw-strategy-audit-patch/docs/MONETIZATION_STRATEGY_AUDIT.md` without restating it.
- `docs/strategy-audit/README.md` — pilot ops pack that links (never duplicates) the existing sample report and intake JSON at `packages/strategy-audit-agent/examples/`, plus two net-new sections: customer intake checklist and a plain-text delivery message template with the historical-only / no-financial-advice / no-guarantee disclaimer.

Note: pricing and pass-criteria disclosure follows the repo's existing public-monetization-docs precedent (README Pro pricing, docs/marketing/, MONETIZATION_STRATEGY_AUDIT.md). No prospect or customer data is included.

## Verification

- `git -C c:/Ai/tradeclaw-receipts-wt branch --show-current` — `docs/receipts-strategy-audit-pilot` (confirmed before commit)
- `diff <scratchpad template> .releases/RELEASE_RECEIPT_TEMPLATE.md` — no output (verbatim copy)
- `diff <scratchpad template> .experiments/EXPERIMENT_TEMPLATE.md` — no output (verbatim copy)
- Repo facts re-verified in the worktree at `b8ad24d5`: `package.json` version field, `CHANGELOG.md` headings (`## [0.5.0] — 2026-05-09` latest), `git tag` (newest `v0.4.0`), bridge throw site at `rstockstrader-bridge.ts:172-174`, README "Strategy presets" section.
- All four linked asset paths confirmed to exist via `ls`/`git ls-files` (sample report and intake JSON live at `packages/strategy-audit-agent/examples/`, not under the patch dir).
- `git diff --check` (unstaged) and `git diff --check --cached` (staged) — clean, no whitespace errors.
- Read-back of all five files after write — content matches intent.
- Push verified: `git rev-parse HEAD` == `git rev-parse origin/docs/receipts-strategy-audit-pilot` == `61398a792caec56d806f2b1d18113b706c902bd3`.

Source: 2026-07-04 Naim portfolio implementation pack, sections Day 3 and Day 7 (trading lane).
