### PR TITLE
fix: close SLC motion-polish follow-up gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,6 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     needs: build
-    # Non-blocking until the suite stabilizes. Flip to false once the suite is
-    # consistently green against the CI Postgres sidecar.
-    continue-on-error: true
     timeout-minutes: 30
     services:
       # Ephemeral Postgres per CI run — avoids any risk of writing test signals
@@ -171,8 +168,11 @@ jobs:
       # Sidecar Postgres URL — visible to the migration step, the dev server
       # spawned by Playwright's webServer, and the tests themselves.
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tradeclaw_test
-      USER_SESSION_SECRET: ${{ secrets.E2E_USER_SESSION_SECRET }}
-      CRON_SECRET: ${{ secrets.E2E_CRON_SECRET }}
+      # Fixed test-only values keep blocking E2E deterministic for forks and
+      # Dependabot, where repository secrets are intentionally withheld. These
+      # authenticate only the ephemeral CI server and are never used in prod.
+      USER_SESSION_SECRET: tradeclaw-ci-only-session-secret-not-for-production
+      CRON_SECRET: tradeclaw-ci-only-cron-secret-not-for-production
     defaults:
       run:
         working-directory: apps/web

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -2174,6 +2174,29 @@ tasks:
       was required. Production health returned HTTP 200/status ok, and the focused production
       Playwright suite passed 15/15. No schema or migration changes.
 
+  - id: TC-240
+    title: "Close SLC motion-polish follow-up gaps"
+    status: done
+    owner: pm-tradeclaw
+    notes: >
+      Closed the deferred gaps from merged PR #163 on fix/slc-motion-followups. The legacy
+      AnimatedChartHero now shares the reduced-motion hook and pauses its single-frame RAF
+      scheduler when offscreen or when the document is hidden, with scheduler unit coverage.
+      The homepage finding is neutral rather than rose, labels itself as the public reference
+      result, and renders distinct unavailable, empty, negative, non-negative, and
+      indeterminate ledger copy without fabricating zeros. CostFieldHero likewise separates a
+      legitimate empty dataset from an API failure. Signal-history caching now serves stale
+      snapshots on refresh failure, surfaces cold-read errors, and generation-tags inflight
+      reads so invalidation cannot resurrect stale memory or Redis rows; deferred concurrency,
+      invalidation, and Redis-initialization races are covered. E2E is blocking with CI-only
+      credentials that work on forks, and warmup owns a 180-second timeout. Verification passed:
+      full Jest 134/134 suites and 1,297 tests (3 suites/26 tests intentionally skipped), web
+      TypeScript, focused ESLint, root production build with 325/325 static pages, YAML and diff
+      checks, and production WebKit setup plus all 18 mobile assertions (19/19 total). Manual
+      dark/light visual QA confirmed neutral headline colors and honest no-data states; final
+      independent review found no unresolved High or Medium issues. No schema, migration,
+      dependency, lockfile, Docker, or Railway configuration changes.
+
 next_actions:
   - "2026-06-07: TC-235 complete. Created weekly performance recap content (X thread + LinkedIn post) highlighting 63.9% non-blacklisted WR, +0.10R expectancy, and methodology transparency. Ready for manual posting. Next: execute GitHub Stars Campaign — ProductHunt launch, HN Show HN post, or Reddit r/algotrading submission using existing prep pages (/launch, /hn, /share, /producthunt)."
   - "2026-06-07: TC-234 complete. Added LinkedIn share button to /track-record so visitors can one-click share verified performance stats. Advances ROADMAP 4.5 content pipeline (LinkedIn organic discovery). Build passes 330 pages, tests 111 passed. Next: create weekly performance recap content for X/LinkedIn using the 63.9% non-blacklisted WR milestone, or continue GitHub Stars Campaign prep."

