### PR TITLE
fix(dashboard): eliminate fresh-load hydration errors

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,11 +1,39 @@
 project: tradeclaw
-updated: 2026-07-20T01:15:08+08:00
+updated: 2026-07-20T02:05:00+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
   Public mode = limited. Admin = full.
   Alpha Screener = confirmed SaaS brand for users who don't want to self-host. Tradesmart name is dropped.
   Goal: viral GitHub repo, thousands of stars.
+
+dashboard_hydration_hotfix_2026_07_20:
+  at: 2026-07-20T02:01:00+08:00
+  agent: TradeClaw PM agent
+  status: ready_for_publish
+  scope: Remove the fresh-load dashboard hydration exception found during the exact-origin-main production audit
+  base_commit: 08a6bfefc92659d7cec0ccacdad85be89dcfb3ed
+  branch: fix/dashboard-hydration-20260720
+  current_step: All local gates passed; rebasing onto current origin/main before protected PR publication and exact-main deployment
+  root_cause: >
+    Browser-persisted UI state was read during the first client render while the
+    server rendered stable defaults. OnboardingBanner and VisitStreak were two
+    confirmed independent fresh-load triggers; a populated signal cache could
+    also disagree whenever server data was empty. The same unsafe pattern was
+    removed from favorites, re-engagement, and feature-unlock state. React
+    therefore no longer discards the server dashboard tree with minified error
+    418. Client navigation and locale switching were already clean, confirming
+    this was not a translation or RTL failure.
+  verification: >
+    All seven Chromium product-localization checks passed, including fresh-storage
+    hard /dashboard loads in English, Malay, and Arabic with correct LTR/RTL state
+    and zero hydration exceptions, the five-locale surface matrix, invalid and
+    blocked storage fallback, Arabic persistence, and mobile containment. Web
+    TypeScript passed. Lint passed with zero errors and the same 23 pre-existing
+    warnings. Root Jest passed 222 suites and 1,741 tests with 26 intentional
+    skips and one snapshot; forced runner cleanup was still required for the
+    existing asynchronous open handle. The mandatory root production build
+    compiled successfully and generated all 324 pages.
 
 emerald_main_sync_release_2026_07_19:
   at: 2026-07-19T23:22:41+08:00

