### PR TITLE
fix: isolate Railway websocket deployment config

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-07-12T00:43:56+08:00
+updated: 2026-07-12T01:00:02+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -2046,6 +2046,20 @@ tasks:
       /methodology, /why-long-term, /open-data, and /api/health; the Cost Field
       signature is present and /api/research/cost-field returned 4,035 aligned
       gross-R/cost-R/class data points across crypto, metals, and FX.
+
+  - id: TC-238
+    title: "Harden Railway ws-server deployments with service-specific config as code"
+    status: in_progress
+    owner: pm-tradeclaw
+    notes: >
+      Started 2026-07-12 after the Cost Field release exposed that Railway's
+      repository-root railway.toml overrides the ws-server service settings on
+      GitHub-triggered deployments. Added railway.ws-server.toml with the dedicated
+      Dockerfile.ws-server build, /health readiness check, and bounded restart policy.
+      The exact-main web deployment 16034700-1d0e-41a1-be56-02a01a9589d0 reached
+      SUCCESS. Remaining release gate: merge this config, set the production
+      ws-server service custom config path to /railway.ws-server.toml, redeploy,
+      and verify the public websocket health endpoint.
 
 next_actions:
   - "2026-06-07: TC-235 complete. Created weekly performance recap content (X thread + LinkedIn post) highlighting 63.9% non-blacklisted WR, +0.10R expectancy, and methodology transparency. Ready for manual posting. Next: execute GitHub Stars Campaign — ProductHunt launch, HN Show HN post, or Reddit r/algotrading submission using existing prep pages (/launch, /hn, /share, /producthunt)."

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-07-12T01:00:02+08:00
+updated: 2026-07-12T01:03:13+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -2055,7 +2055,8 @@ tasks:
       Started 2026-07-12 after the Cost Field release exposed that Railway's
       repository-root railway.toml overrides the ws-server service settings on
       GitHub-triggered deployments. Added railway.ws-server.toml with the dedicated
-      Dockerfile.ws-server build, /health readiness check, and bounded restart policy.
+      Dockerfile.ws-server build, scoped websocket/shared-package watch paths,
+      /health readiness check, and bounded restart policy.
       The exact-main web deployment 16034700-1d0e-41a1-be56-02a01a9589d0 reached
       SUCCESS. Remaining release gate: merge this config, set the production
       ws-server service custom config path to /railway.ws-server.toml, redeploy,

--- a/railway.ws-server.toml
+++ b/railway.ws-server.toml
@@ -1,6 +1,15 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile.ws-server"
+watchPatterns = [
+  "/railway.ws-server.toml",
+  "/Dockerfile.ws-server",
+  "/.dockerignore",
+  "/package.json",
+  "/package-lock.json",
+  "/apps/ws-server/**",
+  "/packages/signals/**",
+]
 
 [deploy]
 healthcheckPath = "/health"

--- a/railway.ws-server.toml
+++ b/railway.ws-server.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile.ws-server"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- add a dedicated Railway config-as-code file for the websocket relay
- keep GitHub-triggered ws-server deploys on Dockerfile.ws-server and /health
- track the production hardening as TC-238

## Verification
- npm run ws:build
- npm run build (325/325 pages)