### PR TITLE
fix(health): report truthful release identity

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-07-16T23:46:46+08:00
+updated: 2026-07-16T23:49:09+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -136,7 +136,7 @@ ci_integrity_followup_2026_07_16:
     full 324-page build also pass locally.
 
 claim_verification_last_run:
-  at: 2026-07-15T16:40:32+08:00
+  at: 2026-07-16T23:49:09+08:00
   agent: TradeClaw PM agent
   status: done
   scope: LinkedIn loss-claim evidence review and WEEX outreach verification
@@ -150,9 +150,12 @@ claim_verification_last_run:
     truncated. The supported claim is negative modeled signal expectancy under
     stated assumptions; actual customer, broker-fill, portfolio-loss, and
     sequential-account-return claims remain unsupported. WEEX fee sharing is not
-    a percentage of volume, the advertised TradFi campaign ended 2026-07-08, the
-    contact identity remains unverified, and Malaysian promotion remains a legal
-    review issue because WEEX is absent from the SC registered-DAX list.
+    a percentage of volume. The selected-region zero-fee offer ended 2026-07-08,
+    while the current TradFi page advertises a separate 9-23 July trading
+    challenge; TradeClaw-user eligibility, attribution, and commission treatment
+    remain unverified. The contact identity remains unverified, and Malaysian
+    promotion remains a legal review issue because WEEX is absent from the SC
+    registered-DAX list.
 
 product_integrity_repair:
   at: 2026-07-15T11:24:23+08:00

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,11 +1,27 @@
 project: tradeclaw
-updated: 2026-07-16T23:18:47+08:00
+updated: 2026-07-16T23:43:19+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
   Public mode = limited. Admin = full.
   Alpha Screener = confirmed SaaS brand for users who don't want to self-host. Tradesmart name is dropped.
   Goal: viral GitHub repo, thousands of stars.
+
+health_release_identity_2026_07_16:
+  at: 2026-07-16T23:43:19+08:00
+  agent: TradeClaw PM agent
+  status: validated_pending_deploy
+  scope: Truthful build identity on both public health endpoints
+  base_commit: e46b597e2779cbbafe13e07ff266e51269f1bc6e
+  notes: >
+    Final production readback found that Railway CLI releases returned
+    build: development because BUILD_ID was absent. Both health routes now use
+    explicit build overrides, Git-trigger metadata, or Railway snapshot and
+    deployment IDs in order, and report unknown rather than development when a
+    production identity is genuinely unavailable. Validation passed six focused
+    Jest cases, scoped ESLint, web TypeScript, YAML parsing, whitespace checks,
+    and the full production build with all 324 pages generated. Commit,
+    production deployment, and live readback remain pending.
 
 truth_release_2026_07_15:
   at: 2026-07-15T16:40:32+08:00

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-07-16T23:43:19+08:00
+updated: 2026-07-16T23:46:46+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -8,11 +8,29 @@ description: >
   Goal: viral GitHub repo, thousands of stars.
 
 health_release_identity_2026_07_16:
-  at: 2026-07-16T23:43:19+08:00
+  at: 2026-07-16T23:46:46+08:00
   agent: TradeClaw PM agent
-  status: validated_pending_deploy
+  status: deployed
   scope: Truthful build identity on both public health endpoints
   base_commit: e46b597e2779cbbafe13e07ff266e51269f1bc6e
+  source_commit: e3d01c2435262a5600a1c8b6e335a34f840d8417
+  deployment:
+    provider: Railway
+    project_id: 4265dacd-9431-446e-8d04-5e1ec8482530
+    environment: production
+    service: web
+    deployment_id: 58671ab2-54b3-41fd-ac5e-d90744f5f2af
+    status: SUCCESS
+    image_digest: sha256:3b81770a6b9274cb649e54b7cc9e94e7e7b97bd4160dae673121e937493e843b
+    build_identity: aa319b6d-8a41-4005-8c95-6d1735f2fa9e
+    live_url: https://tradeclaw.win
+  live_verification:
+    health: "HTTP 200 /api/health with status ok and real Railway build identity"
+    v1_health: "HTTP 200 /api/v1/health with status healthy and matching build identity"
+    eligible_outcomes: 1341
+    proof_wins: 477
+    proof_losses: 864
+    mean_net_r_from_published_arrays: -0.4685876212
   notes: >
     Final production readback found that Railway CLI releases returned
     build: development because BUILD_ID was absent. Both health routes now use
