### PR TITLE
Show homepage hero art at narrow widths

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -4131,3 +4131,37 @@ next_actions:
       application assertion. The broad dirty primary checkout was excluded from
       Git history and the Railway payload. Dependencies, Docker, database, auth,
       billing, strategy, allocation, and trading rules are unchanged.
+
+  - id: TC-247
+    title: "Homepage hero artwork at narrow desktop widths"
+    status: in_progress
+    owner: pm-tradeclaw
+    notes: >
+      Started 2026-08-03 after the owner supplied a roughly 702px-wide homepage
+      screenshot where the primary proof hero still appeared on the plain grid.
+      Audit confirmed that the generated market-field asset and stacking context
+      are present, but the shared backdrop is deliberately display:none below
+      768px and its responsive image sizes fall back to 1px. Work is isolated in
+      clean branch agent/tc247-home-narrow-art from exact origin/main
+      bfa4ff80e3136fb1c5846a44f5d2e139f2ee4ad7. Scope is a homepage-only
+      640px-767px treatment at lower opacity with an accurate image-size hint;
+      phone widths below 640px, all other product heroes, copy, charts, product
+      behavior, dependencies, Docker, database, auth, billing, strategy,
+      allocation, and trading rules remain unchanged. Implementation now exposes
+      only the homepage variant from 640px through 767px at 12% dark-theme and
+      7% light-theme opacity and supplies a 640px responsive image threshold.
+      Browser QA at the owner's exact 702x717 viewport confirmed a decoded 435px
+      local WebP, hero-heading overlap, pointer-events none, empty alt text,
+      aria-hidden decoration, and no horizontal overflow; 390x844 remains hidden
+      and overflow-free. Focused ESLint, web typecheck, the required production
+      build (324/324 generated pages), and git diff whitespace validation pass.
+      Completed locally 2026-08-03 13:02 MPST (+0800); no commit, push, PR, or
+      deployment was performed, and the broad dirty primary checkout was excluded.
+      Release was explicitly authorized 2026-08-04. Fresh release audit confirms
+      the same four intended files, authenticated GitHub access, unchanged exact
+      origin/main bfa4ff80e3136fb1c5846a44f5d2e139f2ee4ad7, and no merge
+      conflict. Publication and deployment are in progress from the clean worktree
+      only; the broad dirty primary checkout remains excluded.
+      Fresh pre-commit production build (324/324 pages), web typecheck, focused
+      ESLint, and diff whitespace validation pass. Docker CLI is unavailable on
+      this host, so the protected GitHub Docker Build check will gate that path.

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -331,6 +331,13 @@ html:not(.dark) .product-hero-backdrop--quiet {
   opacity: 0.04;
 }
 
+@media (min-width: 640px) and (max-width: 767px) {
+  .product-hero-backdrop--home {
+    display: block;
+    opacity: 0.12;
+  }
+}
+
 @media (min-width: 768px) {
   .product-hero-backdrop {
     display: block;

--- a/apps/web/components/landing/proof-hero.tsx
+++ b/apps/web/components/landing/proof-hero.tsx
@@ -162,6 +162,7 @@ export async function ProofHero() {
           testId="homepage-hero-art"
           className="product-hero-backdrop--home"
           priority
+          sizes="(min-width: 1280px) 720px, (min-width: 640px) 62vw, 1px"
         />
         <div className="relative z-10 flex flex-col justify-center py-4 sm:py-8 lg:py-14">
           <p className="animate-fade-up flex items-center gap-2.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-secondary)]">

--- a/apps/web/components/product-hero-backdrop.tsx
+++ b/apps/web/components/product-hero-backdrop.tsx
@@ -5,20 +5,22 @@ interface ProductHeroBackdropProps {
   testId: string;
   className?: string;
   priority?: boolean;
+  sizes?: string;
 }
 
 /**
  * Quiet generated artwork for product-page hero copy.
  *
  * The host owns the stacking context (`relative isolate`). This component is
- * decorative only, stays bounded to that host, and leaves the mobile reading
- * flow image-free.
+ * decorative only, stays bounded to that host, and leaves narrow phone reading
+ * flows image-free.
  */
 export function ProductHeroBackdrop({
   src,
   testId,
   className = '',
   priority = false,
+  sizes = '(min-width: 1280px) 720px, (min-width: 768px) 62vw, 1px',
 }: ProductHeroBackdropProps) {
   return (
     <div
@@ -31,7 +33,7 @@ export function ProductHeroBackdrop({
           src={src}
           alt=""
           fill
-          sizes="(min-width: 1280px) 720px, (min-width: 768px) 62vw, 1px"
+          sizes={sizes}
           className="product-hero-backdrop__image"
           priority={priority}
         />


### PR DESCRIPTION
## What changed

- reveal the existing homepage market-field backdrop between 640px and 767px
- keep the treatment restrained at 12% opacity in dark mode and 7% in light mode
- provide a homepage-specific responsive `sizes` hint so the 702px layout receives a real image candidate
- keep phones below 640px and every other product hero unchanged

## Why

The shared decorative backdrop was hidden below 768px and its image sizing fell back to 1px. At the owner’s exact 702×717 viewport, the asset existed in the DOM but the primary hero still rendered on the plain grid.

## Impact

The homepage now follows the Research-derived background-art treatment at narrow tablet/desktop widths without crowding phone layouts, changing copy, or affecting trading/product behavior.

## Verification

- exact 702×717 dark/light browser QA
- 390×844 phone QA
- focused ESLint
- `npm run typecheck:web`
- `npm run build` (324/324 generated pages)
- `git diff --check`

Local Docker is unavailable; the protected GitHub Docker Build check is the authoritative Docker gate.