### PR TITLE
fix(ci): restore daily track-record cron; stop scheduling the 4 Cloudflare-blocked dispatchers

### DIFF
--- a/.github/workflows/daily-track-record.yml
+++ b/.github/workflows/daily-track-record.yml
@@ -23,16 +23,21 @@ jobs:
           node-version: '20'
 
       - name: Install Playwright
+        # npm ci reproduces the lockfile-pinned playwright; invoking the install
+        # CLI via the module path guarantees the CLI that downloads the browser
+        # is the same version require("playwright") loads. A floating
+        # `npm install playwright@^1.59.1` here left two playwright generations
+        # in node_modules once upstream drifted past 1.59.x, crashing at
+        # browser launch with a browser-build mismatch.
         run: |
-          npm init -y
-          npm install playwright@^1.59.1
-          npx playwright install --with-deps chromium
+          npm ci
+          node node_modules/playwright/cli.js install --with-deps chromium
 
       - name: Screenshot + post
         env:
           TRACK_RECORD_URL: https://tradeclaw.win/track-record
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHANNEL_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TRADECLAW_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHANNEL_ID: ${{ secrets.TRADECLAW_TELEGRAM_CHANNEL_ID }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
         run: node scripts/post-track-record.js
 

--- a/.github/workflows/push-signals.yml
+++ b/.github/workflows/push-signals.yml
@@ -1,8 +1,17 @@
 name: Push Signals
 
 on:
-  schedule:
-    - cron: "*/15 * * * *"
+  # Schedule disabled 2026-07-11: Cloudflare's managed challenge on
+  # tradeclaw.win 403s GitHub-hosted runner traffic before it reaches the app
+  # (0 successes in 753 runs since this workflow was created). Re-enable once
+  # a Cloudflare WAF skip rule covers /api/cron/* — the endpoint already
+  # enforces bearer CRON_SECRET app-side. NOTE: unlike the other cron
+  # endpoints, /api/cron/push-signals has no slot in the internal
+  # /api/cron/sync fanout, so this workflow was the ONLY trigger for Expo
+  # pushes; the durable fix is a fanout slot (loopback, immune to
+  # Cloudflare), not just the WAF rule.
+  # schedule:
+  #   - cron: "*/15 * * * *"
   workflow_dispatch:
 
 # Prevent overlapping runs.

--- a/.github/workflows/signal-alerts.yml
+++ b/.github/workflows/signal-alerts.yml
@@ -1,8 +1,14 @@
 name: Signal Alerts
 
 on:
-  schedule:
-    - cron: "*/5 * * * *"
+  # Schedule disabled 2026-07-11: Cloudflare's managed challenge on
+  # tradeclaw.win 403s GitHub-hosted runner traffic before it reaches the app
+  # (0 successes in ~1,900 runs since 2026-05-02; GitHub throttles the 5-min
+  # schedule to roughly 27 runs/day). Re-enable once a Cloudflare WAF skip
+  # rule covers /api/cron/* — the endpoint already enforces bearer
+  # CRON_SECRET app-side.
+  # schedule:
+  #   - cron: "*/5 * * * *"
   workflow_dispatch:
 
 # Prevent overlapping runs. If a run takes >5 minutes the next scheduled

--- a/.github/workflows/signal-log.yml
+++ b/.github/workflows/signal-log.yml
@@ -13,11 +13,17 @@ name: Signal Log
 #
 # This workflow no longer writes to the repo — `permissions: contents: read`
 # is enforced. The Vercel/Railway 5-min internal cron already covers normal
-# operation; this scheduled job is a backup trigger every 6 hours.
+# operation; this job was a backup trigger every 6 hours until its schedule
+# was disabled (see below) — manual dispatch remains available.
 
 on:
-  schedule:
-    - cron: "0 */6 * * *"
+  # Schedule disabled 2026-07-11: Cloudflare's managed challenge on
+  # tradeclaw.win 403s GitHub-hosted runner traffic before it reaches the app
+  # (every run red since 2026-05-05). The internal 5-min cron covers normal
+  # operation, so only the backup redundancy is lost. Re-enable once a
+  # Cloudflare WAF skip rule covers /api/cron/*.
+  # schedule:
+  #   - cron: "0 */6 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/telegram-broadcast.yml
+++ b/.github/workflows/telegram-broadcast.yml
@@ -1,8 +1,13 @@
 name: Telegram Broadcast
 
 on:
-  schedule:
-    - cron: "0 */4 * * *"
+  # Schedule disabled 2026-07-11: Cloudflare's managed challenge on
+  # tradeclaw.win 403s GitHub-hosted runner traffic — even this plain GET of
+  # the public /api/digest/daily with a descriptive User-Agent (every run red
+  # since 2026-05-02). Re-enable once a Cloudflare WAF skip rule covers
+  # /api/digest/*.
+  # schedule:
+  #   - cron: "0 */4 * * *"
   workflow_dispatch:
 
 jobs:

--- a/scripts/post-track-record.js
+++ b/scripts/post-track-record.js
@@ -31,9 +31,23 @@ async function screenshot() {
     colorScheme: "dark",
   });
   const page = await ctx.newPage();
-  await page.goto(URL, { waitUntil: "networkidle", timeout: 60_000 });
+  const resp = await page.goto(URL, { waitUntil: "networkidle", timeout: 60_000 });
   // let charts finish animating
   await page.waitForTimeout(2500);
