### PR TITLE
fix(test): stop Jest indexing .codex worktree copies; ignore local agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ node_modules/
 # Worktrees
 .worktrees/
 
-# Local Claude Code agent state (worktrees, settings, projects) — never track
+# Local agent state (worktrees, settings, projects) — never track
 .claude/
+.codex/
 
 # Generated data
 scripts/signals.db
@@ -34,3 +35,7 @@ graphify-out/
 # strategy-audit-agent runtime output (logs, fixture runs)
 /audit-output/
 packages/strategy-audit-agent/tmp/
+
+# Playwright agent artifacts (screenshots, console logs, page snapshots)
+/output/
+.playwright-cli/

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   modulePathIgnorePatterns: [
     "/.next/standalone/",
     "/.claude/worktrees/",
+    "/.codex/worktrees/",
   ],
   transform: {
     ...tsJestTransformCfg,


### PR DESCRIPTION
Two tooling defects found by a full-sweep repository audit. Both share one root cause: untracked `.codex/` worktree checkouts sit under the project root and nothing excludes them.

## 1. Jest indexes the `.codex` worktree copies

`modulePathIgnorePatterns` excluded `/.claude/worktrees/` but never `/.codex/worktrees/`. Two registered worktrees (`main-release-b4b04388`, `pr166-release`) mirror the whole repo — including `package.json`, `apps/web/lib/__mocks__/`, and `scripts/research/__tests__/` — under `rootDir`.

Before, running the recost suites by pattern from the repo root:

```
Test Suites: 1 failed, 3 passed, 4 total
Tests:       23 failed, 52 passed, 75 total
Error: Cannot find module 'C:\Ai\tradeclaw\.codex\worktrees\main-release-b4b04388\node_modules\tsx\dist\cli.mjs'
jest-haste-map: duplicate manual mock found: signal-history
```

Jest matched **4 suites instead of 2** and failed 23 tests from a worktree that has no `node_modules`. After:

```
Test Suites: 2 passed, 2 total
Tests:       29 passed, 29 total
```

No collision warnings. This is the identical defect already fixed for `/.claude/worktrees/` on 2026-06-03 (STATE.yaml:2317 records 37 suite failures from the same cause); `.codex/worktrees/` was simply never added when that tooling started writing worktrees.

## 2. `.gitignore` does not cover local agent state or Playwright artifacts

Three surfaces were untracked but **not** ignored — one `git add -A` away from being committed:

| Path | Contents |
|---|---|
| `.codex/` | two full registered worktree checkouts of the repo |
| `/output/` | 4 Playwright agent screenshots |
| `.playwright-cli/` | 14 console logs and page snapshots |

`.claude/` was already ignored for exactly this reason. Checked before ignoring: `/output/` is **not** the recost `--json` target — `scripts/research/recost-segment.ts` only writes to the user-supplied path — so nothing depends on tracking it. The registered worktrees themselves are left alone; only the ignore rule changes.

## Test plan

- [x] `npx jest scripts/research/__tests__/recost-report.test.ts scripts/research/__tests__/recost-segment-cli.test.ts --runInBand --forceExit` — 2 suites / 29 tests pass, no Haste warnings (was 4 suites, 23 failed)
- [x] `git status --porcelain --ignored=matching` — `.codex/`, `.playwright-cli/`, `output/` report `!!` (ignored), previously `??` (untracked)
- [x] No product code touched; both files are developer tooling. No web runtime, trading-rule, DB/schema, auth, deployment, cron, secret, or dependency surface is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
