### PR TITLE
Restore homepage destination card artwork

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-08-02T14:26:56+08:00
+updated: 2026-08-04T15:21:00+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -4171,3 +4171,40 @@ next_actions:
       isolated on exact post-merge main; Railway will deploy the exact final main
       produced after this closure merges. The broad dirty primary checkout remains
       excluded from GitHub and every deployment payload.
+
+  - id: TC-248
+    title: "Restore homepage destination-card artwork"
+    status: done
+    owner: pm-tradeclaw
+    notes: >
+      Started 2026-08-04 after the owner supplied a 1515x385 homepage screenshot
+      showing that the five Explore the stack destination cards were plain. Audit
+      confirmed TC-246 removed the TC-245 card markup and styling when artwork was
+      moved behind the core page heroes, even though all five generated WebPs remain
+      tracked. The owner now wants the restrained card backgrounds restored while
+      retaining every current hero background. Work is isolated in clean branch
+      agent/tc248-explore-art from exact origin/main
+      d0aa57276cfe9eb72cce1f09cc627b8c10707c42. Scope is limited to restoring the
+      proven low-opacity, trailing-edge ExploreStrip treatment with the existing
+      assets and verifying desktop, light theme, and mobile readability. No new
+      asset, dependency, copy, route, Docker, database, auth, billing, strategy,
+      allocation, or trading-rule change is included. The exact TC-245 ExploreStrip markup
+      and styling are now restored alongside the TC-246/TC-247 hero backgrounds:
+      all five local WebPs render on the cards' trailing edge behind z-10 copy,
+      remain decorative and pointer-free, and use the original theme-aware opacity
+      caps. Full lint passed with zero errors and 23 pre-existing warnings; focused
+      ESLint, web typecheck, the required production build (324/324 pages), diff
+      whitespace validation, and the existing homepage destination plus product
+      hero Chromium suite (11/11) passed. Direct browser QA at 1515x900 and 390x844
+      in dark and light themes confirmed five unique decoded images, one preserved
+      homepage hero backdrop, exact source mappings, 12%/7.5% desktop and 10%/6.5%
+      mobile base opacity, 17% desktop hover cap, correct z-index and mask layering,
+      readable copy, and zero horizontal overflow. Completed locally 2026-08-04;
+      no commit, push, PR, or deployment was performed, and the broad dirty primary
+      checkout remains excluded from release payloads. At 2026-08-04 15:20 MPST
+      (+0800) the owner explicitly authorized commit and production deployment.
+      Fresh release audit confirmed authenticated GitHub access, unchanged exact
+      origin/main d0aa57276cfe9eb72cce1f09cc627b8c10707c42, and only STATE.yaml,
+      globals.css, and explore-strip.tsx as content diffs. Publication is in
+      progress from the isolated clean branch; the broad dirty primary checkout
+      remains excluded.

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -291,6 +291,10 @@ html:not(.dark) .text-white\/20 { color: rgb(0 0 0 / 0.3); }
   aspect-ratio: 1;
   opacity: 0.12;
   pointer-events: none;