+  // Refuse to post anything that isn't the track record. Cloudflare's managed
+  // challenge serves an interstitial with a 4xx status to datacenter IPs
+  // (GitHub runners included); page.goto resolves on it rather than throwing,
+  // so without this guard the challenge page would be posted to the channel.
+  const status = resp ? resp.status() : 0;
+  const title = await page.title();
+  if (status >= 400 || /just a moment|attention required/i.test(title)) {
+    await page.screenshot({ path: file, fullPage: true });
+    await browser.close();
+    throw new Error(
+      `Refusing to post: HTTP ${status}, title "${title}" — not the track record ` +
+        `(Cloudflare challenge?). Diagnostic screenshot: ${file}`,
+    );
+  }
   await page.screenshot({ path: file, fullPage: true });
   await browser.close();
   return file;


### PR DESCRIPTION
## Summary

All 5 daily/intraday scheduled workflows have been red for weeks. A 6-agent triage of the actual run logs found two distinct root causes; this PR fixes the one that is fixable from the repo and stops burning Actions minutes on the four that are not.

### Commit 1 — restore `daily-track-record` (the standup's "5 dispatchers 403" claim was wrong for this one)

Its logs contain no 403. Every scheduled run crashes pre-network at `browserType.launch`:

- **Playwright version skew**: `npm install playwright@^1.59.1` at the lockfile-pinned workspace root resolved to 1.61.x (needs browser build 1228) while the lockfile-generation CLI downloaded build 1217. Fixed with `npm ci` + `node node_modules/playwright/cli.js install --with-deps chromium` — CLI and module are now the same lockfile-pinned 1.59.1, so skew is structurally impossible. (`npm ci` at root is already proven 5× in `ci.yml`.)
- **Dead secret references**: the workflow referenced `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHANNEL_ID`, which do not exist. The real secrets are `TRADECLAW_TELEGRAM_BOT_TOKEN`/`TRADECLAW_TELEGRAM_CHANNEL_ID` (set 2026-04-04; the same pair that powered ~1,469 successful signal-alerts posts until 2026-05-02). April-era runs completed the screenshot and died on exactly this.
- **No-post guard** (added after adversarial review): `page.goto()` resolves fine on a Cloudflare challenge 403, so a first green run could have screenshotted the "Just a moment..." interstitial and posted it to the public channel captioned "Live, auditable." The script now refuses to post when the load returns ≥400 or the title matches a challenge page, saves a diagnostic screenshot artifact, and exits 1.

### Commit 2 — stop scheduling the 4 Cloudflare-blocked dispatchers

`push-signals`, `signal-alerts`, `signal-log`, `telegram-broadcast` all die at the Cloudflare edge: the managed challenge on `tradeclaw.win` 403s GitHub-hosted runner (Azure datacenter) IPs before requests reach the Railway origin. Captured verbatim in the signal-log run logs (`cType: 'managed'`, `cZone: 'tradeclaw.win'`). The app cannot emit 403 on these paths (`apps/web/lib/cron-auth.ts` returns only 401/503), method/UA changes don't help (telegram-broadcast already GETs with a descriptive UA), and the old Railway origin bypass URL is dead (404). Failure tallies: signal-alerts 0 successes in ~1,900 runs since 2026-05-02; push-signals 0/753 ever; signal-log red since 2026-05-05.

Schedules are commented out with the root cause and re-enable condition documented in place; `workflow_dispatch` stays on all four for re-testing.

## Owner actions required (not fixable in-repo)

1. **Cloudflare WAF skip rule** for zone `tradeclaw.win`: skip managed challenge / Bot Fight Mode for URI paths starting `/api/cron/` and `/api/digest/`. Safe — every cron route enforces bearer `CRON_SECRET` app-side (timing-safe compare) and `/api/digest/daily` is intentionally public. This single rule unblocks all four dispatchers; then uncomment the schedules.
2. **First track-record run**: trigger `workflow_dispatch` with `dry_run=true` and inspect the uploaded artifact before trusting the daily schedule — headless Chromium from a runner IP may still hit the challenge (the guard makes that a loud red run with a diagnostic screenshot, never a public wrong post).
3. **Expo push asymmetry**: `/api/cron/push-signals` has no slot in the internal `/api/cron/sync` fanout, so the disabled workflow was its ONLY trigger. Durable fix is a fanout slot (loopback, immune to Cloudflare) — but the route first needs a dedup gate: it currently re-fetches all high-confidence signals per call with no pushed-marker (re-push spam bug).
4. **Known coverage gap (pre-existing, unchanged by this PR)**: the server-side `/api/cron/telegram` path only posts 6 public symbols at confidence ≥80 within a 30min–2h age window on a 4h cadence; sub-5-minute immediate alerts have no server-side equivalent while signal-alerts' schedule is off.
5. Separate decision, not in this PR: `weekly-report.yml` — the only green scheduled workflow — posts seeded-PRNG-fabricated win-rate/uptime stats to GitHub Discussions weekly, which contradicts the transparency pivot.

Note: `STATE.yaml` log entries still describe the 15-min/5-min cadences as live; left untouched (loop-session-owned), flagging here instead.

## Test plan

- [x] All 5 workflow YAMLs parse (`js-yaml`); `daily-track-record` keeps `schedule`+`workflow_dispatch`, the four disabled ones keep `workflow_dispatch` only
- [x] `node --check scripts/post-track-record.js` passes
- [x] `package-lock.json` pins `playwright`/`playwright-core` 1.59.1 at root; `gh secret list` confirms the `TRADECLAW_*` names (and absence of the old names)
- [x] 3-lens adversarial review (Actions semantics, claim-vs-evidence, blast radius); all HIGH findings addressed (no-post guard), comment dates/tallies corrected against run history
- [ ] Post-merge: `workflow_dispatch` daily-track-record with `dry_run=true`, inspect artifact (owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
