### PR TITLE
fix(proof): share the canonical signal slice

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -35,11 +35,13 @@ proof_population_alignment_2026_07_17:
   notes: >
     Final live readback caught proof advancing to 1,342 resolved outcomes while
     cost-field still exposed 1,341 from the shared 10-minute history snapshot.
-    Proof bypassed getResolvedSlice, so public counts could temporarily disagree
-    and proof did not inherit the pending-partner tv-* exclusion. Proof now reads
+    Proof bypassed getResolvedSlice, so public counts could temporarily disagree.
+    The prior direct read already excluded pending-partner tv-* rows; the repair
+    centralizes that existing rule rather than introducing it. Proof now reads
     scopedRecords and resolved from the same canonical slice as cost-field and
-    publishes the source-window metadata. Validation passed 14 focused tests
-    across proof, cost-field, and partner-strategy filtering, scoped ESLint, web
+    publishes typed and OpenAPI-documented source-window metadata. Validation
+    passed 15 focused tests across proof, cost-field, and partner-strategy
+    filtering, scoped ESLint, web
     TypeScript, YAML and whitespace checks, and the full production build with
     all 324 pages generated. Railway deployed the exact b0b89a92 source with a
     successful Dockerfile health check. Fresh proof and cost-field requests now

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,11 +1,29 @@
 project: tradeclaw
-updated: 2026-07-16T23:49:09+08:00
+updated: 2026-07-17T00:06:44+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
   Public mode = limited. Admin = full.
   Alpha Screener = confirmed SaaS brand for users who don't want to self-host. Tradesmart name is dropped.
   Goal: viral GitHub repo, thousands of stars.
+
+proof_population_alignment_2026_07_17:
+  at: 2026-07-17T00:06:44+08:00
+  agent: TradeClaw PM agent
+  status: validated_pending_deploy
+  scope: Align proof and cost-field to the same cached public signal slice
+  discovered_after_main_merge: a57c351d72af4b52ae46c98dbd8e13edb83ba796
+  notes: >
+    Final live readback caught proof advancing to 1,342 resolved outcomes while
+    cost-field still exposed 1,341 from the shared 10-minute history snapshot.
+    Proof bypassed getResolvedSlice, so public counts could temporarily disagree
+    and proof did not inherit the pending-partner tv-* exclusion. Proof now reads
+    scopedRecords and resolved from the same canonical slice as cost-field and
+    publishes the source-window metadata. Validation passed 14 focused tests
+    across proof, cost-field, and partner-strategy filtering, scoped ESLint, web
+    TypeScript, YAML and whitespace checks, and the full production build with
+    all 324 pages generated. Commit, deployment, and live reconciliation remain
+    pending.
 
 health_release_identity_2026_07_16:
   at: 2026-07-16T23:46:46+08:00

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-07-17T00:09:31+08:00
+updated: 2026-07-17T00:19:33+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -8,28 +8,28 @@ description: >
   Goal: viral GitHub repo, thousands of stars.
 
 proof_population_alignment_2026_07_17:
-  at: 2026-07-17T00:09:31+08:00
+  at: 2026-07-17T00:19:33+08:00
   agent: TradeClaw PM agent
   status: deployed
   scope: Align proof and cost-field to the same cached public signal slice
   discovered_after_main_merge: a57c351d72af4b52ae46c98dbd8e13edb83ba796
-  source_commit: b0b89a926e46400eb2b99dc54c78c9404e406ddc
-  canonical_branch_commit: afd2306a43a67f6b456ad4633de12b3b5b7c132f
+  source_commit: bd43a467ed020fdc1b112d342e5bd513cad31eb3
+  canonical_branch_commit: abfa32e3d1e4601992c4620f166fca9ccb54a25c
   deployment:
     provider: Railway
     project_id: 4265dacd-9431-446e-8d04-5e1ec8482530
     environment: production
     service: web
-    deployment_id: 40e81da2-46bb-4556-a378-75c595411101
+    deployment_id: 23bec7a0-0161-4b0f-b64f-6c98e2f0f46e
     status: SUCCESS
-    image_digest: sha256:c70633a11d1835ebea0566d7d58c826db4e6d9f1ff4c1e25bffbba86fd5dd279
-    build_identity: c928ce9d-d332-4bf1-b960-31e6b72e59f4
+    image_digest: sha256:0560aac6892ed49576b159af22ef8d9f7a7e4d2dd17a2d3a161d9218c229636b
+    build_identity: 475f99b7-93b8-4d4b-b35e-236c881853b9
     live_url: https://tradeclaw.win
   live_verification:
-    eligible_outcomes: 1342
-    proof_wins: 478
+    eligible_outcomes: 1343
+    proof_wins: 479
     proof_losses: 864
-    mean_net_r_from_published_arrays: -0.4683800298
+    mean_net_r_from_published_arrays: -0.4668086374
     counts_match: true
     source_windows_match: true
   notes: >
@@ -43,10 +43,11 @@ proof_population_alignment_2026_07_17:
     passed 15 focused tests across proof, cost-field, and partner-strategy
     filtering, scoped ESLint, web
     TypeScript, YAML and whitespace checks, and the full production build with
-    all 324 pages generated. Railway deployed the exact b0b89a92 source with a
+    all 324 pages generated. Railway deployed the exact bd43a467 source with a
     successful Dockerfile health check. Fresh proof and cost-field requests now
-    return the same 1,342-row population and the same 10,000-row capped source
-    window; proof wins plus losses also reconcile to the shared count.
+    return the same 1,343-row population and the same 10,000-row capped source
+    window; proof wins plus losses reconcile to the shared count, and the live
+    OpenAPI schema requires the typed methodology and window fields.
 
 health_release_identity_2026_07_16:
   at: 2026-07-16T23:46:46+08:00

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-07-17T00:06:44+08:00
+updated: 2026-07-17T00:09:31+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -8,11 +8,30 @@ description: >
   Goal: viral GitHub repo, thousands of stars.
 
 proof_population_alignment_2026_07_17:
-  at: 2026-07-17T00:06:44+08:00
+  at: 2026-07-17T00:09:31+08:00
   agent: TradeClaw PM agent
-  status: validated_pending_deploy
+  status: deployed
   scope: Align proof and cost-field to the same cached public signal slice
   discovered_after_main_merge: a57c351d72af4b52ae46c98dbd8e13edb83ba796
+  source_commit: b0b89a926e46400eb2b99dc54c78c9404e406ddc
+  canonical_branch_commit: afd2306a43a67f6b456ad4633de12b3b5b7c132f
+  deployment:
+    provider: Railway
+    project_id: 4265dacd-9431-446e-8d04-5e1ec8482530
+    environment: production
+    service: web
+    deployment_id: 40e81da2-46bb-4556-a378-75c595411101
+    status: SUCCESS
+    image_digest: sha256:c70633a11d1835ebea0566d7d58c826db4e6d9f1ff4c1e25bffbba86fd5dd279
+    build_identity: c928ce9d-d332-4bf1-b960-31e6b72e59f4
+    live_url: https://tradeclaw.win
+  live_verification:
+    eligible_outcomes: 1342
+    proof_wins: 478
+    proof_losses: 864
+    mean_net_r_from_published_arrays: -0.4683800298
+    counts_match: true
+    source_windows_match: true
   notes: >
     Final live readback caught proof advancing to 1,342 resolved outcomes while
     cost-field still exposed 1,341 from the shared 10-minute history snapshot.
@@ -22,8 +41,10 @@ proof_population_alignment_2026_07_17:
     publishes the source-window metadata. Validation passed 14 focused tests
     across proof, cost-field, and partner-strategy filtering, scoped ESLint, web
     TypeScript, YAML and whitespace checks, and the full production build with
-    all 324 pages generated. Commit, deployment, and live reconciliation remain
-    pending.
+    all 324 pages generated. Railway deployed the exact b0b89a92 source with a
+    successful Dockerfile health check. Fresh proof and cost-field requests now
+    return the same 1,342-row population and the same 10,000-row capped source
+    window; proof wins plus losses also reconcile to the shared count.
 
 health_release_identity_2026_07_16:
   at: 2026-07-16T23:46:46+08:00