--- a/apps/web/components/animated-chart-hero.test.ts
+++ b/apps/web/components/animated-chart-hero.test.ts
@@ -1,0 +1,77 @@
+import { createPausableAnimationLoop } from "./animated-chart-hero";
+
+function createFrameScheduler() {
+  let nextId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const cancelled: number[] = [];
+
+  return {
+    scheduler: {
+      request(callback: FrameRequestCallback) {
+        const id = nextId++;
+        callbacks.set(id, callback);
+        return id;
+      },
+      cancel(frameId: number) {
+        cancelled.push(frameId);
+        callbacks.delete(frameId);
+      },
+    },
+    callbacks,
+    cancelled,
+    runNext(timestamp = 16) {
+      const entry = callbacks.entries().next().value as
+        | [number, FrameRequestCallback]
+        | undefined;
+      if (!entry) throw new Error("No animation frame is queued");
+
+      const [id, callback] = entry;
+      callbacks.delete(id);
+      callback(timestamp);
+    },
+  };
+}
+
+describe("createPausableAnimationLoop", () => {
+  test("queues one frame while active and cancels it while paused", () => {
+    const frames = createFrameScheduler();
+    const draw = jest.fn();
+    const loop = createPausableAnimationLoop(draw, frames.scheduler);
+
+    expect(frames.callbacks.size).toBe(0);
+
+    loop.setActive(true);
+    loop.setActive(true);
+    expect(frames.callbacks.size).toBe(1);
+
+    frames.runNext(42);
+    expect(draw).toHaveBeenCalledWith(42);
+    expect(frames.callbacks.size).toBe(1);
+
+    const queuedFrameId = [...frames.callbacks.keys()][0];
+    loop.setActive(false);
+    expect(frames.cancelled).toEqual([queuedFrameId]);
+    expect(frames.callbacks.size).toBe(0);
+  });
+
+  test("resumes from a fresh frame and disposal prevents further work", () => {
+    const frames = createFrameScheduler();
+    const draw = jest.fn();
+    const loop = createPausableAnimationLoop(draw, frames.scheduler);
+
+    loop.setActive(true);
+    loop.setActive(false);
+    loop.setActive(true);
+    frames.runNext();
+
+    expect(draw).toHaveBeenCalledTimes(1);
+    expect(frames.callbacks.size).toBe(1);
+
+    loop.dispose();
+    expect(frames.callbacks.size).toBe(0);
+
+    loop.setActive(true);
+    expect(() => frames.runNext()).toThrow("No animation frame is queued");
+    expect(draw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/animated-chart-hero.tsx
+++ b/apps/web/components/animated-chart-hero.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useHeroPrices, formatPairPrice } from "../lib/hooks/use-hero-prices";
+import { useReducedMotion } from "./motion/use-reduced-motion";
 
 interface Particle {
   x: number;
@@ -41,6 +42,56 @@ interface AnimatedChartHeroProps {
   className?: string;
 }
 
+interface AnimationFrameScheduler {
+  request(callback: FrameRequestCallback): number;
+  cancel(frameId: number): void;
+}
+
+/**
+ * Keeps at most one animation frame queued and fully cancels the loop while
+ * inactive. Exported so pause/resume behavior can be verified without a DOM.
+ */
+export function createPausableAnimationLoop(
+  drawFrame: FrameRequestCallback,
+  scheduler: AnimationFrameScheduler,
+) {
+  let active = false;
+  let disposed = false;
+  let frameId: number | null = null;
+
+  const runFrame: FrameRequestCallback = (timestamp) => {
+    frameId = null;
+    if (!active) return;
+
+    drawFrame(timestamp);
+    if (active && frameId === null) {
+      frameId = scheduler.request(runFrame);
+    }
+  };
+
+  return {
+    setActive(nextActive: boolean) {
+      if (disposed) return;
+      active = nextActive;
+
+      if (active) {
+        if (frameId === null) frameId = scheduler.request(runFrame);
+      } else if (frameId !== null) {
+        scheduler.cancel(frameId);
+        frameId = null;
+      }
+    },
+    dispose() {
+      disposed = true;
+      active = false;
+      if (frameId !== null) {
+        scheduler.cancel(frameId);
+        frameId = null;
+      }
+    },
+  };
+}
+
 const ANIMATED_HERO_LABELS = [
   "BTC/USD",
   "XAU/USD",
@@ -64,6 +115,7 @@ export function AnimatedChartHero({
   className = "",
 }: AnimatedChartHeroProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = useReducedMotion();
   const { prices } = useHeroPrices(ANIMATED_HERO_LABELS);
   const symbolsRef = useRef<{ symbol: string; price: string }[]>([]);
 
@@ -79,9 +131,7 @@ export function AnimatedChartHero({
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    // Respect prefers-reduced-motion
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    if (mq.matches) return;
+    if (reducedMotion) return;
 
     const cvs: HTMLCanvasElement = canvas;
     const ctxRaw = cvs.getContext("2d");
@@ -101,7 +151,6 @@ export function AnimatedChartHero({
       };
     }
 
-    let animFrameId: number;
     let t = 0;
     let lastSignalFrame = 0;
     let lastSparkleFrame = 0;
@@ -363,10 +412,7 @@ export function AnimatedChartHero({
     function draw() {
       const w = cvs.width;
       const h = cvs.height;
-      if (w === 0 || h === 0) {
-        animFrameId = requestAnimationFrame(draw);
-        return;
-      }
+      if (w === 0 || h === 0) return;
 
       ctx.clearRect(0, 0, w, h);
 
@@ -509,16 +555,41 @@ export function AnimatedChartHero({
       }
 
       t++;
-      animFrameId = requestAnimationFrame(draw);
     }
 
-    animFrameId = requestAnimationFrame(draw);
+    const animationLoop = createPausableAnimationLoop(draw, {
+      request: (callback) => window.requestAnimationFrame(callback),
+      cancel: (frameId) => window.cancelAnimationFrame(frameId),
+    });
+    let isDocumentVisible = document.visibilityState !== "hidden";
+    let isIntersecting = typeof IntersectionObserver === "undefined";
+
+    const syncAnimation = () => {
+      animationLoop.setActive(isDocumentVisible && isIntersecting);
+    };
+    const handleVisibilityChange = () => {
+      isDocumentVisible = document.visibilityState !== "hidden";
+      syncAnimation();
+    };
+    const intersectionObserver =
+      typeof IntersectionObserver === "undefined"
+        ? null
+        : new IntersectionObserver((entries) => {
+            isIntersecting = entries[0]?.isIntersecting ?? false;
+            syncAnimation();
+          });
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    intersectionObserver?.observe(cvs);
+    syncAnimation();
 
     return () => {
-      cancelAnimationFrame(animFrameId);
+      animationLoop.dispose();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      intersectionObserver?.disconnect();
       ro.disconnect();
     };
-  }, [height]);
+  }, [height, reducedMotion]);
 
   return (
     <canvas

--- a/apps/web/components/landing/cost-field/CostFieldHero.tsx
+++ b/apps/web/components/landing/cost-field/CostFieldHero.tsx
@@ -33,7 +33,7 @@ function webglAvailable(): boolean {
 
 export function CostFieldHero() {
   const [data, setData] = useState<CostFieldData | null>(null);
-  const [failed, setFailed] = useState(false);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
   const [mode, setMode] = useState<CostFieldMode>('auto');
   const [phase, setPhase] = useState<'gross' | 'net'>('gross');
   // WebGL support is a fixed client capability; probe once in a lazy
@@ -48,13 +48,14 @@ export function CostFieldHero() {
       .then((body: CostFieldData & { count: number }) => {
         if (cancelled) return;
         if (!Array.isArray(body.t) || body.t.length === 0) {
-          setFailed(true);
+          setStatus('empty');
           return;
         }
         setData(body);
+        setStatus('ready');
       })
       .catch(() => {
-        if (!cancelled) setFailed(true);
+        if (!cancelled) setStatus('error');
       });
     return () => {
       cancelled = true;
@@ -65,11 +66,14 @@ export function CostFieldHero() {
   const count = data?.t.length ?? 0;
   const countLabel = useMemo(() => count.toLocaleString('en-US'), [count]);
 
-  if (failed) {
+  if (status === 'empty' || status === 'error') {
     return (
       <div className="flex h-full min-h-72 items-center justify-center rounded-[var(--radius-card)] border border-[var(--border)] bg-[var(--glass-bg)] p-6 text-center text-sm text-[var(--text-secondary)]">
         <p>
-          The trade field could not load. The same dataset is at{' '}
+          {status === 'empty'
+            ? 'No resolved, position-sized trades are available in this environment yet. '
+            : 'The trade field could not load. '}
+          Inspect the dataset at{' '}
           <a href={DATA_URL} className="underline hover:text-[var(--foreground)]">
             {DATA_URL}
           </a>{' '}

--- a/apps/web/components/landing/proof-hero.tsx
+++ b/apps/web/components/landing/proof-hero.tsx
@@ -81,7 +81,17 @@ function LedgerItem({
 
 export async function ProofHero() {
   const eq = await fetchEquitySummary();
-  const trades = eq?.sizedTrades ?? eq?.totalSignals;
+  const trades = eq?.sizedTrades ?? eq?.totalSignals ?? 0;
+  const hasMeasuredTrades = trades > 0;
+  const ledgerState = !eq
+    ? 'unavailable'
+    : !hasMeasuredTrades
+      ? 'empty'
+      : eq.netExpectancyR == null
+        ? 'indeterminate'
+        : eq.netExpectancyR < 0
+          ? 'negative'
+          : 'nonnegative';
 
   return (
     <section data-testid="proof-hero" className="mx-auto max-w-6xl px-4 pt-6">
@@ -89,26 +99,64 @@ export async function ProofHero() {
         {/* The claim */}
         <div className="flex flex-col justify-center lg:col-span-5">
           <p className="animate-fade-up font-mono text-[11px] uppercase tracking-[0.2em] text-[var(--text-secondary)]">
-            Open-source trading transparency
+            Public reference finding · open-source transparency
           </p>
           {/* The page's one orchestrated load entrance (DESIGN.md Motion):
               headline lands line by line, the finding last. */}
           <h1 className="font-display mt-4 text-[clamp(2.75rem,6.5vw,5rem)] font-bold uppercase leading-[0.92] tracking-tight">
             <span className="animate-fade-up fade-delay-1 block">We measured</span>
             <span className="animate-fade-up fade-delay-2 block">the edge.</span>
-            <span className="animate-fade-up fade-delay-3 block text-[var(--color-down)]">
+            <span className="animate-fade-up fade-delay-3 block">
               There isn&apos;t one.
             </span>
           </h1>
           <p className="animate-fade-up fade-delay-3 mt-5 max-w-md text-sm leading-relaxed text-[var(--text-secondary)]">
-            TradeClaw runs a real signal engine and charges every sized trade its
-            real execution cost. After costs, net expectancy is negative:
-            short-term timing loses what it costs to trade. The engine, the
-            {' '}{trades ? trades.toLocaleString('en-US') : ''} recorded trades, and
-            this conclusion are free for anyone to check, fork, and reuse.
+            {ledgerState === 'negative' ? (
+              <>
+                TradeClaw runs a real signal engine and charges every sized trade
+                its real execution cost. After costs, this environment&apos;s net
+                expectancy is negative: short-term timing loses what it costs to
+                trade. The engine, its {trades.toLocaleString('en-US')} recorded
+                position-sized trades, and this measured finding are free for
+                anyone to check, fork, and reuse.
+              </>
+            ) : ledgerState === 'nonnegative' ? (
+              <>
+                TradeClaw runs a real signal engine and charges every sized trade
+                its real execution cost. This environment&apos;s{' '}
+                {trades.toLocaleString('en-US')} recorded trades currently report
+                non-negative net expectancy after cost. The ledger shows that
+                result as-is; it does not substitute the public reference result.
+                The engine, cost model, and reported result are free for anyone to
+                check, fork, and reuse.
+              </>
+            ) : ledgerState === 'indeterminate' ? (
+              <>
+                This environment has {trades.toLocaleString('en-US')} recorded
+                trades, but not enough sized win/loss evidence to compute net
+                expectancy after cost. The ledger reports the available evidence
+                as-is; no reference or placeholder values are substituted. The
+                engine and cost model remain free for anyone to check, fork, and
+                reuse.
+              </>
+            ) : ledgerState === 'empty' ? (
+              <>
+                The headline states TradeClaw&apos;s public reference finding. This
+                environment does not yet have the resolved, position-sized trades
+                needed to recompute it. The engine, cost model, and methodology
+                remain free for anyone to check, fork, and reuse.
+              </>
+            ) : (
+              <>
+                The headline states TradeClaw&apos;s public reference finding. This
+                environment&apos;s live ledger is temporarily unavailable, so it
+                cannot recompute the result right now. The engine, cost model, and
+                methodology remain free for anyone to check, fork, and reuse.
+              </>
+            )}
           </p>
 
-          {eq ? (
+          {eq && hasMeasuredTrades ? (
             <dl className="animate-fade-up fade-delay-4 mt-7 grid grid-cols-2 gap-x-2 divide-y divide-[var(--border)] border-y border-[var(--border)] sm:grid-cols-2">
               <LedgerItem
                 label="net expectancy / trade, after cost"
@@ -181,12 +229,25 @@ export async function ProofHero() {
               />
             </dl>
           ) : (
-            <p className="animate-fade-up fade-delay-4 mt-7 border-y border-[var(--border)] py-3 text-sm text-[var(--text-secondary)]">
-              The live cost-adjusted result loads on the{' '}
+            <p
+              className="animate-fade-up fade-delay-4 mt-7 border-y border-[var(--border)] py-3 text-sm text-[var(--text-secondary)]"
+              data-testid="proof-ledger-empty"
+            >
+              {eq
+                ? 'No resolved, position-sized trades are available in this environment yet. '
+                : 'The live cost-adjusted ledger is temporarily unavailable. '}
+              Inspect the{' '}
               <a href="/track-record" className="underline hover:text-[var(--foreground)]">
-                track record
+                full track record
               </a>
-              .
+              {' '}or the{' '}
+              <a
+                href="/api/signals/equity?summaryOnly=1&scope=pro"
+                className="underline hover:text-[var(--foreground)]"
+              >
+                raw summary
+              </a>{' '}
+              instead of placeholder results.
             </p>
           )}
 

--- a/apps/web/lib/__tests__/signal-history-cache.test.ts
+++ b/apps/web/lib/__tests__/signal-history-cache.test.ts
@@ -1,38 +1,144 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+jest.mock('../redis', () => ({
+  redis: null,
+  isRedisAvailable: jest.fn(() => false),
+  ensureRedis: jest.fn().mockResolvedValue(false),
+  redisKey: jest.fn((key: string) => key),
+}));
+
+jest.mock('../signal-history', () => ({
+  readHistoryAsync: jest.fn(),
+}));
+
 import {
   getCachedHistory,
   invalidateHistoryCache,
   _setCacheForTest,
 } from '../signal-history-cache';
+import { ensureRedis } from '../redis';
+import { readHistoryAsync, type SignalHistoryRecord } from '../signal-history';
 
-vi.mock('../signal-history', () => ({
-  readHistoryAsync: vi.fn().mockResolvedValue([]),
-}));
+const mockedReadHistory = readHistoryAsync as jest.MockedFunction<typeof readHistoryAsync>;
+const mockedEnsureRedis = ensureRedis as jest.MockedFunction<typeof ensureRedis>;
+const fakeRows = [{ id: '1', pair: 'BTCUSD' }] as unknown as SignalHistoryRecord[];
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function flushAsyncWork(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 describe('signal-history-cache', () => {
   beforeEach(async () => {
+    jest.useRealTimers();
+    mockedEnsureRedis.mockReset();
+    mockedEnsureRedis.mockResolvedValue(false);
+    mockedReadHistory.mockReset();
+    mockedReadHistory.mockResolvedValue([]);
     await invalidateHistoryCache();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('returns injected test data immediately', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fakeRows = [{ id: '1', pair: 'BTCUSD' }] as any;
     _setCacheForTest(fakeRows);
     const result = await getCachedHistory();
     expect(result).toEqual(fakeRows);
+    expect(mockedReadHistory).not.toHaveBeenCalled();
   });
 
-  it('returns empty array when cache is cold and no db (test env)', async () => {
+  it('preserves a legitimate empty result from the history source', async () => {
     const result = await getCachedHistory();
-    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([]);
   });
 
   it('invalidation clears the cache', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fakeRows = [{ id: '1', pair: 'BTCUSD' }] as any;
     _setCacheForTest(fakeRows);
     await invalidateHistoryCache();
     const result = await getCachedHistory();
     expect(result).toEqual([]);
+  });
+
+  it('rethrows a cold history read failure instead of fabricating an empty ledger', async () => {
+    mockedReadHistory.mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(getCachedHistory()).rejects.toThrow('database unavailable');
+  });
+
+  it('serves an expired in-memory snapshot when a refresh fails', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-14T00:00:00Z'));
+    _setCacheForTest(fakeRows);
+    jest.advanceTimersByTime(10 * 60 * 1000 + 1);
+    mockedReadHistory.mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(getCachedHistory()).resolves.toEqual(fakeRows);
+  });
+
+  it('deduplicates concurrent history reads', async () => {
+    const pending = deferred<SignalHistoryRecord[]>();
+    mockedReadHistory.mockReturnValueOnce(pending.promise);
+
+    const first = getCachedHistory();
+    const second = getCachedHistory();
+    await flushAsyncWork();
+
+    expect(mockedReadHistory).toHaveBeenCalledTimes(1);
+    pending.resolve(fakeRows);
+    await expect(Promise.all([first, second])).resolves.toEqual([fakeRows, fakeRows]);
+  });
+
+  it('does not let an invalidated read overwrite a newer generation', async () => {
+    const oldRows = [{ id: 'old', pair: 'ETHUSD' }] as unknown as SignalHistoryRecord[];
+    const newRows = [{ id: 'new', pair: 'SOLUSD' }] as unknown as SignalHistoryRecord[];
+    const pendingOldRead = deferred<SignalHistoryRecord[]>();
+    mockedReadHistory
+      .mockReturnValueOnce(pendingOldRead.promise)
+      .mockResolvedValueOnce(newRows);
+
+    const oldRead = getCachedHistory();
+    await flushAsyncWork();
+    expect(mockedReadHistory).toHaveBeenCalledTimes(1);
+
+    await invalidateHistoryCache();
+    const freshRead = getCachedHistory();
+    await flushAsyncWork();
+    expect(mockedReadHistory).toHaveBeenCalledTimes(2);
+
+    pendingOldRead.resolve(oldRows);
+    await expect(oldRead).resolves.toEqual(oldRows);
+    await expect(freshRead).resolves.toEqual(newRows);
+    await expect(getCachedHistory()).resolves.toEqual(newRows);
+    expect(mockedReadHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejoins the current generation when invalidated during Redis initialization', async () => {
+    const newRows = [{ id: 'new', pair: 'XAUUSD' }] as unknown as SignalHistoryRecord[];
+    const pendingRedisInitialization = deferred<boolean>();
+    mockedEnsureRedis
+      .mockReturnValueOnce(pendingRedisInitialization.promise)
+      .mockResolvedValue(false);
+    mockedReadHistory.mockResolvedValueOnce(newRows);
+
+    const supersededRead = getCachedHistory();
+    await flushAsyncWork();
+    expect(mockedEnsureRedis).toHaveBeenCalledTimes(1);
+    expect(mockedReadHistory).not.toHaveBeenCalled();
+
+    await invalidateHistoryCache();
+    await expect(getCachedHistory()).resolves.toEqual(newRows);
+
+    pendingRedisInitialization.resolve(false);
+    await expect(supersededRead).resolves.toEqual(newRows);
+    expect(mockedReadHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/signal-history-cache.ts
+++ b/apps/web/lib/signal-history-cache.ts
@@ -9,8 +9,15 @@ interface CacheEntry {
   expiresAt: number;
 }
 
+interface InflightRead {
+  generation: number;
+  token: symbol;
+  promise: Promise<SignalHistoryRecord[]>;
+}
+
 let memoryCache: CacheEntry | null = null;
-let inflight: Promise<SignalHistoryRecord[]> | null = null;
+let cacheGeneration = 0;
+let inflight: InflightRead | null = null;
 
 /**
  * Returns cached signal history. On first call (or after TTL expiry),
@@ -21,6 +28,8 @@ let inflight: Promise<SignalHistoryRecord[]> | null = null;
  * so the app works without Redis in test/local environments.
  */
 export async function getCachedHistory(): Promise<SignalHistoryRecord[]> {
+  const generation = cacheGeneration;
+
   // 1. Try in-memory first (fastest)
   if (memoryCache && Date.now() < memoryCache.expiresAt) {
     return memoryCache.rows;
@@ -34,50 +43,79 @@ export async function getCachedHistory(): Promise<SignalHistoryRecord[]> {
       if (raw) {
         const parsed = JSON.parse(raw) as CacheEntry;
         if (parsed.expiresAt > Date.now()) {
+          if (generation !== cacheGeneration) {
+            return getCachedHistory();
+          }
           memoryCache = parsed; // warm local memory
           return parsed.rows;
         }
-        // Stale — remove it
-        await redis.del(CACHE_KEY);
+        // Stale — remove it only if no invalidation superseded this read.
+        if (generation === cacheGeneration) {
+          await redis.del(CACHE_KEY);
+        }
       }
     }
   } catch {
     // Redis unavailable — fall through to DB fetch
   }
 
-  // 3. Deduplicated DB fetch
-  if (inflight) return inflight;
+  // Invalidation may have happened while Redis initialization or lookup was
+  // pending. Retry at the current generation before touching the inflight slot.
+  if (generation !== cacheGeneration) {
+    return getCachedHistory();
+  }
 
-  inflight = (async () => {
+  // 3. Deduplicated DB fetch. A generation prevents an invalidated request
+  // from being shared with, or overwriting, a newer request.
+  if (inflight?.generation === generation) return inflight.promise;
+
+  const requestToken = Symbol('signal-history-read');
+  const promise = (async () => {
     try {
       const { readHistoryAsync } = await import('./signal-history');
       const rows = await readHistoryAsync();
       const entry: CacheEntry = { rows, expiresAt: Date.now() + TTL_MS };
 
-      // Write back to Redis (best-effort)
+      // Write back to Redis (best-effort).
       try {
-        if (isRedisAvailable() && redis) {
+        if (generation === cacheGeneration && isRedisAvailable() && redis) {
           await redis.set(CACHE_KEY, JSON.stringify(entry), 'PX', TTL_MS);
+          // Invalidation may have raced the write. Delete the old generation
+          // again so this request cannot resurrect stale rows in Redis.
+          if (generation !== cacheGeneration) {
+            await redis.del(CACHE_KEY);
+          }
         }
       } catch {
         // ignore Redis write errors
       }
 
-      memoryCache = entry;
+      if (generation === cacheGeneration) {
+        memoryCache = entry;
+      }
       return rows;
-    } catch {
-      return memoryCache?.rows ?? [];
+    } catch (error) {
+      // An expired snapshot is safer than turning a transient database outage
+      // into a convincing zero-signal result. With no prior snapshot, surface
+      // the read failure so API/UI callers can render an unavailable state.
+      if (memoryCache) return memoryCache.rows;
+      throw error;
     } finally {
-      inflight = null;
+      if (inflight?.token === requestToken) {
+        inflight = null;
+      }
     }
   })();
 
-  return inflight;
+  inflight = { generation, token: requestToken, promise };
+  return promise;
 }
 
 /** Force-expire the cache (call after new signals are recorded). */
 export async function invalidateHistoryCache(): Promise<void> {
+  cacheGeneration += 1;
   memoryCache = null;
+  inflight = null;
   try {
     if (isRedisAvailable() && redis) {
       await redis.del(CACHE_KEY);

--- a/apps/web/tests/e2e/warmup.setup.ts
+++ b/apps/web/tests/e2e/warmup.setup.ts
@@ -1,5 +1,9 @@
 import { test as setup, expect } from '@playwright/test';
 
+// The three warmups each permit 60s, so the enclosing setup must not retain
+// Playwright's 30s default and abort a healthy final request mid-flight.
+setup.setTimeout(180_000);
+
 // Warms the signal-generation paths so the first real assertion in the suite
 // doesn't pay the ~10-15s cold cost. The request path warms the in-process
 // OHLCV cache (lib/ohlcv.ts), shared across the suite because CI runs a single

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
     "/.next/",
     "/apps/web/tests/e2e/",
     "/apps/ws-server/",
-    "/apps/web/lib/__tests__/signal-history-cache.test.ts",
   ],
   modulePathIgnorePatterns: [
     "/.next/standalone/",


### PR DESCRIPTION
## Summary

Follow-up to #163 that closes every deferred motion-polish gap without adding dependencies.

- pause the legacy canvas animation offscreen, in hidden tabs, and under reduced motion
- make the homepage proof ledger honest for unavailable, empty, negative, non-negative, and indeterminate datasets
- distinguish an empty Cost Field dataset from an API failure
- prevent signal-history cache invalidation races from resurrecting stale memory or Redis rows
- make Playwright E2E blocking and deterministic for fork/Dependabot runs
- give the warmup setup enough time for all three bounded requests

## Root cause and impact

The remaining gaps were lifecycle and state-modeling issues rather than missing visual effects: the canvas RAF loop never paused, empty data was indistinguishable from backend failure, transient history failures could look like a legitimate zero ledger, and an invalidated in-flight read could repopulate stale cache state. CI was also non-blocking and depended on secrets unavailable to forks.

The result is lower idle browser work, truthful proof states in every environment, generation-safe cache invalidation, and a WebKit-capable E2E gate that can actually block regressions.

## Verification

- full Jest: 134 suites / 1,297 tests passed; 3 suites / 26 tests intentionally skipped
- focused cache + animation Jest: 10/10
- web TypeScript: clean
- focused ESLint: clean
- root production build: 325/325 static pages
- production WebKit/mobile: 19/19 including setup
- manual dark/light visual QA
- independent final review: no unresolved High or Medium findings
- STATE.yaml and workflow YAML parse; git diff check clean

No dependency, lockfile, schema, migration, Docker, or Railway configuration changes.