### PR TITLE
ci: park daily-track-record schedule until the Cloudflare WAF rule covers /track-record

### DIFF
--- a/.github/workflows/daily-track-record.yml
+++ b/.github/workflows/daily-track-record.yml
@@ -1,9 +1,16 @@
 name: Daily Track Record Post
 
 on:
-  schedule:
-    # 14:00 UTC = 22:00 MYT (after US close)
-    - cron: '0 14 * * *'
+  # Schedule parked 2026-07-11: dry-run dispatch 29150198868 proved the
+  # install/secret fixes work (Chromium launched, secrets set) but Cloudflare's
+  # managed challenge blocks even headless Chromium from runner IPs —
+  # page.goto times out at networkidle because the challenge keeps the page
+  # busy. Re-enable once the owner's Cloudflare WAF skip rule covers
+  # /track-record for GitHub-runner traffic; verify with a dry_run=true
+  # dispatch first.
+  # schedule:
+  #   # 14:00 UTC = 22:00 MYT (after US close)
+  #   - cron: '0 14 * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/scripts/post-track-record.js
+++ b/scripts/post-track-record.js
@@ -31,7 +31,19 @@ async function screenshot() {
     colorScheme: "dark",
   });
   const page = await ctx.newPage();
-  const resp = await page.goto(URL, { waitUntil: "networkidle", timeout: 60_000 });
+  let resp;
+  try {
+    resp = await page.goto(URL, { waitUntil: "networkidle", timeout: 60_000 });
+  } catch (err) {
+    // The Cloudflare challenge keeps the page busy from datacenter IPs so
+    // networkidle never settles (run 29150198868, 2026-07-11). Capture
+    // whatever rendered before failing so the artifact shows what the runner saw.
+    await page.screenshot({ path: file, fullPage: true }).catch(() => {});
+    await browser.close();
+    throw new Error(
+      `Page load failed: ${String(err && err.message).split("\n")[0]} Diagnostic screenshot: ${file}`,
+    );
+  }
   // let charts finish animating
   await page.waitForTimeout(2500);
   // Refuse to post anything that isn't the track record. Cloudflare's managed


### PR DESCRIPTION
## Summary

Follow-up to #154, driven by its deploy verification. Dry-run dispatch [29150198868](https://github.com/naimkatiman/tradeclaw/actions/runs/29150198868) confirmed the #154 fixes work — `npm ci` + browser install succeeded, Chromium launched, and the `TRADECLAW_*` secrets were populated for the first time since April — but `page.goto` timed out at 60s waiting for `networkidle`: Cloudflare's managed challenge keeps the page busy from GitHub-runner IPs, so **headless Chromium is blocked too**, not just curl.

- Parks the daily 14:00 UTC schedule (comment documents the evidence and re-enable condition); `workflow_dispatch` stays. Without this, tomorrow's run is a guaranteed red.
- `scripts/post-track-record.js` now catches the goto timeout, screenshots whatever rendered, and uploads it as the run artifact — the next manual dispatch shows visually what the runner saw.

## Owner action (updates #154's item 1)

The Cloudflare WAF skip rule needs to cover **`/track-record`** in addition to `/api/cron/*` and `/api/digest/*`. After adding it: `workflow_dispatch` this workflow with `dry_run=true`, check the artifact, then uncomment the schedule.

## Test plan

- [x] `node --check scripts/post-track-record.js`
- [x] YAML parses; `on:` = `workflow_dispatch` only, `dry_run` input intact
- [x] Code review pass: 0 CRITICAL/HIGH (catch block referenced only pre-goto bindings; browser closed on all paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)