--- a/apps/web/app/api/proof/__tests__/route.test.ts
+++ b/apps/web/app/api/proof/__tests__/route.test.ts
@@ -1,12 +1,13 @@
-jest.mock('../../../../lib/signal-history', () => {
-  const actual = jest.requireActual('../../../../lib/signal-history');
-  return { ...actual, readHistoryAsync: jest.fn() };
+jest.mock('../../../../lib/signal-slice', () => {
+  const actual = jest.requireActual('../../../../lib/signal-slice');
+  return { ...actual, getResolvedSlice: jest.fn() };
 });
 
-import { readHistoryAsync, type SignalHistoryRecord } from '../../../../lib/signal-history';
+import { isCountedResolved, type SignalHistoryRecord } from '../../../../lib/signal-history';
+import { getResolvedSlice } from '../../../../lib/signal-slice';
 import { GET } from '../route';
 
-const mockedHistory = readHistoryAsync as jest.MockedFunction<typeof readHistoryAsync>;
+const mockedGetResolvedSlice = getResolvedSlice as jest.MockedFunction<typeof getResolvedSlice>;
 
 function record(
   id: string,
@@ -28,11 +29,24 @@ function record(
   };
 }
 
+function setHistory(rows: SignalHistoryRecord[]) {
+  mockedGetResolvedSlice.mockResolvedValue({
+    sourceRecordsLoaded: rows.length,
+    sourceReadLimit: 10_000,
+    sourceWindowPotentiallyTruncated: false,
+    scopedRecords: rows,
+    periodFiltered: rows,
+    resolved: rows.filter(isCountedResolved),
+    cutoffTs: null,
+    earliestTimestamp: rows.length > 0 ? rows[rows.length - 1].timestamp : null,
+  });
+}
+
 describe('GET /api/proof', () => {
-  beforeEach(() => mockedHistory.mockReset());
+  beforeEach(() => mockedGetResolvedSlice.mockReset());
 
   it('derives all performance fields from the canonical 24h population', async () => {
-    mockedHistory.mockResolvedValue([
+    setHistory([
       record('tp-win', { price: 102, pnlPct: 2, hit: true, target: 'TP1', source: 'binance' }),
       record('sl-loss', { price: 99, pnlPct: -1, hit: false, target: 'SL', source: 'binance' }),
       record('drift-win', { price: 100.5, pnlPct: 0.5, hit: true, target: 'expired', source: 'binance' }),
@@ -56,6 +70,12 @@ describe('GET /api/proof', () => {
       totalLosses: 2,
     });
     expect(body.stats.totalWins + body.stats.totalLosses).toBe(body.stats.resolvedSignals);
+    expect(mockedGetResolvedSlice).toHaveBeenCalledWith({ scope: 'pro' });
+    expect(body.window).toEqual({
+      sourceRecordsLoaded: 7,
+      sourceReadLimit: 10_000,
+      potentiallyTruncatedBeforeStart: false,
+    });
     expect(body.methodology.runningPnlPct).toMatch(/not account or portfolio P&L/i);
     expect(body.signals.find((signal: { id: string }) => signal.id === 'force-expired').outcome24h).toEqual({
       resolved: false,
@@ -66,7 +86,7 @@ describe('GET /api/proof', () => {
   });
 
   it('does not publish legacy outcomes whose OHLCV source is missing', async () => {
-    mockedHistory.mockResolvedValue([
+    setHistory([
       record('legacy', { price: 102, pnlPct: 2, hit: true, target: 'TP1' }),
     ]);
 

--- a/apps/web/app/api/proof/__tests__/route.test.ts
+++ b/apps/web/app/api/proof/__tests__/route.test.ts
@@ -5,6 +5,7 @@ jest.mock('../../../../lib/signal-slice', () => {
 
 import { isCountedResolved, type SignalHistoryRecord } from '../../../../lib/signal-history';
 import { getResolvedSlice } from '../../../../lib/signal-slice';
+import { buildOpenApiSpec } from '../../../../lib/openapi';
 import { GET } from '../route';
 
 const mockedGetResolvedSlice = getResolvedSlice as jest.MockedFunction<typeof getResolvedSlice>;
@@ -100,5 +101,18 @@ describe('GET /api/proof', () => {
       price: null,
       pnlPct: null,
     });
+  });
+
+  it('publishes proof methodology and source-window metadata in OpenAPI', () => {
+    const spec = buildOpenApiSpec() as {
+      components: { schemas: { ProofResponse: { required: string[]; properties: Record<string, unknown> } } };
+    };
+    const schema = spec.components.schemas.ProofResponse;
+
+    expect(schema.required).toEqual(expect.arrayContaining(['stats', 'signals', 'methodology', 'window']));
+    expect(schema.properties).toEqual(expect.objectContaining({
+      methodology: expect.any(Object),
+      window: expect.any(Object),
+    }));
   });
 });

--- a/apps/web/app/api/proof/route.ts
+++ b/apps/web/app/api/proof/route.ts
@@ -38,6 +38,16 @@ export interface ProofSignal {
 export interface ProofResponse {
   stats: ProofStats;
   signals: ProofSignal[];
+  methodology: {
+    population: string;
+    score: string;
+    runningPnlPct: string;
+  };
+  window: {
+    sourceRecordsLoaded: number;
+    sourceReadLimit: number;
+    potentiallyTruncatedBeforeStart: boolean;
+  };
 }
 
 export interface ProofStats {
@@ -136,7 +146,7 @@ export async function GET() {
       lastUpdated: mapped.reduce((latest, signal) => Math.max(latest, signal.timestamp), 0),
     };
 
-    return NextResponse.json({
+    const body: ProofResponse = {
       stats,
       signals: mapped.slice(0, 200),
       methodology: {
@@ -149,7 +159,9 @@ export async function GET() {
         sourceReadLimit: slice.sourceReadLimit,
         potentiallyTruncatedBeforeStart: slice.sourceWindowPotentiallyTruncated,
       },
-    });
+    };
+
+    return NextResponse.json(body);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to load proof data';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/web/app/api/proof/route.ts
+++ b/apps/web/app/api/proof/route.ts
@@ -3,8 +3,8 @@ import {
   isCountedResolved,
   isObservedOHLCVOutcomeSource,
   isRealOutcome,
-  readHistoryAsync,
 } from '../../../lib/signal-history';
+import { getResolvedSlice } from '../../../lib/signal-slice';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;
@@ -56,10 +56,11 @@ export interface ProofStats {
 
 export async function GET() {
   try {
-    const history = await readHistoryAsync();
+    const slice = await getResolvedSlice({ scope: 'pro' });
+    const history = slice.scopedRecords;
 
     const realSignals = history.filter((r) => !r.isSimulated);
-    const counted24h = history.filter(isCountedResolved);
+    const counted24h = slice.resolved;
 
     const mapped: ProofSignal[] = realSignals.map((r) => {
       const o4h = r.outcomes['4h'];
@@ -139,9 +140,14 @@ export async function GET() {
       stats,
       signals: mapped.slice(0, 200),
       methodology: {
-        population: 'non-simulated, non-gate-blocked records with approved observed-OHLCV outcome provenance',
+        population: 'public-scope, non-simulated, non-gate-blocked records with approved observed-OHLCV outcome provenance',
         score: 'mechanical rule/confluence score; not a probability or edge estimate',
         runningPnlPct: 'legacy field name for mean unsized 24h directional price move; not account or portfolio P&L',
+      },
+      window: {
+        sourceRecordsLoaded: slice.sourceRecordsLoaded,
+        sourceReadLimit: slice.sourceReadLimit,
+        potentiallyTruncatedBeforeStart: slice.sourceWindowPotentiallyTruncated,
       },
     });
   } catch (err) {

--- a/apps/web/lib/openapi.ts
+++ b/apps/web/lib/openapi.ts
@@ -180,9 +180,32 @@ export function buildOpenApiSpec(): OpenApiSpec {
         },
         ProofResponse: {
           type: "object",
+          required: ["stats", "signals", "methodology", "window"],
           properties: {
             stats: { $ref: "#/components/schemas/ProofStats" },
             signals: { type: "array", items: { type: "object" } },
+            methodology: {
+              type: "object",
+              required: ["population", "score", "runningPnlPct"],
+              properties: {
+                population: { type: "string" },
+                score: { type: "string" },
+                runningPnlPct: { type: "string" },
+              },
+            },
+            window: {
+              type: "object",
+              required: [
+                "sourceRecordsLoaded",
+                "sourceReadLimit",
+                "potentiallyTruncatedBeforeStart",
+              ],
+              properties: {
+                sourceRecordsLoaded: { type: "integer" },
+                sourceReadLimit: { type: "integer" },
+                potentiallyTruncatedBeforeStart: { type: "boolean" },
+              },
+            },
           },
         },
         DigestResponse: {


### PR DESCRIPTION
## Summary
- make `/api/proof` read the same cached public signal slice as cost-field, equity, history, and leaderboard surfaces
- publish typed methodology/source-window fields and require them in the OpenAPI contract
- cover shared-slice and contract behavior in focused tests

## Why
A final live read caught `/api/proof` advancing to 1,342 resolved outcomes while `/api/research/cost-field` still exposed 1,341 from the canonical 10-minute snapshot. The routes used different read paths, so counts could temporarily disagree even though their outcome predicate matched.

## Verification
- focused proof/cost-field/dark-strategy/OpenAPI Jest: 15/15
- scoped ESLint: pass
- web TypeScript: pass
- `npm run build`: pass, 324/324 pages
- Railway deployment `23bec7a0-0161-4b0f-b64f-6c98e2f0f46e`: SUCCESS
- live proof and cost-field: 1,343 outcomes on both surfaces, matching 10,000-row source-window metadata
- proof: 479 wins + 864 losses; published-array mean modeled net expectancy: -0.46681R/signal
- live `/api/openapi.json`: ProofResponse requires `stats`, `signals`, `methodology`, and `window`