### PR TITLE
fix: backfill frozen D1 activation history

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -4333,4 +4333,13 @@ next_actions:
       boundary is signal tracking only: exact env value active promotes future
       newest-bar BTC/ETH D1 transitions; missing/invalid values remain paper,
       no historical backfill occurs, broadcast remains fail-closed without an
-      explicit decision, and broker execution stays disabled.
+      explicit decision, and broker execution stays disabled. PR #204 passed all
+      protected checks, squash merged as c14164a8e3ab8a8170a44d8b4eae9279e1da3ed7,
+      and exact merged main deployed successfully as a5379c1b-5949-41df-a7e2-cb5f4171405c.
+      Setting D1_SLOW_GATE_MODE=active triggered successful Railway redeploy
+      12877bcf-94d8-4e25-91d9-b1d3d9cdbee8. The first authenticated tick confirmed
+      mode=active but failed closed for both symbols before emission because the
+      production D1 store lacked the exact frozen 2017-09-01 prefix. A follow-up
+      append-only paginated Binance D1 repair is in progress; activation is not
+      complete until a subsequent active tick processes both symbols without
+      failures.

--- a/apps/web/lib/__tests__/candle-store-d1.test.ts
+++ b/apps/web/lib/__tests__/candle-store-d1.test.ts
@@ -3,7 +3,7 @@ jest.mock('../db-pool', () => ({
 }));
 
 import { query } from '../db-pool';
-import { refreshDailyCandles } from '../candle-store';
+import { backfillDailyCandles, refreshDailyCandles } from '../candle-store';
 
 const mockedQuery = query as jest.MockedFunction<typeof query>;
 const realFetch = global.fetch;
@@ -42,5 +42,40 @@ describe('refreshDailyCandles', () => {
       'BTCUSD', 'D1', closedOpen, 100, 110, 90, 105, 12, 'binance',
     ]);
     expect(openOpen + DAY_MS).toBeGreaterThan(now);