@@ -20,8 +38,10 @@ health_release_identity_2026_07_16:
     deployment IDs in order, and report unknown rather than development when a
     production identity is genuinely unavailable. Validation passed six focused
     Jest cases, scoped ESLint, web TypeScript, YAML parsing, whitespace checks,
-    and the full production build with all 324 pages generated. Commit,
-    production deployment, and live readback remain pending.
+    and the full production build with all 324 pages generated. The exact clean
+    e3d01c24 worktree deployed successfully on top of the current emerald asset
+    release. Both health routes now return the same Railway snapshot identity,
+    and the post-deploy proof and cost-field populations reconcile exactly.
 
 truth_release_2026_07_15:
   at: 2026-07-15T16:40:32+08:00

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import pkg from "../../../package.json";
+import { getBuildIdentity } from "../../../lib/build-identity";
 
 export const dynamic = "force-dynamic";
 
@@ -11,7 +12,7 @@ export async function GET() {
       uptime: process.uptime(),
       timestamp: new Date().toISOString(),
       node: process.version,
-      build: process.env.BUILD_ID ?? "development",
+      build: getBuildIdentity(),
     });
   } catch {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/apps/web/app/api/v1/health/route.ts
+++ b/apps/web/app/api/v1/health/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getBuildIdentity } from "../../../../lib/build-identity";
 
 export const runtime = "nodejs";
 const startTime = Date.now();
@@ -12,7 +13,7 @@ export async function GET() {
         status: "healthy",
         uptime: Math.floor((Date.now() - startTime) / 1000),
         timestamp: new Date().toISOString(),
-        build: process.env.NEXT_PUBLIC_BUILD_TIME ?? "development",
+        build: getBuildIdentity(),
         repository: "https://github.com/naimkatiman/tradeclaw",
         license: "MIT",
       },