+  user-select: none;
+  filter: saturate(0.82) contrast(1.04);
+  -webkit-mask-image: linear-gradient(270deg, #000 0%, #000 58%, transparent 100%);
+  mask-image: linear-gradient(270deg, #000 0%, #000 58%, transparent 100%);
   transition: opacity 200ms ease;
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -259,6 +259,82 @@ html:not(.dark) .text-white\/20 { color: rgb(0 0 0 / 0.3); }
   box-shadow: var(--glass-nav-shadow);
 }
 
+/* Homepage destination artwork stays subordinate to the navigation copy.
+   The mask keeps each instrument concentrated on the card's trailing edge. */
+.explore-card {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.explore-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 0%,
+    color-mix(in srgb, var(--bg-card) 92%, transparent) 42%,
+    color-mix(in srgb, var(--bg-card) 46%, transparent) 76%,
+    transparent 100%
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.explore-card-art {
+  position: absolute;
+  right: -3.75rem;
+  bottom: -5.75rem;
+  z-index: 0;
+  width: clamp(13rem, 22vw, 16rem);
+  aspect-ratio: 1;
+  opacity: 0.12;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+}
+
+.explore-card-art__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.explore-card:hover .explore-card-art {
+  opacity: 0.17;
+}
+
+html:not(.dark) .explore-card-art {
+  opacity: 0.075;
+  filter: saturate(0.7) contrast(0.92);
+}
+
+html:not(.dark) .explore-card:hover .explore-card-art {
+  opacity: 0.11;
+}
+
+@media (max-width: 767px) {
+  .explore-card-art {
+    right: -2rem;
+    bottom: -6.25rem;
+    width: 15.5rem;
+    opacity: 0.1;
+  }
+
+  .explore-card:hover .explore-card-art {
+    opacity: 0.13;
+  }
+
+  html:not(.dark) .explore-card-art {
+    opacity: 0.065;
+  }
+
+  html:not(.dark) .explore-card:hover .explore-card-art {
+    opacity: 0.09;
+  }
+}
+
 /* Generated product artwork sits behind hero copy only. The local clipping
    layer prevents wide raster crops from creating horizontal page overflow. */
 .product-hero-backdrop {

--- a/apps/web/components/landing/explore-strip.tsx
+++ b/apps/web/components/landing/explore-strip.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 
@@ -6,6 +7,10 @@ interface Destination {
   eyebrow: string;
   title: string;
   desc: string;
+  art: {
+    src: string;
+    testId: string;
+  };
 }
 
 const DESTINATIONS: Destination[] = [
@@ -14,30 +19,50 @@ const DESTINATIONS: Destination[] = [
     eyebrow: '01 · Product',
     title: 'Live app',
     desc: 'Signals, screener, charts, and transparent engine state.',
+    art: {
+      src: '/brand/homepage/tradeclaw-live-signal-observatory-v1.webp',
+      testId: 'explore-art-live-app',
+    },
   },
   {
     href: '/how-it-works',
     eyebrow: '02 · System',
     title: 'How it works',
     desc: 'The scoring algorithm, risk model, and real implementation.',
+    art: {
+      src: '/brand/homepage/tradeclaw-scoring-engine-v1.webp',
+      testId: 'explore-art-how-it-works',
+    },
   },
   {
     href: '/research',
     eyebrow: '03 · Evidence',
     title: 'Research',
     desc: 'What survived testing, what failed, and why it was removed.',
+    art: {
+      src: '/brand/editorial/tradeclaw-research-gate-v1.webp',
+      testId: 'explore-art-research',
+    },
   },
   {
     href: '/methodology',
     eyebrow: '04 · Proof',
     title: 'Methodology',
     desc: 'How every public performance number is reproduced.',
+    art: {
+      src: '/brand/editorial/tradeclaw-methodology-calibrator-v1.webp',
+      testId: 'explore-art-methodology',
+    },
   },
   {
     href: '/open-data',
     eyebrow: '05 · API',
     title: 'Open data',
     desc: 'The endpoints behind the dashboard, ledger, and charts.',
+    art: {
+      src: '/brand/editorial/tradeclaw-open-data-aperture-v1.webp',
+      testId: 'explore-art-open-data',
+    },
   },
 ];
 
@@ -70,19 +95,33 @@ export function ExploreStrip() {
           >
             <Link
               href={destination.href}
-              className="group flex h-full min-h-44 flex-col p-5 transition-colors duration-200 hover:bg-[var(--brand-soft)] sm:p-6"
+              className="explore-card group flex h-full min-h-44 flex-col p-5 transition-colors duration-200 hover:bg-[var(--brand-soft)] sm:p-6"
             >
-              <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-[var(--text-secondary)]">
+              <span
+                className="explore-card-art"
+                data-testid={destination.art.testId}
+                aria-hidden="true"
+              >
+                <Image
+                  src={destination.art.src}
+                  alt=""
+                  width={1254}
+                  height={1254}
+                  sizes="(min-width: 1280px) 220px, (min-width: 768px) 38vw, 68vw"
+                  className="explore-card-art__image"
+                />
+              </span>
+              <span className="relative z-10 text-[10px] font-mono uppercase tracking-[0.12em] text-[var(--text-secondary)]">
                 {destination.eyebrow}
               </span>
-              <span className="mt-8 flex items-center justify-between gap-3 text-base font-semibold">
+              <span className="relative z-10 mt-8 flex items-center justify-between gap-3 text-base font-semibold">
                 {destination.title}
                 <ArrowUpRight
                   className="h-4 w-4 text-[var(--text-secondary)] transition-all duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-[var(--brand)]"
                   aria-hidden="true"
                 />
               </span>
-              <span className="mt-2 text-sm leading-5 text-[var(--text-secondary)]">
+              <span className="relative z-10 mt-2 text-sm leading-5 text-[var(--text-secondary)]">
                 {destination.desc}
               </span>
             </Link>


### PR DESCRIPTION
## What changed

- Restores the five existing generated WebPs as restrained trailing-edge backgrounds in the homepage ExploreStrip cards.
- Keeps every current generated hero backdrop, including the homepage hero artwork.
- Preserves destination copy, links, accessibility semantics, and product behavior.

## Why

TC-246 removed the TC-245 card rendering layer when generated artwork was moved behind page heroes. The image files remained in the repository, but the ExploreStrip became plain. The owner now wants both treatments to coexist.

## Impact

The homepage gains low-opacity decorative artwork behind Live app, How it works, Research, Methodology, and Open data. No new assets, dependencies, routes, Docker configuration, database behavior, auth, billing, strategy, allocation, or trading rules change.

## Verification

- `npm run lint` — 0 errors, 23 pre-existing warnings
- `npm run typecheck:web`
- `npm run build` — 324/324 pages
- Focused Chromium homepage destination + product hero suite — 11/11
- Direct 1515x900 and 390x844 dark/light QA — exact five decoded sources, preserved homepage hero, restrained opacity, readable copy, zero overflow
- `git diff --check`