+  });
+
+  it('backfills paginated closed D1 history from an explicit UTC boundary', async () => {
+    const start = Date.UTC(2017, 8, 1);
+    const firstPageLast = start + 999 * DAY_MS;
+    const secondPageOpen = firstPageLast + DAY_MS;
+    jest.spyOn(Date, 'now').mockReturnValue(secondPageOpen + 2 * DAY_MS);
+    mockedQuery
+      .mockResolvedValueOnce(Array.from({ length: 1000 }, (_, index) => ({ ts: String(start + index * DAY_MS) })))
+      .mockResolvedValueOnce([{ ts: String(secondPageOpen) }]);
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => Array.from({ length: 1000 }, (_, index) => [
+          start + index * DAY_MS, '100', '110', '90', '105', '12',
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [[secondPageOpen, '105', '115', '95', '111', '13']],
+      }) as unknown as typeof fetch;
+
+    await expect(backfillDailyCandles('BTCUSD', start)).resolves.toBe(1001);
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(`startTime=${start}`),
+      expect.any(Object),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(`startTime=${secondPageOpen}`),
+      expect.any(Object),
+    );
+    expect(mockedQuery).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/lib/__tests__/d1-slow-gate-paper.test.ts
+++ b/apps/web/lib/__tests__/d1-slow-gate-paper.test.ts
@@ -1,4 +1,5 @@
 jest.mock('../candle-store', () => ({
+  backfillDailyCandles: jest.fn(),
   getCandlesSince: jest.fn(),
   refreshDailyCandles: jest.fn(),
 }));
@@ -18,7 +19,12 @@ import {
   runD1SlowGate,
   type D1SlowGateRun,
 } from '@tradeclaw/strategies';
-import { getCandlesSince, refreshDailyCandles, type StoredCandle } from '../candle-store';
+import {
+  backfillDailyCandles,
+  getCandlesSince,
+  refreshDailyCandles,
+  type StoredCandle,
+} from '../candle-store';
 import { recordSignalsAsync } from '../signal-history';
 import {
   D1_SLOW_GATE_PAPER_START_TS,
@@ -29,6 +35,7 @@ import {
 const mockedRun = runD1SlowGate as jest.MockedFunction<typeof runD1SlowGate>;
 const mockedGetCandles = getCandlesSince as jest.MockedFunction<typeof getCandlesSince>;
 const mockedRefresh = refreshDailyCandles as jest.MockedFunction<typeof refreshDailyCandles>;
+const mockedBackfill = backfillDailyCandles as jest.MockedFunction<typeof backfillDailyCandles>;
 const mockedRecord = recordSignalsAsync as jest.MockedFunction<typeof recordSignalsAsync>;
 
 const DAY_MS = 86_400_000;
@@ -79,6 +86,7 @@ beforeEach(() => {
   mockedRun.mockReset();
   mockedGetCandles.mockReset();
   mockedRefresh.mockReset().mockResolvedValue(1);
+  mockedBackfill.mockReset().mockResolvedValue(1);
   mockedRecord.mockReset().mockResolvedValue(1);
 });
 
@@ -139,6 +147,22 @@ describe('runD1SlowGateLane', () => {
         isSimulated: false,
       }),
     ]);
+  });
+
+  it('repairs a later production prefix before evaluating the lane', async () => {
+    const bars = dailyBars();
+    mockedGetCandles
+      .mockResolvedValueOnce(bars.slice(1))
+      .mockResolvedValueOnce(bars)
+      .mockResolvedValueOnce(bars);
+    mockedRun.mockImplementation(() => runFor(bars, false));
+
+    const result = await runD1SlowGateLane({ now: NOW, mode: 'active' });
+
+    expect(result).toEqual({ mode: 'active', processed: 2, candidates: 0, recorded: 0, failures: [] });
+    expect(mockedBackfill).toHaveBeenCalledTimes(1);
+    expect(mockedBackfill).toHaveBeenCalledWith('BTCUSD', D1_SLOW_GATE_PAPER_START_TS);
+    expect(mockedGetCandles).toHaveBeenCalledTimes(3);
   });
 
   it('fails closed when the latest closed D1 bar is stale', async () => {

--- a/apps/web/lib/candle-store.ts
+++ b/apps/web/lib/candle-store.ts
@@ -19,6 +19,8 @@ const BINANCE_BASE = 'https://data-api.binance.vision/api/v3/klines';
  */
 const REFRESH_KLINE_LIMIT = 48;
 const D1_REFRESH_KLINE_LIMIT = 14;
+const D1_BACKFILL_KLINE_LIMIT = 1000;
+const D1_BACKFILL_MAX_PAGES = 10;
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -171,4 +173,75 @@ export async function refreshCandles(symbol: string): Promise<number> {
 /** Append the latest provably closed UTC-D1 bars for the slow-gate paper lane. */
 export async function refreshDailyCandles(symbol: string): Promise<number> {
   return refreshBinanceCandles(symbol, 'D1', '1d', D1_MS, D1_REFRESH_KLINE_LIMIT);
+}
+
+/**
+ * Append closed Binance D1 history from an explicit UTC boundary. This is the
+ * repair path for a production store whose recent prefix exists but whose
+ * frozen slow-gate history has not yet been loaded. Inserts remain append-only.
+ */
+export async function backfillDailyCandles(
+  symbol: string,
+  startTimestamp: number,
+): Promise<number> {
+  const pair = BINANCE_MAP[symbol];
+  if (!pair) throw new Error(`no Binance mapping for ${symbol}`);
+  if (!Number.isSafeInteger(startTimestamp) || startTimestamp <= 0 || startTimestamp % D1_MS !== 0) {
+    throw new Error('D1 backfill start must be a positive UTC-day safe integer');
+  }
+
+  const fetchStartTs = Date.now();
+  let cursor = startTimestamp;
+  let inserted = 0;
+
+  for (let page = 0; page < D1_BACKFILL_MAX_PAGES; page++) {
+    const url = `${BINANCE_BASE}?symbol=${pair}&interval=1d&startTime=${cursor}&limit=${D1_BACKFILL_KLINE_LIMIT}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!res.ok) {
+      throw new Error(
+        `Binance ${res.status} for ${pair} D1 backfill: ${(await res.text()).slice(0, 200)}`,
+      );
+    }
+    const klines = (await res.json()) as Array<
+      [number, string, string, string, string, string, ...unknown[]]
+    >;
+    const closed = klines.filter((k) => k[0] >= cursor && k[0] + D1_MS <= fetchStartTs);
+    if (closed.length === 0) break;
+
+    const values: string[] = [];
+    const params: unknown[] = [];
+    let parameter = 1;
+    for (const kline of closed) {
+      values.push(`($${parameter++}, $${parameter++}, $${parameter++}, $${parameter++}, $${parameter++}, $${parameter++}, $${parameter++}, $${parameter++}, $${parameter++})`);
+      params.push(
+        symbol,
+        'D1',
+        kline[0],
+        Number(kline[1]),
+        Number(kline[2]),
+        Number(kline[3]),
+        Number(kline[4]),
+        Number(kline[5]),
+        'binance',
+      );
+    }
+    const rows = await query<{ ts: string }>(
+      `INSERT INTO candles (symbol, timeframe, ts, open, high, low, close, volume, source)
+       VALUES ${values.join(', ')}
+       ON CONFLICT (symbol, timeframe, ts) DO NOTHING
+       RETURNING ts`,
+      params,
+    );
+    inserted += rows.length;
+
+    const nextCursor = closed[closed.length - 1][0] + D1_MS;
+    if (nextCursor <= cursor) throw new Error('Binance D1 backfill did not advance');
+    cursor = nextCursor;
+    if (klines.length < D1_BACKFILL_KLINE_LIMIT || cursor + D1_MS > fetchStartTs) break;
+  }
+
+  if (cursor + D1_MS <= fetchStartTs && inserted === 0) {
+    throw new Error(`Binance D1 backfill produced no closed rows for ${symbol}`);
+  }
+  return inserted;
 }

--- a/apps/web/lib/d1-slow-gate-paper.ts
+++ b/apps/web/lib/d1-slow-gate-paper.ts
@@ -6,7 +6,12 @@ import {
   runD1SlowGate,
   type D1SlowGateTransition,
 } from '@tradeclaw/strategies';
-import { getCandlesSince, refreshDailyCandles, type StoredCandle } from './candle-store';
+import {
+  backfillDailyCandles,
+  getCandlesSince,
+  refreshDailyCandles,
+  type StoredCandle,
+} from './candle-store';
 import { recordSignalsAsync, type TrackedSignalInput } from './signal-history';
 
 const DAY_MS = 86_400_000;
@@ -136,6 +141,14 @@ export async function runD1SlowGateLane(
     let candles: StoredCandle[];
     try {
       candles = await getCandlesSince(symbol, D1_SLOW_GATE_TIMEFRAME, D1_SLOW_GATE_PAPER_START_TS);
+      if (candles[0]?.timestamp !== D1_SLOW_GATE_PAPER_START_TS) {
+        await backfillDailyCandles(symbol, D1_SLOW_GATE_PAPER_START_TS);
+        candles = await getCandlesSince(
+          symbol,
+          D1_SLOW_GATE_TIMEFRAME,
+          D1_SLOW_GATE_PAPER_START_TS,
+        );
+      }
       validatePaperCandles(candles, now);
     } catch (error) {
       failures.push({ symbol, stage: 'data', error: message(error) });

--- a/docs/plans/2026-08-09-d1-slow-gate-activation.md
+++ b/docs/plans/2026-08-09-d1-slow-gate-activation.md
@@ -34,3 +34,13 @@ reconciliation/lookahead/cadence QA gates passed.
 
 Set `D1_SLOW_GATE_MODE=paper` and redeploy. Previously written real rows remain
 historical records; the mode change only affects future newest-bar transitions.
+
+## Production activation check
+
+The first authenticated active tick on 2026-08-09 reported `mode=active` but
+failed closed for both symbols because production had a recent D1 prefix rather
+than the frozen 2017-09-01 boundary. No D1 row was emitted. The repair keeps the
+exact frozen-start validator and append-only store: when that prefix is absent,
+the lane paginates closed Binance D1 bars from the registered boundary, inserts
+with `ON CONFLICT DO NOTHING`, reloads the database stream, and only then runs
+the unchanged integrity and strategy gates.


### PR DESCRIPTION
## Production blocker
The first authenticated active cron tick confirmed D1_SLOW_GATE_MODE=active but failed closed for BTCUSD and ETHUSD because Railway had only a later D1 prefix, not the frozen 2017-09-01 boundary. No D1 row was emitted.

## Fix
- append-only paginate closed Binance D1 bars from the exact frozen boundary
- insert with ON CONFLICT DO NOTHING, reload the database stream, then run the unchanged validator and strategy
- retain exact-start, >=200 bars, UTC cadence, <=48h staleness, frequency cap, newest-bar-only emission, broadcast fail-closed, and broker-execution-disabled boundaries

## Verification
- TDD: focused production-prefix repair tests failed before implementation and pass 9/9 after
- full Jest: 232 suites, 1,839 passed, 26 skipped, 1 snapshot
- typecheck pass
- lint 0 errors (23 pre-existing warnings)
- production build pass, 324/324 pages