--- a/apps/web/app/docs/self-hosting/page.tsx
+++ b/apps/web/app/docs/self-hosting/page.tsx
@@ -179,14 +179,14 @@ sudo certbot renew --dry-run`} />
         <h2 className="text-2xl font-semibold text-white mb-4">Health Monitoring</h2>
         <p className="text-zinc-400 leading-relaxed mb-4">
           TradeClaw exposes a <code className="text-emerald-400 text-sm">/api/health</code> endpoint
-          that returns uptime, version, and build status. Use it for uptime checks.
+          that returns uptime, version, and the available build identity. Use it for uptime checks.
         </p>
         <CodeBlock language="json" filename="GET /api/health" code={`{
   "status": "ok",
   "version": "0.5.0",
   "uptime": 86400,
   "node": "v22.0.0",
-  "build": "standalone",
+  "build": "<revision-or-deployment-id>",
   "timestamp": "2026-03-27T10:00:00.000Z"
 }`} />
         <p className="text-zinc-400 leading-relaxed mt-4">

--- a/apps/web/lib/__tests__/build-identity.test.ts
+++ b/apps/web/lib/__tests__/build-identity.test.ts
@@ -1,0 +1,69 @@
+import { getBuildIdentity } from "../build-identity";
+
+describe("getBuildIdentity", () => {
+  test("prefers an explicit build ID", () => {
+    expect(
+      getBuildIdentity({
+        BUILD_ID: "release-42",
+        RAILWAY_GIT_COMMIT_SHA: "git-sha",
+        RAILWAY_SNAPSHOT_ID: "snapshot-id",
+        RAILWAY_DEPLOYMENT_ID: "deployment-id",
+        NODE_ENV: "production",
+      })
+    ).toBe("release-42");
+  });
+
+  test("keeps the existing public build-time override", () => {
+    expect(
+      getBuildIdentity({
+        NEXT_PUBLIC_BUILD_TIME: "2026-07-16T15:00:00Z",
+        RAILWAY_GIT_COMMIT_SHA: "git-sha",
+        NODE_ENV: "production",
+      })
+    ).toBe("2026-07-16T15:00:00Z");
+  });
+
+  test("uses the Git commit for GitHub-triggered Railway deploys", () => {
+    expect(
+      getBuildIdentity({
+        RAILWAY_GIT_COMMIT_SHA: "git-sha",
+        RAILWAY_SNAPSHOT_ID: "snapshot-id",
+        RAILWAY_DEPLOYMENT_ID: "deployment-id",
+        NODE_ENV: "production",
+      })
+    ).toBe("git-sha");
+  });
+
+  test("uses Railway snapshot then deployment identity for CLI deploys", () => {
+    expect(
+      getBuildIdentity({
+        RAILWAY_SNAPSHOT_ID: "snapshot-id",
+        RAILWAY_DEPLOYMENT_ID: "deployment-id",
+        NODE_ENV: "production",
+      })
+    ).toBe("snapshot-id");
+
+    expect(
+      getBuildIdentity({
+        RAILWAY_DEPLOYMENT_ID: "deployment-id",
+        NODE_ENV: "production",
+      })
+    ).toBe("deployment-id");
+  });
+
+  test("never labels an unidentified production build as development", () => {
+    expect(getBuildIdentity({ NODE_ENV: "production" })).toBe("unknown");
+    expect(getBuildIdentity({ NODE_ENV: "development" })).toBe("development");
+  });
+
+  test("ignores blank identity values", () => {
+    expect(
+      getBuildIdentity({
+        BUILD_ID: " ",
+        RAILWAY_GIT_COMMIT_SHA: "",
+        RAILWAY_DEPLOYMENT_ID: "deployment-id",
+        NODE_ENV: "production",
+      })
+    ).toBe("deployment-id");
+  });
+});

--- a/apps/web/lib/build-identity.ts
+++ b/apps/web/lib/build-identity.ts
@@ -1,0 +1,26 @@
+type BuildIdentityKey =
+  | "BUILD_ID"
+  | "NEXT_PUBLIC_BUILD_TIME"
+  | "RAILWAY_GIT_COMMIT_SHA"
+  | "RAILWAY_SNAPSHOT_ID"
+  | "RAILWAY_DEPLOYMENT_ID"
+  | "NODE_ENV";
+
+type BuildEnvironment = Partial<Pick<NodeJS.ProcessEnv, BuildIdentityKey>>;
+
+const BUILD_ID_KEYS = [
+  "BUILD_ID",
+  "NEXT_PUBLIC_BUILD_TIME",
+  "RAILWAY_GIT_COMMIT_SHA",
+  "RAILWAY_SNAPSHOT_ID",
+  "RAILWAY_DEPLOYMENT_ID",
+] as const;
+
+export function getBuildIdentity(env: BuildEnvironment = process.env): string {
+  for (const key of BUILD_ID_KEYS) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+
+  return env.NODE_ENV === "production" ? "unknown" : "development";
+}

--- a/docs/audits/2026-07-15-linkedin-claim-verification.md
+++ b/docs/audits/2026-07-15-linkedin-claim-verification.md
@@ -1,6 +1,7 @@
 # TradeClaw loss-claim and WEEX outreach verification
 
 Date: 2026-07-15
+Last source recheck: 2026-07-16
 Reviewer: TradeClaw PM agent
 Purpose: decide what the production evidence supports for a public LinkedIn post and verify the factual claims in the WEEX outreach.
 
@@ -186,7 +187,7 @@ The commercial claims require qualification:
 | Better terms than Binance | Not established. The claim needs a written tier schedule and a like-for-like comparison of fees, thresholds, fills, counterparty risk, and jurisdiction access. |
 | TradFi execution | WEEX offers USDT-margined perpetual exposure to forex, commodities, stocks, and indices. These are synthetic derivatives, not the underlying shares, gold, or spot FX. Public docs do not establish that every TradFi contract is available through the broker API. |
 | Natural symbol fit | Not yet. Examples include EUR/USDT rather than EUR/USD, and synthetic/tokenized proxies may have different basis, funding, hours, and corporate-action behavior. |
-| Active TradFi campaigns now | Not supported on 15 July. WEEX says its selected-region zero-fee TradFi campaign ended on 8 July 2026. The outreach may have been timely if sent before then. Ask for a current campaign ID, terms, eligible regions, and end date. |
+| Active TradFi campaigns now | Supported only in the general sense on 16 July: WEEX's public TradFi page advertises a trading challenge from 9-23 July 2026 (UTC+8). A separate selected-region zero-fee offer ended on 8 July. The public page does not establish TradeClaw-user eligibility, broker attribution, or commission treatment; obtain the campaign ID, full terms, eligible regions, and written broker confirmation. |
 | Rebate on TradFi volume | Not publicly guaranteed. Obtain written confirmation that each TradFi product is commission-eligible. |
 | `@Weex_Illiaa` identity | Unverified. Confirm the contact through `bd@weex.com` or WEEX's published business channel before sharing credentials or announcing a partnership. |
 
@@ -194,11 +195,12 @@ Primary sources:
 
 - WEEX broker API: https://www.weex.com/api-doc/broker/intro
 - WEEX broker program: https://www.weex.com/news/detail/weex-api-broker-program-turn-your-trading-platform-into-a-revenue-engine-s25tw96lzabkau5am0yfy9zj
+- WEEX current TradFi page: https://www.weex.com/events/tradfi
 - WEEX TradFi assets: https://www.weex.com/help/articles/help_article_79108
 - WEEX TradFi overview: https://www.weex.com/help/articles/help_article_84489
 - WEEX promotion end notice: https://www.weex.com/help/articles/djgzm3mmmp14bnzyoj5p1e72
 
-These official pages were rechecked on 15 July 2026. The broker documentation still requires application and approval before a unique broker ID and initial commission rate are issued. The 50%-70% number remains WEEX marketing for trading-fee sharing and is expressly subject to partner verification and changing program terms; it is not a confirmed TradeClaw rate or a percentage of user volume.
+These official pages were last rechecked on 16 July 2026. The broker documentation still requires application and approval before a unique broker ID and initial commission rate are issued. The 50%-70% number remains WEEX marketing for trading-fee sharing and is expressly subject to partner verification and changing program terms; it is not a confirmed TradeClaw rate or a percentage of user volume. The current challenge supports only the narrow statement that a TradFi campaign is advertised; it does not validate the outreach's promised bonuses, availability, API execution coverage, or rebate economics for TradeClaw users.
 
 ## Malaysia publication risk
 

--- a/docs/audits/2026-07-15-linkedin-claim-verification.md
+++ b/docs/audits/2026-07-15-linkedin-claim-verification.md
@@ -154,17 +154,17 @@ CI follow-up on 16 July found that the required Strategy Backtests job had repor
 
 The repaired runtime counts nonzero 24-hour OHLCV closes only when their resolver source is an approved observed provider (`market-data-hub`, `binance`, `stooq`, `kraken`, or `cryptocompare`). Legacy rows without source, synthetic or unknown sources, and missing or zero force-expiry placeholders remain stored but do not count. Public history GET is read-only, row IDs plus cost and outcome provenance are available through `?include=provenance`, and a fail-closed cost-adjusted evidence gate sits before entry-like execution and hosted alert fan-out.
 
-These changes do not retroactively alter the frozen 3,967-row response above. That historical result remains valid only for its dated, pre-repair production denominator. The 1,220-row result in this section is the current, deployed source-gated study.
+These changes do not retroactively alter the frozen 3,967-row response above. That historical result remains valid only for its dated, pre-repair production denominator. The 1,220-row result in this section is the frozen, deployed post-repair snapshot captured on 15 July; the rolling live population changes as records enter and leave the 10,000-row source window.
 
 ## LinkedIn-safe copy
 
-> We reran TradeClaw after deploying the evidence-provenance repair. In the currently available 10,000-row source window, 1,220 outcomes had approved observed-OHLCV provenance, covering 10 June through 15 July 2026 UTC.
+> We reran TradeClaw after deploying the evidence-provenance repair. In a production snapshot captured on 15 July 2026, the available 10,000-row source window contained 1,220 outcomes with approved observed-OHLCV provenance, covering 10 June through 15 July UTC.
 >
 > Average gross result was -0.0225R per signal. After our published fee-and-slippage model, average net result was -0.4253R per signal. This engine version did not demonstrate a net edge under those assumptions.
 >
 > These are OHLCV-derived signal outcomes with modeled costs, not broker fills, customer losses, or portfolio returns. The source window is capped and may omit earlier rows.
 >
-> Data: https://tradeclaw.win/api/research/cost-field?scope=pro
+> Archived data: https://github.com/naimkatiman/tradeclaw/tree/main/docs/audits/evidence/2026-07-15-b070197b
 > Method: https://tradeclaw.win/methodology
 
 Do not replace the last paragraph with "not financial advice" and remove the methodological limitations. A generic disclaimer does not repair an overbroad performance claim.


### PR DESCRIPTION
## Summary
- stop both health endpoints from labelling unidentified production releases as `development`
- resolve explicit, Git, Railway snapshot, and Railway deployment identities in a shared tested helper
- distinguish WEEX's active 9-23 July TradFi challenge from its ended zero-fee offer in the claim audit
- document and record the successful production release

## Verification
- focused Jest: 6/6
- scoped ESLint: pass
- web TypeScript: pass
- `npm run build`: pass, 324/324 pages
- Railway deployment `58671ab2-54b3-41fd-ac5e-d90744f5f2af`: SUCCESS
- `/api/health` and `/api/v1/health`: HTTP 200 with matching Railway snapshot identity
- post-deploy evidence: 1,341 eligible outcomes, proof count reconciled, modeled net expectancy -0.4686R/signal
- official WEEX broker, TradFi, and promotion pages rechecked 16 July 2026