### PR TITLE
fix(production): close evidence and rendering gaps

### DIFF
--- a/apps/web/app/api/og/summary/route.tsx
+++ b/apps/web/app/api/og/summary/route.tsx
@@ -51,40 +51,40 @@ export async function GET(request: Request) {
           </span>
         </div>
 
-        <div style={{ fontSize: '18px', color: '#6b7280', marginBottom: '36px' }}>{dateStr}</div>
+        <div style={{ display: 'flex', fontSize: '18px', color: '#6b7280', marginBottom: '36px' }}>{dateStr}</div>
 
         {/* Stats */}
         <div style={{ display: 'flex', gap: '56px', marginBottom: '40px' }}>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <div style={{ fontSize: '64px', fontWeight: 800, color: sumPriceMoveColor }}>
+            <div style={{ display: 'flex', fontSize: '64px', fontWeight: 800, color: sumPriceMoveColor }}>
               {available ? `${sumPriceMovePct >= 0 ? '+' : ''}${sumPriceMovePct.toFixed(2)}%` : unavailable}
             </div>
-            <div style={{ fontSize: '14px', color: '#6b7280', letterSpacing: '0.08em' }}>
+            <div style={{ display: 'flex', fontSize: '14px', color: '#6b7280', letterSpacing: '0.08em' }}>
               UNSIZED SUM OF PRICE MOVES
             </div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <div style={{ fontSize: '64px', fontWeight: 800, color: available ? '#ffffff' : '#71717a' }}>
+            <div style={{ display: 'flex', fontSize: '64px', fontWeight: 800, color: available ? '#ffffff' : '#71717a' }}>
               {available ? `${s.winRatePct.toFixed(1)}%` : unavailable}
             </div>
-            <div style={{ fontSize: '16px', color: '#6b7280', letterSpacing: '0.08em' }}>WIN RATE</div>
+            <div style={{ display: 'flex', fontSize: '16px', color: '#6b7280', letterSpacing: '0.08em' }}>WIN RATE</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <div style={{ display: 'flex', gap: '16px', alignItems: 'baseline' }}>
-              <div style={{ fontSize: '48px', fontWeight: 800, color: available ? '#10b981' : '#71717a' }}>
+              <div style={{ display: 'flex', fontSize: '48px', fontWeight: 800, color: available ? '#10b981' : '#71717a' }}>
                 {available ? s.wins : unavailable}
               </div>
-              <div style={{ fontSize: '48px', fontWeight: 800, color: '#3f3f46' }}>/</div>
-              <div style={{ fontSize: '48px', fontWeight: 800, color: available ? '#f43f5e' : '#71717a' }}>
+              <div style={{ display: 'flex', fontSize: '48px', fontWeight: 800, color: '#3f3f46' }}>/</div>
+              <div style={{ display: 'flex', fontSize: '48px', fontWeight: 800, color: available ? '#f43f5e' : '#71717a' }}>
                 {available ? s.losses : unavailable}
               </div>
             </div>
-            <div style={{ fontSize: '16px', color: '#6b7280', letterSpacing: '0.08em' }}>WINS / LOSSES</div>
+            <div style={{ display: 'flex', fontSize: '16px', color: '#6b7280', letterSpacing: '0.08em' }}>WINS / LOSSES</div>
           </div>
         </div>
 
         {/* Footer */}
-        <div style={{ color: '#3f3f46', fontSize: '14px', letterSpacing: '0.05em' }}>
+        <div style={{ display: 'flex', color: '#3f3f46', fontSize: '14px', letterSpacing: '0.05em' }}>
           Source-approved OHLCV outcomes only; unavailable when none are counted. Not portfolio P/L or broker fills.
         </div>
       </div>

--- a/apps/web/app/earningsedge/layout.tsx
+++ b/apps/web/app/earningsedge/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function EarningsEdgeLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-white">
-      <nav className="border-b border-white/10 px-6 py-4">
+      <nav className="border-b border-white/10 px-4 py-4 sm:px-6">
         <div className="max-w-6xl mx-auto flex items-center justify-between">
           <a href="/earningsedge" className="flex items-center gap-2">
             <span className="text-green-400 font-bold text-xl">EarningsEdge</span>
@@ -17,22 +17,22 @@ export default function EarningsEdgeLayout({ children }: { children: React.React
               Beta
             </span>
           </a>
-          <div className="flex items-center gap-6">
+          <div className="flex items-center gap-3 sm:gap-6">
             <a
               href="/earningsedge/analyze"
-              className="text-sm text-gray-400 hover:text-white transition-colors"
+              className="hidden text-sm text-gray-400 hover:text-white transition-colors sm:inline"
             >
               Analyze
             </a>
             <a
               href="/earningsedge/pricing"
-              className="text-sm text-gray-400 hover:text-white transition-colors"
+              className="hidden text-sm text-gray-400 hover:text-white transition-colors sm:inline"
             >
               Pricing
             </a>
             <a
               href="/earningsedge/analyze"
-              className="text-sm bg-green-500 hover:bg-green-400 text-black font-semibold px-4 py-1.5 rounded-lg transition-colors"
+              className="whitespace-nowrap rounded-lg bg-green-500 px-3 py-1.5 text-sm font-semibold text-black transition-colors hover:bg-green-400 sm:px-4"
             >
               Try Free
             </a>
@@ -41,7 +41,7 @@ export default function EarningsEdgeLayout({ children }: { children: React.React
       </nav>
       {children}
       <footer className="border-t border-white/10 mt-24 py-8 px-6">
-        <div className="max-w-6xl mx-auto flex items-center justify-between text-sm text-gray-500">
+        <div className="max-w-6xl mx-auto flex flex-col items-start gap-4 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
           <span>© 2026 EarningsEdge by TradeClaw</span>
           <div className="flex gap-6">
             <a href="/earningsedge/pricing" className="hover:text-gray-300 transition-colors">

--- a/apps/web/lib/__tests__/leaderboard-ranking.test.ts
+++ b/apps/web/lib/__tests__/leaderboard-ranking.test.ts
@@ -1,0 +1,77 @@
+import { recomputeOverall, type AssetStats } from '../signal-history';
+
+function asset(overrides: Partial<AssetStats> = {}): AssetStats {
+  return {
+    pair: 'BTCUSD',
+    totalSignals: 10,
+    resolved4h: 4,
+    resolved24h: 4,
+    hits4h: 2,
+    hits24h: 2,
+    hitRate4h: 50,
+    hitRate24h: 50,
+    avgConfidence: 75,
+    avgPnl: 0,
+    totalPnl: 0,
+    bestStreak: 1,
+    worstStreak: -1,
+    recentHits: [true, false],
+    ...overrides,
+  };
+}
+
+function unresolvedAsset(pair: string, totalSignals: number = 10): AssetStats {
+  return asset({
+    pair,
+    totalSignals,
+    resolved4h: 0,
+    resolved24h: 0,
+    hits4h: 0,
+    hits24h: 0,
+    hitRate4h: 0,
+    hitRate24h: 0,
+    avgPnl: 0,
+    totalPnl: 0,
+    bestStreak: 0,
+    worstStreak: 0,
+    recentHits: [],
+  });
+}
+
+describe('leaderboard performer evidence boundary', () => {
+  it('excludes zero-evidence assets from best and worst performer selection', () => {
+    const overall = recomputeOverall([
+      asset({ pair: 'BTCUSD', hitRate24h: 75, hits24h: 3 }),
+      asset({ pair: 'ETHUSD', hitRate24h: 25, hits24h: 1, totalPnl: -2 }),
+      unresolvedAsset('SOLUSD'),
+    ]);
+
+    expect(overall.topPerformer).toBe('BTCUSD');
+    expect(overall.worstPerformer).toBe('ETHUSD');
+  });
+
+  it('returns unavailable performer markers when every asset has zero evidence', () => {
+    const overall = recomputeOverall([
+      unresolvedAsset('SOLUSD'),
+      unresolvedAsset('SPYUSD'),
+    ]);
+
+    expect(overall.resolvedSignals).toBe(0);
+    expect(overall.topPerformer).toBe('\u2014');
+    expect(overall.worstPerformer).toBe('\u2014');
+  });
+
+  it('keeps zero-evidence signal totals while ranking only mixed evidence-backed assets', () => {
+    const overall = recomputeOverall([
+      asset({ pair: 'BTCUSD', totalSignals: 8, resolved24h: 2, hits24h: 1, hitRate24h: 50 }),
+      asset({ pair: 'ETHUSD', totalSignals: 7, resolved24h: 5, hits24h: 4, hitRate24h: 80 }),
+      unresolvedAsset('SOLUSD', 20),
+    ]);
+
+    expect(overall.totalSignals).toBe(35);
+    expect(overall.resolvedSignals).toBe(7);
+    expect(overall.overallHitRate24h).toBe(71.4);
+    expect(overall.topPerformer).toBe('ETHUSD');
+    expect(overall.worstPerformer).toBe('BTCUSD');
+  });
+});

--- a/apps/web/lib/signal-history.ts
+++ b/apps/web/lib/signal-history.ts
@@ -217,13 +217,14 @@ export function recomputeOverall(
   const hits24h = assets.reduce((sum, a) => sum + a.hits24h, 0);
   const totalPnl = +assets.reduce((sum, a) => sum + a.totalPnl, 0).toFixed(2);
 
-  const byHitRate = [...assets].sort((a, b) =>
+  const rankedAssets = assets.filter(a => a.resolved24h > 0);
+  const byHitRate = [...rankedAssets].sort((a, b) =>
     b.hitRate24h - a.hitRate24h
     || b.totalPnl - a.totalPnl
     || b.totalSignals - a.totalSignals
     || a.pair.localeCompare(b.pair),
   );
-  const byWorstHitRate = [...assets].sort((a, b) =>
+  const byWorstHitRate = [...rankedAssets].sort((a, b) =>
     a.hitRate24h - b.hitRate24h
     || a.totalPnl - b.totalPnl
     || b.totalSignals - a.totalSignals

--- a/apps/web/tests/e2e/api/og-images.spec.ts
+++ b/apps/web/tests/e2e/api/og-images.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+const routes = [
+  '/api/og/leaderboard',
+  '/api/og/track-record',
+  '/api/og/summary?period=daily&date=2026-07-15',
+] as const;
+
+test.describe('Open Graph image routes', () => {
+  for (const route of routes) {
+    test(`${route} returns a rendered image`, async ({ request }) => {
+      const response = await request.get(route);
+      const body = await response.body();
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()['content-type']).toMatch(/^image\//);
+      expect(body.byteLength).toBeGreaterThan(1_000);
+    });
+  }
+});

--- a/apps/web/tests/e2e/features/earningsedge-pricing.spec.ts
+++ b/apps/web/tests/e2e/features/earningsedge-pricing.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('EarningsEdge pricing layout', () => {
+  test('keeps the header CTA and page content inside the viewport', async ({ page }) => {
+    await page.goto('/earningsedge/pricing');
+
+    const cta = page.getByRole('link', { name: 'Try Free' });
+    await expect(cta).toBeVisible();
+
+    const ctaBox = await cta.boundingBox();
+    expect(ctaBox).not.toBeNull();
+    expect(ctaBox!.x).toBeGreaterThanOrEqual(0);
+    expect(ctaBox!.x + ctaBox!.width).toBeLessThanOrEqual(await page.evaluate(() => window.innerWidth));
+
+    const dimensions = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+  });
+});


### PR DESCRIPTION
## Summary
- exclude zero-evidence assets from best/worst leaderboard rankings
- restore the daily summary OG image response
- keep the EarningsEdge mobile pricing CTA inside the viewport
- add focused Jest and Playwright regression coverage

## Production findings addressed
- `SOLUSD` was labeled worst performer despite zero resolved 24h outcomes
- `/api/og/summary?period=daily` returned 502 from Satori layout validation
- `/earningsedge/pricing` overflowed by 29px at 390x844 and clipped `Try Free`

## Verification
- `npm run build`
- web TypeScript and scoped ESLint
- 3 focused Jest suites, 17 tests
- targeted production-mode Playwright, 5 tests
- manual Chromium check at 390x844
- summary OG image rendered locally as PNG