--- a/apps/web/app/dashboard/DashboardClient.tsx
+++ b/apps/web/app/dashboard/DashboardClient.tsx
@@ -49,14 +49,23 @@ function useDashboardCopy() {
 
 function OnboardingBanner() {
   const { t } = useDashboardCopy();
-  const [visible, setVisible] = useState(() => {
-    try {
-      if (typeof window === 'undefined') return false;
-      const dismissed = localStorage.getItem('tc_onboarding_dismissed');
-      const tourDone = localStorage.getItem('tc_tour_done');
-      return !dismissed && !tourDone;
-    } catch { return false; }
-  });
+  const [visible, setVisible] = useState(false);
+
+  // Browser persistence is intentionally read after hydration. Reading it in
+  // the state initializer makes a fresh client render insert this banner where
+  // the server rendered nothing, which forces React to discard the dashboard.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      try {
+        const dismissed = localStorage.getItem('tc_onboarding_dismissed');
+        const tourDone = localStorage.getItem('tc_tour_done');
+        setVisible(!dismissed && !tourDone);
+      } catch {
+        setVisible(false);
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   if (!visible) return null;
   const dismiss = () => {
@@ -902,18 +911,11 @@ function setCachedSignals(signals: TradingSignal[]) {
 export function DashboardClient({ initialSignals, initialSyntheticSymbols }: { initialSignals?: TradingSignal[]; initialSyntheticSymbols?: string[] }) {
   const { language, t } = useDashboardCopy();
   const { prices, state: connectionState } = usePriceStream(TICKER_PAIRS);
-  const [signals, setSignals] = useState<TradingSignal[]>(() => {
-    if (initialSignals && initialSignals.length > 0) return initialSignals;
-    if (typeof window !== 'undefined') return getCachedSignals();
-    return [];
-  });
+  const hasInitialSignals = Boolean(initialSignals && initialSignals.length > 0);
+  const [signals, setSignals] = useState<TradingSignal[]>(hasInitialSignals ? initialSignals! : []);
   const [syntheticSymbols, setSyntheticSymbols] = useState<string[]>(initialSyntheticSymbols || []);
   const [tfMap, setTfMap] = useState<Map<string, TFDirection[]>>(new Map());
-  const [loading, setLoading] = useState(() => {
-    if (initialSignals && initialSignals.length > 0) return false;
-    if (typeof window !== 'undefined' && getCachedSignals().length > 0) return false;
-    return true;
-  });
+  const [loading, setLoading] = useState(!hasInitialSignals);
   const [timeframe, setTimeframe] = useState('ALL');
   const [direction, setDirection] = useState<'ALL' | 'BUY' | 'SELL'>('ALL');
   const [assetClass, setAssetClass] = useState<AssetClass>('ALL');
@@ -927,13 +929,26 @@ export function DashboardClient({ initialSignals, initialSyntheticSymbols }: { i
     markStepDone('opened-detail');
   }, []);
 
-  const [favorites, setFavorites] = useState<Set<string>>(() => {
+  const [favorites, setFavorites] = useState<Set<string>>(new Set());
+
+  // Keep the first browser render identical to SSR, then restore optional
+  // cached signals and watchlist preferences once hydration is complete.
+  useEffect(() => {
+    if (!hasInitialSignals) {
+      const cachedSignals = getCachedSignals();
+      if (cachedSignals.length > 0) {
+        setSignals(cachedSignals);
+        setLoading(false);
+      }
+    }
+
     try {
-      if (typeof window === 'undefined') return new Set<string>();
       const raw = localStorage.getItem('tc_favorites');
-      return raw ? new Set(JSON.parse(raw) as string[]) : new Set<string>();
-    } catch { return new Set<string>(); }
-  });
+      if (raw) setFavorites(new Set(JSON.parse(raw) as string[]));
+    } catch {
+      setFavorites(new Set());
+    }
+  }, [hasInitialSignals]);
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
 
   const toggleFavorite = useCallback((signalId: string) => {

--- a/apps/web/components/feature-unlock-banner.tsx
+++ b/apps/web/components/feature-unlock-banner.tsx
@@ -66,8 +66,15 @@ function computeActiveUnlock(): UnlockItem | null {
 }
 
 export function FeatureUnlockBanner() {
-  const [active, setActive] = useState<UnlockItem | null>(computeActiveUnlock);
+  const [active, setActive] = useState<UnlockItem | null>(null);
   const [visible, setVisible] = useState(false);
+
+  // Returning-visitor state can only be known in the browser. Resolve it after
+  // hydration so the server and first client render both start without a toast.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setActive(computeActiveUnlock()));
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   // Slide in after mount if there is an active unlock
   useEffect(() => {

--- a/apps/web/components/re-engagement-banner.tsx
+++ b/apps/web/components/re-engagement-banner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { getStreak } from '../lib/visit-streak';
 import { useLocale } from '../app/components/locale-provider';
@@ -33,12 +33,17 @@ function computeReEngagement(): { visible: boolean; daysAway: number } {
 export function ReEngagementBanner() {
   const { locale } = useLocale();
   const copy = getDashboardEvidenceTranslations(locale).reEngagement;
-  const [state] = useState(computeReEngagement);
-  const [visible, setVisible] = useState(state.visible);
+  const [state, setState] = useState({ visible: false, daysAway: 0 });
+  const visible = state.visible;
   const daysAway = state.daysAway;
 
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setState(computeReEngagement()));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
   function handleDismiss() {
-    setVisible(false);
+    setState((current) => ({ ...current, visible: false }));
     try {
       const streak = getStreak();
       localStorage.setItem(DISMISS_KEY, streak.lastVisit);

--- a/apps/web/components/visit-streak.tsx
+++ b/apps/web/components/visit-streak.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { recordVisit, type StreakData } from '../lib/visit-streak';
 import { useLocale } from '../app/components/locale-provider';
 import { formatMessage } from '../lib/product-i18n/format';
@@ -31,11 +31,13 @@ function getMilestoneLabel(
 export function VisitStreak() {
   const { locale } = useLocale();
   const copy = getDashboardEvidenceTranslations(locale).visitStreak;
-  const [streak] = useState<StreakData | null>(() => {
-    if (typeof window === 'undefined') return null;
-    return recordVisit();
-  });
+  const [streak, setStreak] = useState<StreakData | null>(null);
   const [showTooltip, setShowTooltip] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setStreak(recordVisit()));
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   if (!streak || streak.currentStreak === 0) return null;
 

--- a/apps/web/tests/e2e/features/product-localization.spec.ts
+++ b/apps/web/tests/e2e/features/product-localization.spec.ts
@@ -3,6 +3,8 @@ import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 type ProductLocale = 'en' | 'es' | 'zh' | 'ms' | 'ar';
 const LOCALE_EXPECT_TIMEOUT = 30_000;
 const pageErrors = new WeakMap<Page, string[]>();
+const hydrationErrors = new WeakMap<Page, string[]>();
+const HYDRATION_ERROR = /Hydration failed|hydration-mismatch|Minified React error #418|react\.dev\/errors\/418/i;
 
 const localeCases: Array<{
   locale: ProductLocale;
@@ -68,12 +70,51 @@ async function setProductLocale(
 test.describe('product localization', () => {
   test.beforeEach(async ({ page }) => {
     const errors: string[] = [];
+    const hydration: string[] = [];
     pageErrors.set(page, errors);
+    hydrationErrors.set(page, hydration);
     page.on('pageerror', (error) => errors.push(error.message));
+    page.on('console', (message) => {
+      if (message.type() === 'error' && HYDRATION_ERROR.test(message.text())) {
+        hydration.push(message.text());
+      }
+    });
   });
 
   test.afterEach(async ({ page }) => {
     expect(pageErrors.get(page) ?? []).toEqual([]);
+    expect(hydrationErrors.get(page) ?? []).toEqual([]);
+  });
+
+  test('hard-loads the dashboard from fresh storage without hydration errors', async ({ browser, baseURL }, testInfo) => {
+    test.skip(testInfo.project.name === 'mobile', 'The fresh-storage locale matrix runs once in desktop Chromium.');
+    test.setTimeout(120_000);
+
+    for (const locale of ['en', 'ms', 'ar'] as const) {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      const errors: string[] = [];
+
+      page.on('pageerror', (error) => {
+        if (HYDRATION_ERROR.test(error.message)) errors.push(error.message);
+      });
+      page.on('console', (message) => {
+        if (message.type() === 'error' && HYDRATION_ERROR.test(message.text())) {
+          errors.push(message.text());
+        }
+      });
+
+      await setProductLocale(context, locale, baseURL);
+      await page.goto(new URL('/dashboard', baseURL ?? 'http://localhost:3000').toString(), {
+        waitUntil: 'domcontentloaded',
+      });
+      await expect(page.locator('[data-tour-id="dashboard-controls"]')).toBeVisible({ timeout: LOCALE_EXPECT_TIMEOUT });
+      await expect(page.locator('html')).toHaveAttribute('dir', locale === 'ar' ? 'rtl' : 'ltr');
+      await page.waitForTimeout(500);
+      expect(errors, `hydration errors for ${locale}`).toEqual([]);
+
+      await context.close();
+    }
   });
 
   test('renders the core product surfaces in every supported locale', async ({ context, page, baseURL }, testInfo) => {


### PR DESCRIPTION
## What changed
- make onboarding, visit-streak, cached-signal, favorites, re-engagement, and feature-unlock persistence hydrate from stable server defaults
- add a hard-navigation regression that catches React hydration error #418 in English, Malay, and Arabic
- record diagnosis and verification in STATE.yaml

## Why
A direct production `/dashboard` load rendered no browser-persisted UI on the server, then inserted it during the first client render. React discarded the server tree with hydration error #418. Locale switching and RTL were already correct; the mismatch came from localStorage-backed state.

## Verification
- `npm run typecheck:web`
- `npm run lint` (0 errors; 23 pre-existing warnings)
- `npm test -- --runInBand --forceExit` (222 suites, 1,741 tests, 26 skips)
- product-localization Chromium E2E (7/7)
- `npm run build` (324/324 pages)