### PR TITLE
feat: separate observed track record and modeled study

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Demo](https://img.shields.io/badge/Demo-Live-10b981?style=flat-square)](https://tradeclaw.win/dashboard)
 
-**[Track Record](https://tradeclaw.win/track-record)** · **[Live Demo](https://tradeclaw.win/dashboard)** · **[API Docs](https://tradeclaw.win/api-docs)** · **[Pricing](https://tradeclaw.win/pricing)**
+**[Track Record](https://tradeclaw.win/track-record)** · **[Modeled Study](https://tradeclaw.win/track-record/study)** · **[Live Demo](https://tradeclaw.win/dashboard)** · **[API Docs](https://tradeclaw.win/api-docs)**
 
 Read this in other languages: [日本語](README.ja.md) · [한국어](README.ko.md) · [中文](README.zh.md) · [more](LANGUAGES.md)
 
@@ -22,7 +22,7 @@ Read this in other languages: [日本語](README.ja.md) · [한국어](README.ko
 
 ---
 
-TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (RSI, MACD, EMA, Bollinger Bands, Stochastic, ADX, Volume). Eligible signals and their OHLCV-derived outcomes are recorded in PostgreSQL. The [track record](https://tradeclaw.win/track-record) exposes counted wins and losses plus exclusion counters and methodology; it is not a broker-fill or customer-portfolio ledger.
+TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (RSI, MACD, EMA, Bollinger Bands, Stochastic, ADX, Volume). Eligible signals and their OHLCV-derived outcomes are recorded in PostgreSQL. The [track record](https://tradeclaw.win/track-record) exposes only observed outcome counts, rates, unsized price moves, exclusions, and row-level evidence. The separate [modeled signal study](https://tradeclaw.win/track-record/study) applies fixed-fractional sizing and fee/slippage assumptions. Neither surface is a broker-fill or customer-portfolio ledger.
 
 > Status: pre-1.0 (`0.1.0`). The signal engine, dashboard, backtester, and self-host path are usable today; APIs and schema may still change between releases.
 
@@ -33,7 +33,7 @@ TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (R
 | Public dashboard and track record | Read-only research access without authentication |
 | Signal history | Current rolling archive, capped at 10,000 source rows; CSV and provenance endpoints are public |
 | Costs | Static fee + slippage models; funding and actual broker charges are excluded |
-| Portfolio curve | Hypothetical sequential 1%-risk simulation, not concurrent account performance |
+| Modeled signal study | Separate hypothetical sequential 1%-risk simulation, not concurrent account performance |
 | Admin operations | Authentication required |
 | Signal broadcasting | Fail-closed unless the broadcast-approved 90-day cohort clears the cost-adjusted evidence gate |
 | Automated execution | Disabled by default; Binance USDT-perp testnet is implemented, while the RoboForex R StocksTrader bridge is an unimplemented interface scaffold |

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-08-04T15:21:00+08:00
+updated: 2026-08-09T13:15:31+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -4352,3 +4352,49 @@ next_actions:
       Broker execution remains disabled, historical rows were not backfilled into
       signal_history, and broadcast eligibility still requires a separate recorded
       gate decision.
+
+  - id: TC-252
+    title: "Separate the observed track record from the modeled signal study"
+    status: done
+    owner: pm-tradeclaw
+    notes: >
+      Started 2026-08-09 after the owner asked to improve the public track record
+      and explicitly separate the study from the record. Work is isolated in clean
+      branch agent/track-record-study-separation from exact origin/main
+      ed333035fb38ecdd9eacbd02b90e69b868337390; the broad dirty primary checkout
+      remains excluded. The observed /track-record surface will retain only
+      source-backed OHLCV outcome counts, rates, unsized price moves, exclusions,
+      per-symbol summaries, and row-level audit evidence. The fixed-fractional,
+      fee/slippage-adjusted sequential equity model and premium-band comparison
+      will move to /track-record/study behind an explicit evidence-surface switcher.
+      Negative study results remain visible and linked; the split must not turn a
+      simulation into a live-performance claim or hide an adverse result. No
+      strategy, allocation, signal generation, resolver, broker execution,
+      database/schema, auth, billing, dependency, Docker, cron, or production
+      activation change is included. Implemented locally on the isolated branch.
+      /track-record now leads with the counted resolved population and contains
+      only observed/source-backed outcome statistics, exclusions, per-symbol
+      summaries, and row-level evidence. /track-record/study owns the hypothetical
+      fixed-fractional curve, drawdown, net expectancy, premium-band comparison,
+      and explicit non-broker/non-portfolio boundary. Shared period/scope/category
+      controls preserve every supported period; this fixes the prior silent
+      90d/180d/1y/5y-to-all-time mapping. Rolling observed rates moved onto the
+      history response so the record no longer fetches the equity-model endpoint.
+      SEO metadata, sitemap, README, embed/share copy, five locales, and route
+      contracts now preserve the evidence boundary. A real-browser pass caught
+      and fixed a zero-evidence +0%/-0% placeholder in the new study hero; it now
+      renders em dashes until at least one trade is sized. Verification: focused
+      separation/API/i18n/sitemap Jest 55/55; full Jest 233 suites passed with 3
+      intentionally skipped, 1,843 tests passed and 26 skipped; web typecheck;
+      lint 0 errors with 23 pre-existing warnings; final production build 325/325
+      pages; diff check clean. CLI-first Playwright verification on the final build
+      returned 200 for both routes, 0 console errors/warnings, no modeled heading
+      or canvas and no equity API request on the observed route, explicit modeled
+      boundaries on the study, and honest no-evidence placeholders. Screenshots
+      are retained under ignored output/playwright. No commit, push, PR, merge, or
+      production deployment was performed; release remains a separate owner
+      decision. The broad dirty primary checkout remained untouched. At
+      2026-08-09 13:15 MPST (+0800), the owner explicitly said "ship",
+      authorizing commit, push, protected PR review, merge after green gates,
+      exact-final-main Railway production deployment, and live verification.
+      Release is in progress from the isolated worktree only.

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-08-09T13:15:31+08:00
+updated: 2026-08-09T13:45:58+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -4397,4 +4397,21 @@ next_actions:
       2026-08-09 13:15 MPST (+0800), the owner explicitly said "ship",
       authorizing commit, push, protected PR review, merge after green gates,
       exact-final-main Railway production deployment, and live verification.
-      Release is in progress from the isolated worktree only.
+      Release is in progress from the isolated worktree only. The implementation
+      was committed as 9d8e6074056ba8e45f3e301db8aff9fbaba1ceda and pushed in
+      draft PR #207. Its first CI run 31296370571 passed lint/typecheck, build,
+      unit tests, strategy backtests, Docker build, and welcome, but correctly
+      blocked merge when Playwright E2E found two release-test defects: the
+      localization matrix conflated the retained OHLCV eyebrow with the newly
+      localized observed-record document title, and the study test's broad
+      heading regex matched both the page h1 and study-card h2. The title matrix
+      now asserts separate eyebrow/title values in all five locales, and the
+      study assertion targets the exact level-one heading. The affected Chromium
+      matrix passed locally (setup plus 14/14 browser checks); the fresh mandatory
+      production build passed all 325 pages and web TypeScript passed. Local
+      WebKit could not be verified because the required browser binary was absent and its
+      installer did not complete within a bounded wait; the protected GitHub
+      runner remains the authoritative pending desktop/mobile check. One unrelated
+      dashboard hero-art duplicate was reported flaky and passed on retry; no
+      out-of-scope product change was made for it. Merge and deploy remain blocked
+      until the replacement PR head passes every required gate.

--- a/apps/web/app/__tests__/sitemap-routes.test.ts
+++ b/apps/web/app/__tests__/sitemap-routes.test.ts
@@ -35,6 +35,7 @@ describe('sitemap', () => {
       '/open-data',
       '/calibration',
       '/track-record',
+      '/track-record/study',
     ]) {
       expect(urls).toContain(`${BASE}${p}`);
     }

--- a/apps/web/app/api/signals/equity/route.ts
+++ b/apps/web/app/api/signals/equity/route.ts
@@ -3,6 +3,7 @@ import { isCountedResolved, type SignalHistoryRecord } from '../../../../lib/sig
 import { HIGH_CONFIDENCE_BAND_MIN } from '../../../../lib/signal-thresholds';
 import { getResolvedSlice, parseScope, type SignalScope } from '../../../../lib/signal-slice';
 import { modeledTradeR } from '../../../../lib/modeled-trade-cost';
+import { computeRollingWinRates } from '../../../../lib/rolling-win-rates';
 import { parseCategoryFilter, symbolsForCategory } from '../../../lib/symbol-config';
 
 export type EquityScope = SignalScope;
@@ -74,18 +75,6 @@ export interface EquitySummary {
   avgCostR: number | null;
   /** Hard R-cap applied to per-trade sizing — bounds single-trade equity contribution. */
   hardRCap: number;
-}
-
-export interface RollingWinRateSummary {
-  totalSignals: number;
-  resolvedSignals: number;
-  winRate: number;
-}
-
-export interface RollingWinRates {
-  '7d': RollingWinRateSummary;
-  '30d': RollingWinRateSummary;
-  '90d': RollingWinRateSummary;
 }
 
 function parseBand(raw: string | null): EquityBand {
@@ -285,29 +274,6 @@ function computeEquityCurve(
   };
 }
 
-function computeWinRateSummary(records: SignalHistoryRecord[]): RollingWinRateSummary {
-  const resolvedSignals = records.filter(isCountedResolved);
-  const wins = resolvedSignals.filter((record) => record.outcomes['24h']!.hit).length;
-
-  return {
-    totalSignals: records.length,
-    resolvedSignals: resolvedSignals.length,
-    winRate: resolvedSignals.length > 0 ? +((wins / resolvedSignals.length) * 100).toFixed(1) : 0,
-  };
-}
-
-function computeRollingWinRates(records: SignalHistoryRecord[]): RollingWinRates {
-  const now = Date.now();
-  const windows = [7, 30, 90] as const;
-
-  return windows.reduce((acc, days) => {
-    const cutoff = now - days * 86_400_000;
-    const key = `${days}d` as const;
-    acc[key] = computeWinRateSummary(records.filter((record) => record.timestamp >= cutoff));
-    return acc;
-  }, {} as RollingWinRates);
-}
-
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -340,7 +306,10 @@ export async function GET(request: NextRequest) {
     const categorySymbols = category !== 'all'
       ? new Set(symbolsForCategory(category))
       : null;
-    const rollingWinRates = computeRollingWinRates(slice.scopedRecords);
+    const rollingPopulation = categorySymbols
+      ? slice.scopedRecords.filter(r => categorySymbols.has(r.pair))
+      : slice.scopedRecords;
+    const rollingWinRates = computeRollingWinRates(rollingPopulation);
 
     // Band filter is equity-only. Apply on the resolved set, then recompute
     // counted-resolved (no-op when band='all', filters confidence otherwise).
@@ -364,6 +333,7 @@ export async function GET(request: NextRequest) {
         band,
         scope,
         category,
+        earliestTimestamp: slice.earliestTimestamp,
         // capR is in R-multiples now (under fixed-fractional sizing). Older
         // capPct field kept null/absent — UI should read capR.
         smooth: smoothMultiplier !== null

--- a/apps/web/app/api/signals/history/__tests__/route.test.ts
+++ b/apps/web/app/api/signals/history/__tests__/route.test.ts
@@ -247,6 +247,30 @@ describe('GET /api/signals/history category filtering', () => {
     expect(body.stats.winRate).toBe(0);
   });
 
+  it('returns category-scoped rolling observed outcomes without the equity model', async () => {
+    const now = Date.now();
+    primeSlice([
+      record({ id: 'btc-recent', pair: 'BTCUSD', timestamp: now - 60_000 }),
+      record({
+        id: 'doge-recent',
+        pair: 'DOGEUSD',
+        timestamp: now - 60_000,
+        outcomes: { '4h': null, '24h': { price: 0.18, pnlPct: -1, hit: false } },
+      }),
+    ]);
+
+    const res = await GET(makeReq('/api/signals/history?category=thematic'));
+    const body = await res.json();
+
+    expect(body.rollingWinRates['7d']).toEqual({
+      totalSignals: 1,
+      resolvedSignals: 1,
+      winRate: 0,
+    });
+    expect(body.rollingWinRates['30d']).toEqual(body.rollingWinRates['7d']);
+    expect(body.rollingWinRates['90d']).toEqual(body.rollingWinRates['7d']);
+  });
+
   it('lets pair filter win over a conflicting category', async () => {
     primeSlice([
       record({ id: 'btc-1', pair: 'BTCUSD' }),

--- a/apps/web/app/api/signals/history/route.ts
+++ b/apps/web/app/api/signals/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isCountedResolved, isRealOutcome, type SignalHistoryRecord } from '../../../../lib/signal-history';
 import { getResolvedSlice, parseScope } from '../../../../lib/signal-slice';
+import { computeRollingWinRates } from '../../../../lib/rolling-win-rates';
 import { parseCategoryFilter, symbolsForCategory } from '../../../lib/symbol-config';
 
 const CSV_HEADERS = [
@@ -93,9 +94,13 @@ export async function GET(request: NextRequest) {
     const slice = await getResolvedSlice({ scope, period });
     let records = slice.periodFiltered;
 
-    const categorySymbols = !pair && category !== 'all'
+    const selectedCategorySymbols = category !== 'all'
       ? new Set(symbolsForCategory(category))
       : null;
+    const categorySymbols = !pair ? selectedCategorySymbols : null;
+    const rollingPopulation = selectedCategorySymbols
+      ? slice.scopedRecords.filter(r => selectedCategorySymbols.has(r.pair))
+      : slice.scopedRecords;
 
     if (pair) records = records.filter(r => r.pair === pair);
     if (categorySymbols) records = records.filter(r => categorySymbols.has(r.pair));
@@ -222,6 +227,7 @@ export async function GET(request: NextRequest) {
       category,
       earliestTimestamp: slice.earliestTimestamp,
       latestTimestamp,
+      rollingWinRates: computeRollingWinRates(rollingPopulation),
       stats: {
         available: resolved.length > 0,
         totalSignals: records.length,

--- a/apps/web/app/components/equity-curve.tsx
+++ b/apps/web/app/components/equity-curve.tsx
@@ -364,7 +364,7 @@ type EquityScope = 'pro' | 'broadcast';
 type EquityBand = 'all' | 'premium' | 'standard';
 
 interface EquityCurveProps {
-  period?: '7d' | '30d' | 'all';
+  period?: '7d' | '30d' | '90d' | '180d' | '1y' | '5y' | 'all';
   scope?: EquityScope;
   category?: CategoryFilter;
   band?: EquityBand;

--- a/apps/web/app/components/share-linkedin.tsx
+++ b/apps/web/app/components/share-linkedin.tsx
@@ -21,7 +21,7 @@ interface ShareLinkedInProps {
 
 /**
  * Pre-filled LinkedIn share button for the public track-record. Opens the
- * LinkedIn feed composer with pre-filled, scope-labeled signal-study text.
+ * LinkedIn feed composer with pre-filled, scope-labeled observed-record text.
  */
 export function ShareLinkedIn({
   winRate,

--- a/apps/web/app/components/share-on-x.tsx
+++ b/apps/web/app/components/share-on-x.tsx
@@ -20,7 +20,7 @@ interface ShareOnXProps {
 }
 
 /**
- * Pre-filled X share button for the public signal study.
+ * Pre-filled X share button for the public observed outcome record.
  */
 export function ShareOnX({ winRate, resolved, period = 'recent', label }: ShareOnXProps) {
   const { locale } = useLocale();

--- a/apps/web/app/components/trailing-week-band-callout.tsx
+++ b/apps/web/app/components/trailing-week-band-callout.tsx
@@ -9,6 +9,7 @@ import {
   type TrackRecordWidgetTranslations,
 } from '@/lib/product-i18n/track-record-widgets';
 import { getHtmlLanguage } from '@/lib/translations';
+import type { CategoryFilter } from '@/app/lib/symbol-config';
 
 interface BandSummary {
   totalReturn: number;
@@ -94,7 +95,7 @@ function rMultiple(language: string, value: number): string {
  * Four parallel summary-only GETs to /api/signals/equity (7d + all-time, each
  * band=all / band=premium). summaryOnly=1 skips the point payload.
  */
-export function TrailingWeekBandCallout() {
+export function TrailingWeekBandCallout({ category = 'all' }: { category?: CategoryFilter }) {
   const { locale } = useLocale();
   const t = getTrackRecordWidgetTranslations(locale).trailingWeek;
   const language = getHtmlLanguage(locale);
@@ -105,7 +106,9 @@ export function TrailingWeekBandCallout() {
     let cancelled = false;
     async function fetchSummary(period: string, band: string): Promise<BandSummary | null> {
       try {
-        const res = await fetch(`/api/signals/equity?period=${period}&scope=pro&band=${band}&summaryOnly=1`);
+        const params = new URLSearchParams({ period, scope: 'pro', band, summaryOnly: '1' });
+        if (category !== 'all') params.set('category', category);
+        const res = await fetch(`/api/signals/equity?${params.toString()}`);
         if (!res.ok) return null;
         const json = (await res.json()) as BandResponse;
         return json.summary;
@@ -136,7 +139,7 @@ export function TrailingWeekBandCallout() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [category]);
 
   if (loading) return null;
   if (!data?.sevenDay.all || !data.sevenDay.premium) return null;

--- a/apps/web/app/embed/track-record/page.tsx
+++ b/apps/web/app/embed/track-record/page.tsx
@@ -32,7 +32,7 @@ export default async function TrackRecordEmbedPage({ searchParams }: { searchPar
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
         <div style={{ fontSize: '12px', letterSpacing: '0.08em', textTransform: 'uppercase', opacity: 0.7 }}>
-          {`TradeClaw — OHLCV-resolved signal study (30d, ${bandLabel})`}
+          {`TradeClaw — observed OHLCV signal record (30d, ${bandLabel})`}
         </div>
         <a href="https://tradeclaw.win/track-record" target="_blank" rel="noopener" style={{ fontSize: '11px', color: '#10b981', textDecoration: 'none' }}>
           tradeclaw.win →

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -22,6 +22,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: base, lastModified: new Date(), changeFrequency: "daily", priority: 1, alternates: { languages: languageAlternates } },
     { url: `${base}/track-record`, lastModified: new Date(), changeFrequency: "daily", priority: 0.95 },
+    { url: `${base}/track-record/study`, lastModified: new Date(), changeFrequency: "daily", priority: 0.9 },
     { url: `${base}/research`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
     { url: `${base}/methodology`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
     { url: `${base}/why-long-term`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },

--- a/apps/web/app/track-record/TrackRecordClient.tsx
+++ b/apps/web/app/track-record/TrackRecordClient.tsx
@@ -2,10 +2,8 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { PageNavBar } from '@/components/PageNavBar';
-import { EquityCurve } from '@/app/components/equity-curve';
-import { TrailingWeekBandCallout } from '@/app/components/trailing-week-band-callout';
 import { BackgroundDecor } from '@/components/background/BackgroundDecor';
 import { InfoHint } from '@/components/InfoHint';
 import { ProductHeroBackdrop } from '@/components/product-hero-backdrop';
@@ -23,29 +21,24 @@ import {
   type TrackRecordTranslations,
 } from '@/lib/product-i18n/track-record';
 import { formatMessage } from '@/lib/product-i18n/format';
+import type { RollingWinRates } from '@/lib/rolling-win-rates';
+import {
+  EvidenceFilters,
+  EvidenceSurfaceNav,
+  type EvidencePeriod,
+  type EvidenceScope,
+} from './evidence-controls';
 
-type Period = '7d' | '30d' | '90d' | '180d' | '1y' | '5y' | 'all';
+type Period = EvidencePeriod;
 
-const PERIOD_OPTIONS: { value: Period; days: number | null }[] = [
-  { value: '7d', days: 7 },
-  { value: '30d', days: 30 },
-  { value: '90d', days: 90 },
-  { value: '180d', days: 180 },
-  { value: '1y', days: 365 },
-  { value: '5y', days: 1825 },
-  { value: 'all', days: null },
-];
-
-const PERIOD_CODE_LABELS: Record<Exclude<Period, 'all'>, string> = {
-  '7d': '7D',
-  '30d': '1M',
-  '90d': '3M',
-  '180d': '6M',
-  '1y': '1Y',
-  '5y': '5Y',
+const PERIOD_DAYS: Record<Exclude<Period, 'all'>, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+  '180d': 180,
+  '1y': 365,
+  '5y': 1825,
 };
-
-const CATEGORY_OPTIONS: CategoryFilter[] = ['all', 'majors', 'thematic'];
 
 function formatHeartbeatAge(
   lastUpdated: number,
@@ -79,16 +72,6 @@ function getResolutionHeartbeat(
   };
 }
 
-/** Periods where the window pre-dates the earliest recorded signal are
- * disabled. Showing "5Y" on 26 days of history fabricates depth we don't
- * have. `all` and the smallest enabled window stay clickable. */
-function isPeriodAvailable(daysWindow: number | null, earliestTs: number | null): boolean {
-  if (daysWindow === null) return true; // 'all' always available
-  if (earliestTs === null) return true; // unknown, don't block
-  const dataAgeDays = (Date.now() - earliestTs) / 86_400_000;
-  return daysWindow <= Math.ceil(dataAgeDays);
-}
-
 interface HistoryRecord {
   id: string;
   pair: string;
@@ -118,7 +101,7 @@ interface HistoryStats {
   resolved: number;
   /** Missing/zero force-expiry placeholders — excluded from win-rate. */
   expired: number;
-  /** Refused by the full-risk gate at emission — excluded from equity. */
+  /** Refused by the full-risk gate at emission — excluded from counted outcomes. */
   gateBlocked: number;
   /** Still open (no 24h outcome yet). */
   pending: number;
@@ -199,14 +182,12 @@ function periodWindowLabel(
   locale: Parameters<typeof getHtmlLanguage>[0],
   t: TrackRecordTranslations,
 ): string {
-  const opt = PERIOD_OPTIONS.find(o => o.value === period);
-  if (!opt) return '';
-  if (opt.days === null) {
+  if (period === 'all') {
     return earliestTs
       ? formatMessage(t.window.storedSince, { date: formatDateStamp(earliestTs, locale) })
       : t.window.currentArchive;
   }
-  const start = Date.now() - opt.days * 86_400_000;
+  const start = Date.now() - PERIOD_DAYS[period] * 86_400_000;
   const effectiveStart = earliestTs ? Math.max(start, earliestTs) : start;
   return `${formatDateStamp(effectiveStart, locale)} – ${formatDateStamp(Date.now(), locale)}`;
 }
@@ -307,34 +288,18 @@ function formatOutcomeCell(
 
 
 type DirectionFilter = 'ALL' | 'BUY' | 'SELL';
-type Scope = 'pro' | 'broadcast';
-type EquityBand = 'premium' | 'standard' | 'all';
-
-function parseEquityBand(raw: string | null): EquityBand {
-  if (raw === 'premium' || raw === 'standard') return raw;
-  return 'all';
-}
+type Scope = EvidenceScope;
 
 interface CategorySnapshot {
   winRate: number;
-  expectancyR: number | null;
-  totalSignals: number;
-  breakEvenWinRate: number | null;
-}
-
-interface RollingWinRateSnapshot {
-  totalSignals: number;
+  avgPnlPct: number | null;
   resolvedSignals: number;
-  winRate: number;
 }
-
-type RollingWindow = '7d' | '30d' | '90d';
-type RollingWinRates = Record<RollingWindow, RollingWinRateSnapshot>;
 
 /**
- * Side-by-side WR / expectancy comparison across All / Majors / Thematic.
- * One fetch per category — same cached endpoint as the equity curve, so
- * cost is one warm hit per category at the s-maxage=60 layer.
+ * Side-by-side observed outcome comparison across All / Majors / Thematic.
+ * This deliberately reads the leaderboard endpoint, not the modeled equity
+ * endpoint, so these cards contain no sizing or cost-study fields.
  */
 function CategoryBreakdownRow({
   period,
@@ -367,7 +332,7 @@ function CategoryBreakdownRow({
         cats.map(c => {
           const params = new URLSearchParams({ period, scope });
           if (c !== 'all') params.set('category', c);
-          return fetch(`/api/signals/equity?${params.toString()}`).then(r => r.ok ? r.json() : null);
+          return fetch(`/api/leaderboard?${params.toString()}`).then(r => r.ok ? r.json() : null);
         }),
       );
       if (cancelled) return;
@@ -378,12 +343,13 @@ function CategoryBreakdownRow({
       };
       cats.forEach((c, i) => {
         const r = results[i];
-        if (r.status === 'fulfilled' && r.value?.summary) {
+        if (r.status === 'fulfilled' && r.value?.overall) {
+          const resolvedSignals = Number(r.value.overall.resolvedSignals ?? 0);
+          const totalPnl = Number(r.value.overall.totalPnl ?? 0);
           next[c] = {
-            winRate: r.value.summary.winRate,
-            expectancyR: r.value.summary.expectancyR ?? null,
-            totalSignals: r.value.summary.totalSignals,
-            breakEvenWinRate: r.value.summary.breakEvenWinRate ?? null,
+            winRate: Number(r.value.overall.overallHitRate24h ?? 0),
+            avgPnlPct: resolvedSignals > 0 ? totalPnl / resolvedSignals : null,
+            resolvedSignals,
           };
         }
       });
@@ -405,10 +371,7 @@ function CategoryBreakdownRow({
       {cells.map(({ value, label }) => {
         const snap = data[value];
         const isActive = active === value;
-        const hasEvidence = Boolean(snap && snap.totalSignals > 0);
-        const winRateBeatsBE = hasEvidence && snap && snap.breakEvenWinRate !== null
-          ? snap.winRate >= snap.breakEvenWinRate
-          : hasEvidence && snap ? snap.winRate >= 50 : false;
+        const hasEvidence = Boolean(snap && snap.resolvedSignals > 0);
         return (
           <button
             key={value}
@@ -424,7 +387,7 @@ function CategoryBreakdownRow({
               <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-500">{label}</span>
               {snap && (
                 <span className="text-[9px] font-mono text-zinc-600 tabular-nums">
-                  n={new Intl.NumberFormat(language).format(snap.totalSignals)}
+                  n={new Intl.NumberFormat(language).format(snap.resolvedSignals)}
                 </span>
               )}
             </div>
@@ -433,27 +396,23 @@ function CategoryBreakdownRow({
             ) : (
               <>
                 <div className={`mt-0.5 text-base font-mono font-semibold tabular-nums ${
-                  !hasEvidence ? 'text-zinc-500' : winRateBeatsBE ? 'text-emerald-400' : 'text-red-400'
+                  hasEvidence ? 'text-zinc-200' : 'text-zinc-500'
                 }`}>
                   {hasEvidence ? `${snap.winRate}%` : '—'}
                 </div>
                 <div className="mt-0.5 flex items-center gap-2 text-[10px] font-mono text-zinc-500">
                   <span className={
-                    snap.expectancyR !== null && snap.expectancyR > 0
+                    snap.avgPnlPct !== null && snap.avgPnlPct > 0
                       ? 'text-emerald-500'
-                      : snap.expectancyR !== null && snap.expectancyR < 0
+                      : snap.avgPnlPct !== null && snap.avgPnlPct < 0
                         ? 'text-red-500'
                         : ''
                   }>
-                    {snap.expectancyR !== null
-                      ? `${snap.expectancyR >= 0 ? '+' : ''}${snap.expectancyR.toFixed(2)}R`
+                    {snap.avgPnlPct !== null
+                      ? `${snap.avgPnlPct >= 0 ? '+' : ''}${snap.avgPnlPct.toFixed(2)}%`
                       : '—'}
                   </span>
-                  {hasEvidence && snap.breakEvenWinRate !== null && (
-                    <span className="text-zinc-600">
-                      {formatMessage(t.header.breakEven, { value: snap.breakEvenWinRate })}
-                    </span>
-                  )}
+                  <span className="text-zinc-600">{t.stats.averagePnl}</span>
                 </div>
               </>
             )}
@@ -470,13 +429,10 @@ export function TrackRecordClient() {
   const language = getHtmlLanguage(locale);
   const numberFormatter = new Intl.NumberFormat(language);
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   // Default tab: eligible signal stream. Broadcast is the gate-approved subset.
   const [scope, setScope] = useState<Scope>('pro');
   const [category, setCategory] = useState<CategoryFilter>('all');
   const [period, setPeriod] = useState<Period>('all');
-  const equityBand = parseEquityBand(searchParams.get('band'));
   const [pairFilter, setPairFilter] = useState<string>('ALL');
   const [directionFilter, setDirectionFilter] = useState<DirectionFilter>('ALL');
   const [stats, setStats] = useState<HistoryStats | null>(null);
@@ -486,15 +442,6 @@ export function TrackRecordClient() {
   const [leaderboard, setLeaderboard] = useState<LeaderboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [rollingWinRates, setRollingWinRates] = useState<RollingWinRates | null>(null);
-  // Break-even win-rate for the current scope/period, from the equity summary.
-  // Surfaced at the headline so the headline win-rate reads against the bar the
-  // system needs, not a meaningless flat 50%.
-  const [headlineBreakEven, setHeadlineBreakEven] = useState<number | null>(null);
-  // Modeled (position-sized) compounded result + max drawdown from the equity
-  // summary. Surfaced at the headline so the sequential model result sits next
-  // to the raw unsized total, not buried in the equity card.
-  const [headlineCompoundedReturn, setHeadlineCompoundedReturn] = useState<number | null>(null);
-  const [headlineMaxDrawdown, setHeadlineMaxDrawdown] = useState<number | null>(null);
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -511,7 +458,7 @@ export function TrackRecordClient() {
     return () => window.clearInterval(timer);
   }, []);
 
-  const fetchData = useCallback(async (p: Period, off: number, pair: string, direction: DirectionFilter, s: Scope, c: CategoryFilter, band: EquityBand, isCancelled: () => boolean) => {
+  const fetchData = useCallback(async (p: Period, off: number, pair: string, direction: DirectionFilter, s: Scope, c: CategoryFilter, isCancelled: () => boolean) => {
     setLoading(true);
     try {
       const historyParams = new URLSearchParams({
@@ -527,16 +474,9 @@ export function TrackRecordClient() {
       const leaderboardParams = new URLSearchParams({ period: p, scope: s });
       if (c !== 'all') leaderboardParams.set('category', c);
 
-      const equityParams = new URLSearchParams({ period: p, scope: s, band });
-      if (c !== 'all') equityParams.set('category', c);
-      // Headline reads summary fields only (rolling win-rates, break-even,
-      // modeled result, drawdown) — the curve itself is fetched by EquityCurve.
-      equityParams.set('summaryOnly', '1');
-
-      const [historyRes, leaderboardRes, equityRes] = await Promise.allSettled([
+      const [historyRes, leaderboardRes] = await Promise.allSettled([
         fetch(`/api/signals/history?${historyParams.toString()}`),
         fetch(`/api/leaderboard?${leaderboardParams.toString()}`),
-        fetch(`/api/signals/equity?${equityParams.toString()}`),
       ]);
 
       if (historyRes.status === 'fulfilled' && historyRes.value.ok) {
@@ -546,49 +486,31 @@ export function TrackRecordClient() {
         setRecords(data.records ?? []);
         setTotal(data.total ?? 0);
         setEarliestTimestamp(typeof data.earliestTimestamp === 'number' ? data.earliestTimestamp : null);
+        setRollingWinRates(data.rollingWinRates ?? null);
+      } else if (!isCancelled()) {
+        setStats(null);
+        setRecords([]);
+        setTotal(0);
+        setEarliestTimestamp(null);
+        setRollingWinRates(null);
       }
 
       if (leaderboardRes.status === 'fulfilled' && leaderboardRes.value.ok) {
         const data = await leaderboardRes.value.json();
         if (isCancelled()) return;
         setLeaderboard(data);
+      } else if (!isCancelled()) {
+        setLeaderboard(null);
       }
 
-      if (equityRes.status === 'fulfilled' && equityRes.value.ok) {
-        const data = await equityRes.value.json();
-        if (isCancelled()) return;
-        const sizedTrades = typeof data.summary?.sizedTrades === 'number'
-          ? data.summary.sizedTrades
-          : 0;
-        setRollingWinRates(data.rollingWinRates ?? null);
-        setHeadlineBreakEven(
-          sizedTrades > 0 && typeof data.summary?.breakEvenWinRate === 'number'
-            ? data.summary.breakEvenWinRate
-            : null,
-        );
-        setHeadlineCompoundedReturn(
-          sizedTrades > 0 && typeof data.summary?.totalReturn === 'number'
-            ? data.summary.totalReturn
-            : null,
-        );
-        setHeadlineMaxDrawdown(
-          sizedTrades > 0 && typeof data.summary?.maxDrawdown === 'number'
-            ? data.summary.maxDrawdown
-            : null,
-        );
-      } else {
-        if (isCancelled()) return;
-        setRollingWinRates(null);
-        setHeadlineBreakEven(null);
-        setHeadlineCompoundedReturn(null);
-        setHeadlineMaxDrawdown(null);
-      }
     } catch {
       if (isCancelled()) return;
+      setStats(null);
+      setRecords([]);
+      setTotal(0);
+      setEarliestTimestamp(null);
       setRollingWinRates(null);
-      setHeadlineCompoundedReturn(null);
-      setHeadlineMaxDrawdown(null);
-      // silently fail
+      setLeaderboard(null);
     } finally {
       if (!isCancelled()) setLoading(false);
     }
@@ -596,9 +518,9 @@ export function TrackRecordClient() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchData(period, offset, pairFilter, directionFilter, scope, category, equityBand, () => cancelled);
+    fetchData(period, offset, pairFilter, directionFilter, scope, category, () => cancelled);
     return () => { cancelled = true; };
-  }, [period, offset, pairFilter, directionFilter, scope, category, equityBand, fetchData]);
+  }, [period, offset, pairFilter, directionFilter, scope, category, fetchData]);
 
   useEffect(() => {
     setOffset(0);
@@ -634,29 +556,16 @@ export function TrackRecordClient() {
     setPairFilter('ALL');
   };
 
-  const handleBandChange = useCallback((nextBand: EquityBand) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (nextBand === 'all') {
-      params.delete('band');
-    } else {
-      params.set('band', nextBand);
-    }
-    const qs = params.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [pathname, router, searchParams]);
-
-  const embeddedBand = scope === 'pro' ? equityBand : 'all';
-
   return (
     <div className="premium-product-shell relative isolate min-h-[100dvh] overflow-hidden text-[var(--foreground)]">
       <BackgroundDecor variant="track-record" />
       <PageNavBar />
 
       <main className="max-w-5xl mx-auto px-4 py-8 pb-20 md:pb-8">
-        {/* Header — lead with Total Return (sum of per-signal % at fixed risk).
-           This is a return-on-risk number, NOT compounded equity. Win rate
-           alone misleads because a 35% WR with positive expectancy beats a
-           70% WR with giant losers. We show both so the reader can judge. */}
+        <EvidenceSurfaceNav active="record" />
+
+        {/* Observed record header. Counted outcomes lead the hierarchy; unsized
+            price statistics remain visible without reading as account P&L. */}
         <div className="relative isolate mb-6">
           <ProductHeroBackdrop
             src="/brand/hero/tradeclaw-replay-evidence-chamber-v1.webp"
@@ -669,83 +578,64 @@ export function TrackRecordClient() {
           </div>
           <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2 mb-2">
             <div className="flex items-baseline gap-2">
-              <span className={`text-5xl sm:text-6xl font-bold tracking-tight tabular-nums ${
-                stats && stats.totalPnlPct > 0 ? 'text-emerald-400'
-                : stats && stats.totalPnlPct < 0 ? 'text-red-400'
-                : 'text-[var(--foreground)]'
-              }`}>
-                {hasResolvedEvidence && stats
-                  ? `${stats.totalPnlPct > 0 ? '+' : ''}${stats.totalPnlPct}%`
-                  : '—'}
+              <span className="text-5xl font-bold tracking-tight tabular-nums text-[var(--foreground)] sm:text-6xl">
+                {stats ? numberFormatter.format(stats.resolved) : '—'}
               </span>
               <span className="text-sm text-[var(--text-secondary)] inline-flex items-center gap-1">
-                {t.header.priceMoveSum}
-                <InfoHint text={t.hints.priceMoveSum} label={t.header.priceMoveHelp} />
+                {t.header.resolvedSignals}
+                <InfoHint text={t.hints.resolved} label={t.header.resolvedHelp} />
               </span>
-              {/* Provenance stamp — the window this headline actually covers,
-                  so a number from 26 days of data doesn't read as "all time". */}
               <span className="text-[11px] font-mono text-[var(--text-secondary)]">
                 {periodWindowLabel(period, earliestTimestamp, locale, t)}
               </span>
             </div>
             <div className="flex items-baseline gap-1.5">
-              <span className={`text-xl font-semibold tabular-nums ${
-                !hasResolvedEvidence ? 'text-[var(--foreground)]'
-                  : headlineBreakEven !== null && stats
-                  ? stats.winRate >= headlineBreakEven ? 'text-emerald-400' : 'text-red-400'
-                  : stats && stats.winRate >= 55 ? 'text-emerald-400'
-                  : stats && stats.winRate >= 45 ? 'text-zinc-400'
-                  : stats ? 'text-red-400' : 'text-[var(--foreground)]'
-              }`}>
+              <span className="text-xl font-semibold tabular-nums text-zinc-200">
                 {hasResolvedEvidence && stats ? `${stats.winRate}%` : '—'}
               </span>
               <span className="text-xs text-[var(--text-secondary)] inline-flex items-center gap-1">
                 {t.header.winRate}
                 <InfoHint text={t.hints.winRate24h} label={t.header.winRateHelp} />
               </span>
-              {/* Break-even win-rate at the headline (not only in sub-cards):
-                  a sub-50% win-rate above break-even is still profitable. */}
-              {headlineBreakEven !== null && (
-                <span className="text-[11px] font-mono text-[var(--text-secondary)] inline-flex items-center gap-1">
-                  {formatMessage(t.header.breakEven, { value: headlineBreakEven })}
-                  <InfoHint text={t.hints.breakEven} label={t.header.breakEvenHelp} />
-                </span>
-              )}
             </div>
             <div className="flex items-baseline gap-1.5">
-              <span className="text-xl font-semibold tabular-nums text-[var(--foreground)]">
-                {stats ? stats.resolved : '—'}
+              <span className={`text-xl font-semibold tabular-nums ${
+                !hasResolvedEvidence || !stats
+                  ? 'text-[var(--foreground)]'
+                  : stats.avgPnlPct > 0
+                    ? 'text-emerald-400'
+                    : stats.avgPnlPct < 0
+                      ? 'text-red-400'
+                      : 'text-zinc-300'
+              }`}>
+                {hasResolvedEvidence && stats
+                  ? `${stats.avgPnlPct >= 0 ? '+' : ''}${stats.avgPnlPct}%`
+                  : '—'}
               </span>
               <span className="text-xs text-[var(--text-secondary)] inline-flex items-center gap-1">
-                {t.header.resolvedSignals}
-                <InfoHint text={t.hints.resolved} label={t.header.resolvedHelp} />
+                {t.stats.averagePnl}
+                <InfoHint text={t.hints.averagePnl} label={t.stats.averagePnl} />
               </span>
             </div>
-            {/* Modeled (position-sized) return at headline weight — a standardized 1%-risk
-               research model shown next to the raw unsized total so the modeled figure isn't
-               buried. Paired with max drawdown so the path's cost is never hidden behind the
-               return. Analytics view, not a promise of subscriber returns. */}
-            {headlineCompoundedReturn !== null && (
-              <div className="flex items-baseline gap-1.5">
-                <span className={`text-xl font-semibold tabular-nums ${
-                  headlineCompoundedReturn > 0 ? 'text-emerald-400'
-                  : headlineCompoundedReturn < 0 ? 'text-red-400'
-                  : 'text-[var(--foreground)]'
-                }`}>
-                  {headlineCompoundedReturn > 0 ? '+' : ''}{headlineCompoundedReturn}%
-                </span>
-                <span className="text-xs text-[var(--text-secondary)] inline-flex items-center gap-1">
-                  {t.header.sequentialSimulation}
-                  <InfoHint text={t.hints.sequentialSimulation} label={t.header.simulationHelp} />
-                </span>
-                {headlineMaxDrawdown !== null && (
-                  <span className="text-[11px] font-mono text-red-400/80 inline-flex items-center gap-1">
-                    {formatMessage(t.header.maxDrawdown, { value: headlineMaxDrawdown })}
-                    <InfoHint text={t.hints.maxDrawdown} label={t.header.maxDrawdownHelp} />
-                  </span>
-                )}
-              </div>
-            )}
+            <div className="flex items-baseline gap-1.5">
+              <span className={`text-xl font-semibold tabular-nums ${
+                !hasResolvedEvidence || !stats
+                  ? 'text-[var(--foreground)]'
+                  : stats.totalPnlPct > 0
+                    ? 'text-emerald-400'
+                    : stats.totalPnlPct < 0
+                      ? 'text-red-400'
+                      : 'text-zinc-300'
+              }`}>
+                {hasResolvedEvidence && stats
+                  ? `${stats.totalPnlPct >= 0 ? '+' : ''}${stats.totalPnlPct}%`
+                  : '—'}
+              </span>
+              <span className="text-xs text-[var(--text-secondary)] inline-flex items-center gap-1">
+                {t.header.priceMoveSum}
+                <InfoHint text={t.hints.priceMoveSum} label={t.header.priceMoveHelp} />
+              </span>
+            </div>
             {resolutionHeartbeat && (
               <div
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-[11px] font-mono text-zinc-300"
@@ -759,7 +649,7 @@ export function TrackRecordClient() {
             )}
           </div>
           <div className="mt-2 flex items-center gap-2">
-            <EmbedButton embedPath={`/embed/track-record?band=${embeddedBand}`} label={t.header.embed} width={600} height={360} />
+            <EmbedButton embedPath="/embed/track-record" label={t.header.embed} width={600} height={360} />
             <ShareOnX
               winRate={stats?.winRate}
               resolved={stats?.resolved}
@@ -784,11 +674,7 @@ export function TrackRecordClient() {
             <div className="mt-4 grid gap-3 sm:grid-cols-3">
               {(['7d', '30d', '90d'] as const).map((window) => {
                 const snap = rollingWinRates[window];
-                const winTone = snap.winRate >= 55
-                  ? 'text-emerald-400'
-                  : snap.winRate >= 45
-                    ? 'text-zinc-300'
-                    : 'text-red-400';
+                const winTone = snap.resolvedSignals > 0 ? 'text-zinc-200' : 'text-zinc-500';
                 // Actual data span available. When the recorded history is
                 // shorter than the window label, a "90d win rate" really only
                 // covers N days — say so rather than imply 90 days of data.
@@ -824,94 +710,21 @@ export function TrackRecordClient() {
           </div>
         </div>
 
-        {/* Period Filter — buttons whose window exceeds available history are
-           disabled with a tooltip explaining how much history we actually have. */}
-        <div className="flex gap-1 mb-6 p-1 rounded-lg bg-white/[0.04] w-fit overflow-x-auto max-w-full">
-          {PERIOD_OPTIONS.map(({ value, days }) => {
-            const available = isPeriodAvailable(days, earliestTimestamp);
-            const label = value === 'all' ? t.periods.all : PERIOD_CODE_LABELS[value];
-            const dataAgeDays = earliestTimestamp
-              ? Math.max(1, Math.floor((Date.now() - earliestTimestamp) / 86_400_000))
-              : null;
-            const tooltip = !available && dataAgeDays
-              ? formatMessage(t.rolling.historyAvailable, { count: dataAgeDays })
-              : undefined;
-            return (
-              <button
-                key={value}
-                onClick={() => available && setPeriod(value)}
-                disabled={!available}
-                title={tooltip}
-                aria-disabled={!available}
-                className={`px-3 py-1.5 text-xs font-mono font-medium rounded-md transition-all whitespace-nowrap ${
-                  period === value && available
-                    ? 'bg-emerald-500/15 text-emerald-400'
-                    : !available
-                      ? 'text-zinc-700 cursor-not-allowed'
-                      : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
-                }`}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Scope tabs — default eligible stream; Broadcast is the subset the
-            risk gate APPROVED for the Telegram broadcast (decision recorded
-            per row since migration 048; approval is not delivery — outage
-            fallbacks and failed sends differ). */}
-        <div className="mb-3 flex items-center gap-1 p-1 rounded-lg bg-white/[0.04] w-fit">
-          {(
-            [
-              { value: 'pro', label: t.scope.eligibleLabel },
-              { value: 'broadcast', label: t.scope.broadcastLabel },
-            ] as const
-          ).map(({ value, label }) => (
-            <button
-              key={value}
-              onClick={() => setScope(value)}
-              aria-pressed={scope === value}
-              className={`px-3 py-1.5 text-xs font-mono font-medium rounded-md transition-all ${
-                scope === value
-                  ? 'bg-white/[0.08] text-[var(--foreground)]'
-                  : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-        {scope === 'broadcast' && (
-          <p className="mb-3 text-[11px] text-[var(--text-secondary)] max-w-xl">
-            {t.scope.broadcastDetail}
-          </p>
-        )}
-
-        {/* Category tabs — display-only segmentation over the same signal history */}
-        <div className="mb-2 flex items-center gap-1 p-1 rounded-lg bg-white/[0.04] w-fit overflow-x-auto max-w-full">
-          {CATEGORY_OPTIONS.map((value) => (
-            <button
-              key={value}
-              onClick={() => handleCategoryChange(value)}
-              aria-pressed={category === value}
-              className={`px-3 py-1.5 text-xs font-mono font-medium rounded-md transition-all whitespace-nowrap ${
-                category === value
-                  ? 'bg-emerald-500/15 text-emerald-400'
-                  : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
-              }`}
-            >
-              {t.categories[value]}
-            </button>
-          ))}
-        </div>
+        <EvidenceFilters
+          period={period}
+          onPeriodChange={setPeriod}
+          earliestTimestamp={earliestTimestamp}
+          scope={scope}
+          onScopeChange={setScope}
+          category={category}
+          onCategoryChange={handleCategoryChange}
+          t={t}
+        />
         <p className="mb-3 text-xs text-[var(--text-secondary)]">
           {categoryCaption}
         </p>
 
-        {/* Side-by-side WR + expectancy comparison so the user can see at a
-            glance which category is dragging the headline. Click a cell to
-            switch the active category — same effect as the tabs above. */}
+        {/* Observed category comparison; no modeled R or break-even fields. */}
         <CategoryBreakdownRow
           period={period}
           scope={scope}
@@ -1054,10 +867,16 @@ export function TrackRecordClient() {
                 {t.research.detail}
               </p>
             </div>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/track-record/study"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500/15 text-emerald-400 text-sm font-medium hover:bg-emerald-500/25 transition-colors"
+              >
+                {t.surfaces.studyLabel}
+              </Link>
               <Link
                 href="/strategies/leaderboard"
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500/15 text-emerald-400 text-sm font-medium hover:bg-emerald-500/25 transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/[0.06] text-[var(--foreground)] text-sm font-medium hover:bg-white/[0.1] transition-colors"
               >
                 {t.research.viewLeaderboard}
               </Link>
@@ -1070,24 +889,6 @@ export function TrackRecordClient() {
             </div>
           </div>
         </div>
-
-        {/* Trailing-7d callout — Premium-band vs eligible-stream side-by-side
-           over the last week. Renders ABOVE the equity curve so the regime
-           context lands before the long-form chart. Eligible scope only — the
-           broadcast subset is too narrow for a band split. */}
-        {scope === 'pro' && <TrailingWeekBandCallout />}
-
-        {/* Equity Curve — component accepts a narrower period set; map unsupported periods to 'all'.
-           Scope mirrors the tab above (eligible stream vs gate-approved broadcast).
-           Band toggle is exposed only on the eligible scope; the broadcast subset
-           is too narrow for a premium-band split to be meaningful. */}
-          <EquityCurve
-          period={period === '7d' || period === '30d' ? period : 'all'}
-          scope={scope}
-          category={category}
-          band={scope === 'pro' ? equityBand : 'all'}
-          onBandChange={scope === 'pro' ? handleBandChange : undefined}
-        />
 
         {/* Per-Symbol Breakdown */}
         <section className="mb-8">

--- a/apps/web/app/track-record/evidence-controls.tsx
+++ b/apps/web/app/track-record/evidence-controls.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import type { CategoryFilter } from '@/app/lib/symbol-config';
+import { useLocale } from '@/app/components/locale-provider';
+import {
+  getTrackRecordTranslations,
+  type TrackRecordTranslations,
+} from '@/lib/product-i18n/track-record';
+import { formatMessage } from '@/lib/product-i18n/format';
+
+export type EvidencePeriod = '7d' | '30d' | '90d' | '180d' | '1y' | '5y' | 'all';
+export type EvidenceScope = 'pro' | 'broadcast';
+export type EvidenceSurface = 'record' | 'study';
+
+const PERIOD_OPTIONS: { value: EvidencePeriod; days: number | null }[] = [
+  { value: '7d', days: 7 },
+  { value: '30d', days: 30 },
+  { value: '90d', days: 90 },
+  { value: '180d', days: 180 },
+  { value: '1y', days: 365 },
+  { value: '5y', days: 1825 },
+  { value: 'all', days: null },
+];
+
+const PERIOD_CODE_LABELS: Record<Exclude<EvidencePeriod, 'all'>, string> = {
+  '7d': '7D',
+  '30d': '1M',
+  '90d': '3M',
+  '180d': '6M',
+  '1y': '1Y',
+  '5y': '5Y',
+};
+
+const CATEGORY_OPTIONS: CategoryFilter[] = ['all', 'majors', 'thematic'];
+
+export function isEvidencePeriodAvailable(
+  daysWindow: number | null,
+  earliestTimestamp: number | null,
+  now: number,
+): boolean {
+  if (daysWindow === null || earliestTimestamp === null) return true;
+  const dataAgeDays = (now - earliestTimestamp) / 86_400_000;
+  return daysWindow <= Math.ceil(dataAgeDays);
+}
+
+export function EvidenceSurfaceNav({ active }: { active: EvidenceSurface }) {
+  const { locale } = useLocale();
+  const t = getTrackRecordTranslations(locale).surfaces;
+  const items = [
+    {
+      value: 'record' as const,
+      href: '/track-record',
+      label: t.recordLabel,
+      description: t.recordDescription,
+    },
+    {
+      value: 'study' as const,
+      href: '/track-record/study',
+      label: t.studyLabel,
+      description: t.studyDescription,
+    },
+  ];
+
+  return (
+    <nav
+      aria-label={t.ariaLabel}
+      className="mb-6 grid gap-2 rounded-2xl border border-white/[0.07] bg-black/20 p-2 sm:grid-cols-2"
+    >
+      {items.map((item) => {
+        const selected = item.value === active;
+        return (
+          <Link
+            key={item.value}
+            href={item.href}
+            aria-current={selected ? 'page' : undefined}
+            className={`rounded-xl border px-4 py-3 transition-colors ${
+              selected
+                ? 'border-emerald-500/35 bg-emerald-500/10 text-emerald-300'
+                : 'border-transparent text-[var(--text-secondary)] hover:border-white/10 hover:bg-white/[0.03] hover:text-[var(--foreground)]'
+            }`}
+          >
+            <span className="block text-sm font-semibold">{item.label}</span>
+            <span className="mt-0.5 block text-[11px] opacity-75">{item.description}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function EvidenceFilters({
+  period,
+  onPeriodChange,
+  earliestTimestamp,
+  scope,
+  onScopeChange,
+  category,
+  onCategoryChange,
+  t,
+}: {
+  period: EvidencePeriod;
+  onPeriodChange: (period: EvidencePeriod) => void;
+  earliestTimestamp: number | null;
+  scope: EvidenceScope;
+  onScopeChange: (scope: EvidenceScope) => void;
+  category: CategoryFilter;
+  onCategoryChange: (category: CategoryFilter) => void;
+  t: TrackRecordTranslations;
+}) {
+  const [now] = useState(() => Date.now());
+  const dataAgeDays = earliestTimestamp
+    ? Math.max(1, Math.floor((now - earliestTimestamp) / 86_400_000))
+    : null;
+
+  return (
+    <div className="mb-4">
+      <div className="mb-6 flex w-fit max-w-full gap-1 overflow-x-auto rounded-lg bg-white/[0.04] p-1">
+        {PERIOD_OPTIONS.map(({ value, days }) => {
+          const available = isEvidencePeriodAvailable(days, earliestTimestamp, now);
+          const label = value === 'all' ? t.periods.all : PERIOD_CODE_LABELS[value];
+          const tooltip = !available && dataAgeDays
+            ? formatMessage(t.rolling.historyAvailable, { count: dataAgeDays })
+            : undefined;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => available && onPeriodChange(value)}
+              disabled={!available}
+              title={tooltip}
+              aria-disabled={!available}
+              className={`whitespace-nowrap rounded-md px-3 py-1.5 font-mono text-xs font-medium transition-all ${
+                period === value && available
+                  ? 'bg-emerald-500/15 text-emerald-400'
+                  : !available
+                    ? 'cursor-not-allowed text-zinc-700'
+                    : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mb-3 flex w-fit items-center gap-1 rounded-lg bg-white/[0.04] p-1">
+        {(
+          [
+            { value: 'pro', label: t.scope.eligibleLabel },
+            { value: 'broadcast', label: t.scope.broadcastLabel },
+          ] as const
+        ).map(({ value, label }) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onScopeChange(value)}
+            aria-pressed={scope === value}
+            className={`rounded-md px-3 py-1.5 font-mono text-xs font-medium transition-all ${
+              scope === value
+                ? 'bg-white/[0.08] text-[var(--foreground)]'
+                : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {scope === 'broadcast' && (
+        <p className="mb-3 max-w-xl text-[11px] text-[var(--text-secondary)]">
+          {t.scope.broadcastDetail}
+        </p>
+      )}
+
+      <div className="mb-2 flex w-fit max-w-full items-center gap-1 overflow-x-auto rounded-lg bg-white/[0.04] p-1">
+        {CATEGORY_OPTIONS.map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onCategoryChange(value)}
+            aria-pressed={category === value}
+            className={`whitespace-nowrap rounded-md px-3 py-1.5 font-mono text-xs font-medium transition-all ${
+              category === value
+                ? 'bg-emerald-500/15 text-emerald-400'
+                : 'text-[var(--text-secondary)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            {t.categories[value]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/track-record/page.tsx
+++ b/apps/web/app/track-record/page.tsx
@@ -22,17 +22,17 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description:
-      'Recorded TradeClaw signals with outcomes resolved against Binance/Yahoo OHLCV, plus modeled costs and a hypothetical sequential equity simulation.',
+      'Source-backed TradeClaw signal outcomes resolved against provider OHLCV, with counted and excluded populations shown separately.',
     openGraph: {
       title,
       description:
-        'Observed OHLCV-resolved signal outcomes, modeled fee/slippage assumptions, and a sequential simulation — not broker fills or customer portfolio returns.',
+        'Observed OHLCV-resolved signal outcomes and exclusions. This is not a broker-fill or customer-portfolio ledger.',
       images: [{ url: ogImage, width: 1200, height: 630, alt: 'TradeClaw Track Record' }],
     },
     twitter: {
       card: 'summary_large_image',
       title,
-      description: 'Recorded signals resolved against Binance/Yahoo OHLCV. Modeled costs and simulations are labeled; no broker fills are claimed.',
+      description: 'Source-backed recorded signals resolved against provider OHLCV. No broker fills or portfolio returns are claimed.',
       images: [ogImage],
     },
   };

--- a/apps/web/app/track-record/study/SignalStudyClient.tsx
+++ b/apps/web/app/track-record/study/SignalStudyClient.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { EquityCurve } from '@/app/components/equity-curve';
+import { TrailingWeekBandCallout } from '@/app/components/trailing-week-band-callout';
+import { PageNavBar } from '@/components/PageNavBar';
+import { BackgroundDecor } from '@/components/background/BackgroundDecor';
+import { ProductHeroBackdrop } from '@/components/product-hero-backdrop';
+import { useLocale } from '@/app/components/locale-provider';
+import { symbolsForCategory, type CategoryFilter } from '@/app/lib/symbol-config';
+import { getHtmlLanguage } from '@/lib/translations';
+import { getTrackRecordTranslations } from '@/lib/product-i18n/track-record';
+import { getTrackRecordWidgetTranslations } from '@/lib/product-i18n/track-record-widgets';
+import { formatMessage } from '@/lib/product-i18n/format';
+import {
+  EvidenceFilters,
+  EvidenceSurfaceNav,
+  type EvidencePeriod,
+  type EvidenceScope,
+} from '../evidence-controls';
+
+type EquityBand = 'all' | 'premium' | 'standard';
+
+interface StudySummary {
+  totalReturn: number;
+  maxDrawdown: number;
+  winRate: number;
+  totalSignals: number;
+  sizedTrades: number;
+  expectancyR: number | null;
+  netExpectancyR: number | null;
+  breakEvenWinRate: number | null;
+  avgCostR: number | null;
+}
+
+function parseEquityBand(raw: string | null): EquityBand {
+  if (raw === 'premium' || raw === 'standard') return raw;
+  return 'all';
+}
+
+function signedPercent(language: string, value: number): string {
+  return new Intl.NumberFormat(language, {
+    style: 'percent',
+    signDisplay: 'always',
+    maximumFractionDigits: 2,
+  }).format(value / 100);
+}
+
+function percent(language: string, value: number): string {
+  return new Intl.NumberFormat(language, {
+    style: 'percent',
+    maximumFractionDigits: 1,
+  }).format(value / 100);
+}
+
+function rMultiple(language: string, value: number): string {
+  return `${new Intl.NumberFormat(language, {
+    signDisplay: 'always',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)}R`;
+}
+
+export function SignalStudyClient() {
+  const { locale } = useLocale();
+  const t = getTrackRecordTranslations(locale);
+  const studyT = getTrackRecordWidgetTranslations(locale).equity;
+  const language = getHtmlLanguage(locale);
+  const numberFormatter = new Intl.NumberFormat(language);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [period, setPeriod] = useState<EvidencePeriod>('all');
+  const [scope, setScope] = useState<EvidenceScope>('pro');
+  const [category, setCategory] = useState<CategoryFilter>('all');
+  const [summary, setSummary] = useState<StudySummary | null>(null);
+  const [earliestTimestamp, setEarliestTimestamp] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const requestedBand = parseEquityBand(searchParams.get('band'));
+  const band = scope === 'pro' ? requestedBand : 'all';
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({
+          period,
+          scope,
+          band,
+          summaryOnly: '1',
+        });
+        if (category !== 'all') params.set('category', category);
+        const response = await fetch(`/api/signals/equity?${params.toString()}`);
+        if (!response.ok) {
+          if (!cancelled) {
+            setSummary(null);
+            setEarliestTimestamp(null);
+          }
+          return;
+        }
+        const data = await response.json();
+        if (cancelled) return;
+        setSummary(data.summary ?? null);
+        setEarliestTimestamp(
+          typeof data.earliestTimestamp === 'number' ? data.earliestTimestamp : null,
+        );
+      } catch {
+        if (!cancelled) {
+          setSummary(null);
+          setEarliestTimestamp(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [band, category, period, scope]);
+
+  const categoryCaption = useMemo(() => {
+    if (category === 'majors') {
+      return formatMessage(t.categoryCaption.majors, {
+        count: symbolsForCategory('majors').length,
+      });
+    }
+    if (category === 'thematic') {
+      return formatMessage(t.categoryCaption.thematic, {
+        count: symbolsForCategory('thematic').length,
+      });
+    }
+    if (scope === 'broadcast') return t.categoryCaption.broadcast;
+    return t.categoryCaption.eligible;
+  }, [category, scope, t]);
+
+  const handleBandChange = useCallback((nextBand: EquityBand) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextBand === 'all') params.delete('band');
+    else params.set('band', nextBand);
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
+
+  const expectancy = summary?.netExpectancyR ?? summary?.expectancyR ?? null;
+  const hasSizedStudy = Boolean(summary && summary.sizedTrades > 0);
+  const sizedTradeNote = summary
+    ? formatMessage(
+        summary.sizedTrades !== summary.totalSignals
+          ? summary.sizedTrades === 1 ? studyT.rStatsExcludedOne : studyT.rStatsExcludedMany
+          : summary.sizedTrades === 1 ? studyT.rStatsAllOne : studyT.rStatsAllMany,
+        {
+          sized: numberFormatter.format(summary.sizedTrades),
+          resolved: numberFormatter.format(summary.totalSignals),
+        },
+      )
+    : null;
+
+  return (
+    <div className="premium-product-shell relative isolate min-h-[100dvh] overflow-hidden text-[var(--foreground)]">
+      <BackgroundDecor variant="track-record" />
+      <PageNavBar />
+
+      <main className="mx-auto max-w-5xl px-4 py-8 pb-20 md:pb-8">
+        <EvidenceSurfaceNav active="study" />
+
+        <section className="relative isolate mb-6">
+          <ProductHeroBackdrop
+            src="/brand/hero/tradeclaw-replay-evidence-chamber-v1.webp"
+            testId="signal-study-hero-art"
+            className="product-hero-backdrop--quiet"
+          />
+          <div className="relative z-10">
+            <div className="mb-2 font-mono text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+              {t.surfaces.studyBoundary}
+            </div>
+            <h1 className="text-3xl font-bold tracking-tight text-[var(--foreground)] sm:text-4xl">
+              {studyT.title}
+            </h1>
+            <p className="mt-3 max-w-4xl text-sm leading-relaxed text-[var(--text-secondary)]">
+              {studyT.sequentialHint}
+            </p>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <StudyMetric
+                label={studyT.sequentialResult}
+                value={hasSizedStudy && summary ? signedPercent(language, summary.totalReturn) : '—'}
+                tone={hasSizedStudy && summary && summary.totalReturn > 0 ? 'positive' : hasSizedStudy && summary && summary.totalReturn < 0 ? 'negative' : 'neutral'}
+                loading={loading}
+              />
+              <StudyMetric
+                label={studyT.simulatedMaxDrawdown}
+                value={hasSizedStudy && summary ? `−${percent(language, summary.maxDrawdown)}` : '—'}
+                tone={hasSizedStudy && summary && summary.maxDrawdown > 0 ? 'negative' : 'neutral'}
+                loading={loading}
+              />
+              <StudyMetric
+                label={studyT.expectancyNet}
+                value={expectancy !== null ? rMultiple(language, expectancy) : '—'}
+                tone={expectancy !== null && expectancy > 0 ? 'positive' : expectancy !== null && expectancy < 0 ? 'negative' : 'neutral'}
+                loading={loading}
+              />
+              <StudyMetric
+                label={studyT.resolvedSignals}
+                value={summary ? numberFormatter.format(summary.totalSignals) : '—'}
+                tone="neutral"
+                loading={loading}
+                detail={sizedTradeNote ?? undefined}
+              />
+            </div>
+
+            <p className="mt-4 rounded-md border border-zinc-600/30 bg-zinc-800/20 px-3 py-2 text-[11px] leading-relaxed text-[var(--text-secondary)]">
+              <strong className="font-semibold text-[var(--foreground)]">{t.header.riskLabel}</strong>{' '}
+              {t.header.riskBody}
+            </p>
+          </div>
+        </section>
+
+        <EvidenceFilters
+          period={period}
+          onPeriodChange={setPeriod}
+          earliestTimestamp={earliestTimestamp}
+          scope={scope}
+          onScopeChange={setScope}
+          category={category}
+          onCategoryChange={setCategory}
+          t={t}
+        />
+        <p className="mb-4 text-xs text-[var(--text-secondary)]">{categoryCaption}</p>
+
+        {scope === 'pro' && <TrailingWeekBandCallout category={category} />}
+
+        <EquityCurve
+          period={period}
+          scope={scope}
+          category={category}
+          band={band}
+          onBandChange={scope === 'pro' ? handleBandChange : undefined}
+        />
+
+        <section className="glass-card mb-8 rounded-2xl border-s-2 border-emerald-500/50 p-5">
+          <h2 className="text-sm font-semibold">{t.sections.population}</h2>
+          <p className="mt-1 text-xs leading-relaxed text-[var(--text-secondary)]">
+            {studyT.sequentialHint}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link
+              href="/track-record"
+              className="rounded-lg bg-emerald-500/15 px-4 py-2 text-sm font-medium text-emerald-400 transition-colors hover:bg-emerald-500/25"
+            >
+              {t.surfaces.recordLabel}
+            </Link>
+            <Link
+              href="/research"
+              className="rounded-lg bg-white/[0.06] px-4 py-2 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-white/[0.1]"
+            >
+              {t.research.title}
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function StudyMetric({
+  label,
+  value,
+  tone,
+  loading,
+  detail,
+}: {
+  label: string;
+  value: string;
+  tone: 'positive' | 'negative' | 'neutral';
+  loading: boolean;
+  detail?: string;
+}) {
+  const toneClass = tone === 'positive'
+    ? 'text-emerald-400'
+    : tone === 'negative'
+      ? 'text-red-400'
+      : 'text-[var(--foreground)]';
+
+  return (
+    <div className="glass-card rounded-xl p-4">
+      <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">{label}</div>
+      {loading ? (
+        <div className="mt-2 h-7 w-24 animate-pulse rounded bg-white/[0.06]" />
+      ) : (
+        <div className={`mt-1 text-2xl font-bold tabular-nums ${toneClass}`}>
+          <bdi dir="ltr">{value}</bdi>
+        </div>
+      )}
+      {detail && <p className="mt-1 text-[9px] leading-relaxed text-zinc-600">{detail}</p>}
+    </div>
+  );
+}

--- a/apps/web/app/track-record/study/page.tsx
+++ b/apps/web/app/track-record/study/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import dynamic from 'next/dynamic';
+import { getTrackRecordWidgetTranslations } from '../../../lib/product-i18n/track-record-widgets';
+import { getPreferredLocaleFromCookie } from '../../../lib/product-i18n/server-locale';
+
+const SignalStudyClient = dynamic(
+  () => import('./SignalStudyClient').then((module) => ({ default: module.SignalStudyClient })),
+  {
+    loading: () => (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--background)]">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+      </div>
+    ),
+  },
+);
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getPreferredLocaleFromCookie();
+  const title = `${getTrackRecordWidgetTranslations(locale).equity.title} | TradeClaw`;
+  const description =
+    'A hypothetical, fee/slippage-adjusted sequential equity study built from OHLCV-resolved signals. It is not the observed track record, broker fills, or customer portfolio performance.';
+
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: 'summary', title, description },
+  };
+}
+
+export default function SignalStudyPage() {
+  return <SignalStudyClient />;
+}

--- a/apps/web/lib/__tests__/track-record-study-separation.test.ts
+++ b/apps/web/lib/__tests__/track-record-study-separation.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function source(path: string): string {
+  return readFileSync(resolve(__dirname, '../..', path), 'utf8');
+}
+
+describe('track-record evidence-surface separation', () => {
+  it('keeps modeled equity widgets off the observed record', () => {
+    const record = source('app/track-record/TrackRecordClient.tsx');
+
+    expect(record).toContain('<EvidenceSurfaceNav active="record" />');
+    expect(record).not.toContain('<EquityCurve');
+    expect(record).not.toContain('<TrailingWeekBandCallout');
+    expect(record).not.toContain('headlineCompoundedReturn');
+    expect(record).not.toContain('headlineMaxDrawdown');
+  });
+
+  it('owns simulations on a distinct, directly linked study route', () => {
+    const study = source('app/track-record/study/SignalStudyClient.tsx');
+    const record = source('app/track-record/TrackRecordClient.tsx');
+
+    expect(study).toContain('<EvidenceSurfaceNav active="study" />');
+    expect(study).toContain('<TrailingWeekBandCallout');
+    expect(study).toContain('<EquityCurve');
+    expect(study).toContain('period={period}');
+    expect(study).not.toMatch(/period === ['"]7d['"][\s\S]*period === ['"]30d['"][\s\S]*['"]all['"]/);
+    expect(study).toContain('const hasSizedStudy = Boolean(summary && summary.sizedTrades > 0)');
+    expect(study).toContain("value={hasSizedStudy && summary ? signedPercent(language, summary.totalReturn) : '—'}");
+    expect(record).toContain('/track-record/study');
+  });
+
+  it('keeps each route metadata inside its own evidence boundary', () => {
+    const recordPage = source('app/track-record/page.tsx');
+    const studyPage = source('app/track-record/study/page.tsx');
+
+    expect(recordPage).toMatch(/source-backed|OHLCV-resolved/i);
+    expect(recordPage).not.toMatch(/sequential (equity )?simulation/i);
+    expect(studyPage).toMatch(/hypothetical|modeled/i);
+    expect(studyPage).toMatch(/not (?:the )?observed track record|not broker fills/i);
+  });
+});

--- a/apps/web/lib/product-i18n/track-record-widgets.ts
+++ b/apps/web/lib/product-i18n/track-record-widgets.ts
@@ -134,11 +134,11 @@ const en: TrackRecordWidgetTranslations = {
   share: {
     xDefaultLabel: 'Share on X',
     xAria: 'Share the track record on X',
-    xObserved: 'TradeClaw observed a {winRate} win rate across {resolved} counted signals resolved using OHLCV. This is signal-study data only, not broker fills or portfolio returns:',
+    xObserved: 'TradeClaw observed a {winRate} win rate across {resolved} counted signals resolved using OHLCV. This is an observed outcome record, not broker fills or portfolio returns:',
     xGeneric: 'TradeClaw publishes recorded signal rows, OHLCV-resolved outcomes, and exclusions. This is not an execution ledger:',
     linkedinDefaultLabel: 'Share on LinkedIn',
     linkedinAria: 'Share the track record on LinkedIn',
-    linkedinObserved: 'TradeClaw observed a {winRate} win rate across {resolved} counted signals whose outcomes were resolved against provider OHLCV. This is signal-study data, not broker fills or customer portfolio returns.\n\nInspect the population and methodology:\n{url}',
+    linkedinObserved: 'TradeClaw observed a {winRate} win rate across {resolved} counted signals whose outcomes were resolved against provider OHLCV. This is an observed outcome record, not broker fills or customer portfolio returns.\n\nInspect the population and methodology:\n{url}',
     linkedinGeneric: 'TradeClaw publishes recorded signal rows, OHLCV-resolved outcomes, and the excluded populations. It is not an execution or customer-account ledger:\n{url}',
   },
   trailingWeek: {
@@ -243,10 +243,10 @@ const es: TrackRecordWidgetTranslations = {
   },
   share: {
     xDefaultLabel: 'Compartir en X', xAria: 'Compartir el historial en X',
-    xObserved: 'TradeClaw observó una tasa de aciertos del {winRate} en {resolved} señales contabilizadas y resueltas mediante OHLCV. Son datos de un estudio de señales, no ejecuciones de bróker ni rentabilidades de cartera:',
+    xObserved: 'TradeClaw observó una tasa de aciertos del {winRate} en {resolved} señales contabilizadas y resueltas mediante OHLCV. Es un registro observado de resultados, no ejecuciones de bróker ni rentabilidades de cartera:',
     xGeneric: 'TradeClaw publica las filas de señales registradas, los resultados resueltos mediante OHLCV y las exclusiones. No es un registro de ejecución:',
     linkedinDefaultLabel: 'Compartir en LinkedIn', linkedinAria: 'Compartir el historial en LinkedIn',
-    linkedinObserved: 'TradeClaw observó una tasa de aciertos del {winRate} en {resolved} señales contabilizadas cuyos resultados se resolvieron con OHLCV del proveedor. Son datos de un estudio de señales, no ejecuciones de bróker ni rentabilidades de carteras de clientes.\n\nConsulta la población y la metodología:\n{url}',
+    linkedinObserved: 'TradeClaw observó una tasa de aciertos del {winRate} en {resolved} señales contabilizadas cuyos resultados se resolvieron con OHLCV del proveedor. Es un registro observado de resultados, no ejecuciones de bróker ni rentabilidades de carteras de clientes.\n\nConsulta la población y la metodología:\n{url}',
     linkedinGeneric: 'TradeClaw publica las filas de señales registradas, los resultados resueltos mediante OHLCV y las poblaciones excluidas. No es un registro de ejecución ni de cuentas de clientes:\n{url}',
   },
   trailingWeek: {
@@ -332,10 +332,10 @@ const zh: TrackRecordWidgetTranslations = {
   },
   share: {
     xDefaultLabel: '分享到 X', xAria: '在 X 上分享交易记录',
-    xObserved: 'TradeClaw 在 {resolved} 条使用 OHLCV 解析的计数信号中观察到 {winRate} 胜率。这仅是信号研究数据，不是经纪商成交或投资组合收益：',
+    xObserved: 'TradeClaw 在 {resolved} 条使用 OHLCV 解析的计数信号中观察到 {winRate} 胜率。这是实测结果记录，不是经纪商成交或投资组合收益：',
     xGeneric: 'TradeClaw 公开已记录的信号行、使用 OHLCV 解析的结果和排除项。这不是执行账本：',
     linkedinDefaultLabel: '分享到 LinkedIn', linkedinAria: '在 LinkedIn 上分享交易记录',
-    linkedinObserved: 'TradeClaw 在 {resolved} 条计数信号中观察到 {winRate} 胜率，其结果由供应商 OHLCV 解析。这是信号研究数据，不是经纪商成交或客户投资组合收益。\n\n查看样本和方法：\n{url}',
+    linkedinObserved: 'TradeClaw 在 {resolved} 条计数信号中观察到 {winRate} 胜率，其结果由供应商 OHLCV 解析。这是实测结果记录，不是经纪商成交或客户投资组合收益。\n\n查看样本和方法：\n{url}',
     linkedinGeneric: 'TradeClaw 公开已记录的信号行、使用 OHLCV 解析的结果以及被排除的样本。这不是执行或客户账户账本：\n{url}',
   },
   trailingWeek: {
@@ -408,10 +408,10 @@ const ms: TrackRecordWidgetTranslations = {
   },
   share: {
     xDefaultLabel: 'Kongsi di X', xAria: 'Kongsi rekod prestasi di X',
-    xObserved: 'TradeClaw memerhatikan kadar menang {winRate} merentas {resolved} isyarat dikira yang diselesaikan menggunakan OHLCV. Ini hanyalah data kajian isyarat, bukan pengisian broker atau pulangan portfolio:',
+    xObserved: 'TradeClaw memerhatikan kadar menang {winRate} merentas {resolved} isyarat dikira yang diselesaikan menggunakan OHLCV. Ini rekod hasil diperhati, bukan pengisian broker atau pulangan portfolio:',
     xGeneric: 'TradeClaw menerbitkan baris isyarat yang direkodkan, hasil yang diselesaikan menggunakan OHLCV dan pengecualian. Ini bukan lejar pelaksanaan:',
     linkedinDefaultLabel: 'Kongsi di LinkedIn', linkedinAria: 'Kongsi rekod prestasi di LinkedIn',
-    linkedinObserved: 'TradeClaw memerhatikan kadar menang {winRate} merentas {resolved} isyarat dikira yang hasilnya diselesaikan berdasarkan OHLCV penyedia. Ini ialah data kajian isyarat, bukan pengisian broker atau pulangan portfolio pelanggan.\n\nPeriksa populasi dan metodologi:\n{url}',
+    linkedinObserved: 'TradeClaw memerhatikan kadar menang {winRate} merentas {resolved} isyarat dikira yang hasilnya diselesaikan berdasarkan OHLCV penyedia. Ini rekod hasil diperhati, bukan pengisian broker atau pulangan portfolio pelanggan.\n\nPeriksa populasi dan metodologi:\n{url}',
     linkedinGeneric: 'TradeClaw menerbitkan baris isyarat yang direkodkan, hasil yang diselesaikan menggunakan OHLCV dan populasi yang dikecualikan. Ini bukan lejar pelaksanaan atau akaun pelanggan:\n{url}',
   },
   trailingWeek: {
@@ -484,10 +484,10 @@ const ar: TrackRecordWidgetTranslations = {
   },
   share: {
     xDefaultLabel: 'مشاركة على X', xAria: 'مشاركة سجل الأداء على X',
-    xObserved: 'رصدت TradeClaw نسبة فوز {winRate} عبر {resolved} إشارة محتسبة حُسمت باستخدام OHLCV. هذه بيانات دراسة إشارات فقط، وليست تنفيذات وسيط أو عوائد محفظة:',
+    xObserved: 'رصدت TradeClaw نسبة فوز {winRate} عبر {resolved} إشارة محتسبة حُسمت باستخدام OHLCV. هذا سجل نتائج مرصود، وليس تنفيذات وسيط أو عوائد محفظة:',
     xGeneric: 'تنشر TradeClaw صفوف الإشارات المسجلة والنتائج المحسومة باستخدام OHLCV والاستبعادات. هذا ليس سجل تنفيذ:',
     linkedinDefaultLabel: 'مشاركة على LinkedIn', linkedinAria: 'مشاركة سجل الأداء على LinkedIn',
-    linkedinObserved: 'رصدت TradeClaw نسبة فوز {winRate} عبر {resolved} إشارة محتسبة، حيث حُسمت نتائجها بيانات OHLCV من المزوّد. هذه بيانات دراسة إشارات، وليست تنفيذات وسيط أو عوائد محافظ العملاء.\n\nافحص المجموعة والمنهجية:\n{url}',
+    linkedinObserved: 'رصدت TradeClaw نسبة فوز {winRate} عبر {resolved} إشارة محتسبة، حيث حُسمت نتائجها بيانات OHLCV من المزوّد. هذا سجل نتائج مرصود، وليس تنفيذات وسيط أو عوائد محافظ العملاء.\n\nافحص المجموعة والمنهجية:\n{url}',
     linkedinGeneric: 'تنشر TradeClaw صفوف الإشارات المسجلة والنتائج المحسومة باستخدام OHLCV والمجموعات المستبعدة. هذا ليس سجل تنفيذ أو حسابات عملاء:\n{url}',
   },
   trailingWeek: {

--- a/apps/web/lib/product-i18n/track-record.ts
+++ b/apps/web/lib/product-i18n/track-record.ts
@@ -2,6 +2,14 @@ import type { Locale } from '../translations';
 
 export interface TrackRecordTranslations {
   documentTitle: string;
+  surfaces: {
+    ariaLabel: string;
+    recordLabel: string;
+    recordDescription: string;
+    studyLabel: string;
+    studyDescription: string;
+    studyBoundary: string;
+  };
   periods: { all: string };
   categories: { all: string; majors: string; thematic: string };
   relativeTime: { minutesAgo: string; hoursAgo: string; daysAgo: string };
@@ -143,7 +151,15 @@ export interface TrackRecordTranslations {
 }
 
 const en: TrackRecordTranslations = {
-  documentTitle: 'OHLCV-Resolved Signal Record — TradeClaw',
+  documentTitle: 'Observed Signal Track Record — TradeClaw',
+  surfaces: {
+    ariaLabel: 'Choose an evidence surface',
+    recordLabel: 'Observed track record',
+    recordDescription: 'Source-backed OHLCV outcomes',
+    studyLabel: 'Modeled signal study',
+    studyDescription: 'Sizing, costs, and sequential equity',
+    studyBoundary: 'Modeled output — not the observed track record or broker performance',
+  },
   periods: { all: 'All' },
   categories: { all: 'All', majors: 'Majors', thematic: 'Thematic' },
   relativeTime: { minutesAgo: '{count}m ago', hoursAgo: '{count}h ago', daysAgo: '{count}d ago' },
@@ -157,7 +173,7 @@ const en: TrackRecordTranslations = {
     simulationHelp: 'What the sequential simulation means', maxDrawdown: 'max drawdown −{value}%',
     maxDrawdownHelp: 'What max drawdown means', latestOutcome: 'Latest counted outcome', embed: 'Embed this',
     shareX: 'Share on X', shareLinkedIn: 'Share on LinkedIn',
-    headlineDisclosure: 'The headline is an arithmetic sum of per-signal OHLCV price outcomes before sizing or costs; it is not a portfolio return. The equity card is a separate sequential simulation that risks 1% of modeled current equity on every eligible sized signal and deducts per-asset fee/slippage assumptions. It does not model broker fills, overlapping exposure, margin, leverage, latency, funding, or subscriber selection. Pending, zero-value expiry placeholders, and gate-blocked rows are surfaced separately instead of being folded into win-rate statistics.',
+    headlineDisclosure: 'This page is the observed signal-outcome record. It reports source-backed OHLCV outcomes, counts, win rate, and unsized price moves; none are broker fills or portfolio returns. Position sizing, modeled costs, drawdown, and sequential equity are kept on the separate Modeled Signal Study page. Pending, zero-value expiry placeholders, and gate-blocked rows are surfaced separately instead of being folded into win-rate statistics.',
     riskLabel: 'Risk notice:',
     riskBody: 'TradeClaw provides educational signal analytics and historical research. Signals are not financial advice, investment recommendations, or guaranteed outcomes. Trading involves substantial risk, including loss of capital. Past performance does not predict future results. Always test with paper trading and independent risk controls before using real funds.',
   },
@@ -188,9 +204,9 @@ const en: TrackRecordTranslations = {
     averagePnl: 'Arithmetic sum of OHLCV-resolved per-signal price moves divided by counted resolved signals. No position sizing or execution costs are applied.',
     winRate24h: 'Counted signals whose usable 24h OHLCV outcome hit TP, divided by all counted signals with a usable 24h outcome. Pending, simulated, gate-blocked, and zero or missing force-expiry placeholders are excluded.',
     winRate4h: 'Resolved signals whose 4h OHLCV outcome hit TP, divided by total resolved signals. This shorter horizon is an early read on signal quality.',
-    resolved: 'Signals with a usable provider-OHLCV 24h outcome: TP, SL, or a nonzero 24h close. Still-open, simulated, gate-blocked, and zero or missing force-expiry placeholders are excluded. This is a signal study, not a subscriber execution ledger.',
+    resolved: 'Signals with a usable provider-OHLCV 24h outcome: TP, SL, or a nonzero 24h close. Still-open, simulated, gate-blocked, and zero or missing force-expiry placeholders are excluded. This is an observed signal-outcome record, not a subscriber execution ledger.',
     unusableOutcome: 'The resolver could not produce a usable 24h market outcome and wrote a zero force-expiry placeholder, or the row remains missing after the horizon. It is excluded from win rate.',
-    gateBlocked: 'The engine emitted the signal, but the full-risk gate refused entry. It is not counted toward the equity simulation.',
+    gateBlocked: 'The engine emitted the signal, but the full-risk gate refused entry. It is excluded from counted outcomes on this page.',
     pending: 'The signal is still inside the 24h tracking window, so its outcome is not yet known.',
     maxDrawdown: 'Worst peak-to-trough drop in the hypothetical sequential equity simulation for this window. It is model drawdown, not drawdown observed in a broker or subscriber account.',
     streak: 'Consecutive resolved signals, signed positive for a win streak and negative for a losing streak.',
@@ -207,12 +223,20 @@ const en: TrackRecordTranslations = {
     barOpenHelp: 'Candle bar open time (your local timezone). The signal anchors to this bar; the engine records it shortly after the bar closes (within the next 5-minute cron tick), so wall-clock recording can be up to one timeframe later than the value shown.',
     firstPage: 'First page', previousPage: 'Previous page', nextPage: 'Next page', lastPage: 'Last page',
   },
-  populationBody: 'Stored signals carry their generation timestamp. New counted outcomes require an approved observed-OHLCV source and are not broker fills. Legacy outcome values without approved source provenance remain visible as unverified audit rows and do not count. Counted outcomes include source-backed TP, SL, and nonzero 24-hour closes; they exclude simulated, gate-blocked, pending, and zero/missing force-expiry placeholders. The unsized price-move sum uses counted rows, while the sequential simulation further requires a recorded stop-loss. The broadcast view includes only gate approvals recorded since 2026-06-10. These populations are signal studies, not customer trades or actual portfolio returns.',
+  populationBody: 'Stored signals carry their generation timestamp. New counted outcomes require an approved observed-OHLCV source and are not broker fills. Legacy outcome values without approved source provenance remain visible as unverified audit rows and do not count. Counted outcomes include source-backed TP, SL, and nonzero 24-hour closes; they exclude simulated, gate-blocked, pending, and zero/missing force-expiry placeholders. The unsized price-move sum uses counted rows. The separate modeled study further requires a recorded stop-loss. The broadcast view includes only gate approvals recorded since 2026-06-10. These populations are signal observations, not customer trades or actual portfolio returns.',
   aria: { filterPair: 'Filter by pair', viewSignal: 'View signal {pair} {direction} {time}', whatMeans: 'What {label} means' },
 };
 
 const es: TrackRecordTranslations = {
-  documentTitle: 'Registro de señales resuelto con OHLCV — TradeClaw',
+  documentTitle: 'Registro observado de señales — TradeClaw',
+  surfaces: {
+    ariaLabel: 'Elegir una superficie de evidencia',
+    recordLabel: 'Registro observado',
+    recordDescription: 'Resultados OHLCV respaldados por fuente',
+    studyLabel: 'Estudio modelado de señales',
+    studyDescription: 'Tamaño, costes y capital secuencial',
+    studyBoundary: 'Resultado modelado: no es el registro observado ni rendimiento del bróker',
+  },
   periods: { all: 'Todo' }, categories: { all: 'Todo', majors: 'Principales', thematic: 'Temáticos' },
   relativeTime: { minutesAgo: 'hace {count} min', hoursAgo: 'hace {count} h', daysAgo: 'hace {count} d' },
   window: { storedSince: 'almacenado desde {date}', currentArchive: 'archivo actual' },
@@ -225,7 +249,7 @@ const es: TrackRecordTranslations = {
     simulationHelp: 'Qué significa la simulación secuencial', maxDrawdown: 'caída máxima −{value}%',
     maxDrawdownHelp: 'Qué significa la caída máxima', latestOutcome: 'Último resultado contado', embed: 'Insertar',
     shareX: 'Compartir en X', shareLinkedIn: 'Compartir en LinkedIn',
-    headlineDisclosure: 'El titular es una suma aritmética de resultados de precio OHLCV por señal antes del tamaño y los costes; no es un retorno de cartera. La tarjeta de capital es una simulación secuencial separada que arriesga el 1% del capital modelado actual en cada señal elegible dimensionada y descuenta supuestos de comisiones y deslizamiento por activo. No modela ejecuciones del bróker, exposición solapada, margen, apalancamiento, latencia, financiación ni selección del suscriptor. Las filas pendientes, los marcadores de vencimiento con valor cero y las bloqueadas por el filtro se muestran por separado y no se incluyen en la tasa de acierto.',
+    headlineDisclosure: 'Esta página es el registro observado de resultados de señales. Informa resultados OHLCV respaldados por fuente, recuentos, tasa de acierto y movimientos de precio sin dimensionar; ninguno representa ejecuciones del bróker ni retornos de cartera. El tamaño de posición, los costes modelados, la caída y el capital secuencial están en la página separada de Estudio Modelado. Las filas pendientes, los marcadores de vencimiento con valor cero y las bloqueadas por el filtro se muestran por separado y no se incluyen en la tasa de acierto.',
     riskLabel: 'Aviso de riesgo:', riskBody: 'TradeClaw ofrece análisis educativos de señales e investigación histórica. Las señales no son asesoramiento financiero, recomendaciones de inversión ni resultados garantizados. Operar implica un riesgo considerable, incluida la pérdida de capital. El rendimiento pasado no predice resultados futuros. Prueba siempre con trading simulado y controles de riesgo independientes antes de usar fondos reales.',
   },
   rolling: { title: 'Tasa de acierto móvil · {window}', onlyDays: '(solo {count} d de datos)', resolved: '{count} resueltas', total: '{count} totales', historyAvailable: 'Solo hay {count} días de historial' },
@@ -255,9 +279,9 @@ const es: TrackRecordTranslations = {
     averagePnl: 'Suma aritmética de los movimientos de precio por señal resueltos con OHLCV, dividida por las señales resueltas contadas. No se aplican tamaño de posición ni costes de ejecución.',
     winRate24h: 'Señales contadas cuyo resultado OHLCV utilizable a 24 h alcanzó TP, divididas por todas las señales con resultado utilizable. Se excluyen pendientes, simuladas, bloqueadas y marcadores de vencimiento forzado ausentes o cero.',
     winRate4h: 'Señales resueltas cuyo resultado OHLCV a 4 h alcanzó TP, divididas por todas las señales resueltas. Este horizonte corto ofrece una lectura temprana de calidad.',
-    resolved: 'Señales con resultado utilizable a 24 h procedente de OHLCV: TP, SL o cierre no nulo. Se excluyen las abiertas, simuladas, bloqueadas y los marcadores de vencimiento ausentes o cero. Es un estudio de señales, no un registro de ejecuciones.',
+    resolved: 'Señales con resultado utilizable a 24 h procedente de OHLCV: TP, SL o cierre no nulo. Se excluyen las abiertas, simuladas, bloqueadas y los marcadores de vencimiento ausentes o cero. Es un registro observado de resultados, no un registro de ejecuciones.',
     unusableOutcome: 'El resolutor no pudo obtener un resultado de mercado utilizable a 24 h y escribió un marcador de vencimiento cero, o la fila sigue sin resultado tras el horizonte. Se excluye de la tasa de acierto.',
-    gateBlocked: 'El motor emitió la señal, pero el filtro integral de riesgo rechazó la entrada. No se cuenta en la simulación de capital.',
+    gateBlocked: 'El motor emitió la señal, pero el filtro integral de riesgo rechazó la entrada. Se excluye de los resultados contados en esta página.',
     pending: 'La señal sigue dentro de la ventana de seguimiento de 24 h; el resultado aún no se conoce.',
     maxDrawdown: 'Peor caída de máximo a mínimo en la simulación secuencial hipotética de esta ventana. Es una caída del modelo, no la observada en una cuenta real.',
     streak: 'Secuencia de señales resueltas: positiva para una racha ganadora y negativa para una perdedora.',
@@ -274,12 +298,20 @@ const es: TrackRecordTranslations = {
     barOpenHelp: 'Hora de apertura de la vela en tu zona horaria. La señal se ancla a esta vela y el motor la registra poco después del cierre, dentro del siguiente ciclo cron de 5 minutos; por eso el registro puede ser hasta un marco temporal posterior al valor mostrado.',
     firstPage: 'Primera página', previousPage: 'Página anterior', nextPage: 'Página siguiente', lastPage: 'Última página',
   },
-  populationBody: 'Las señales almacenadas conservan su hora de generación. Los nuevos resultados contados requieren una fuente OHLCV observada y aprobada; no son ejecuciones del bróker. Los valores históricos sin procedencia aprobada siguen visibles como filas de auditoría sin verificar y no cuentan. Los resultados contados incluyen TP, SL y cierres no nulos a 24 horas respaldados por fuente; excluyen datos simulados, filas bloqueadas, pendientes y marcadores de vencimiento forzado ausentes o cero. La suma sin dimensionar usa las filas contadas y la simulación secuencial exige además un stop-loss registrado. La vista de difusión incluye solo aprobaciones registradas desde 2026-06-10. Son estudios de señales, no operaciones de clientes ni retornos reales de cartera.',
+  populationBody: 'Las señales almacenadas conservan su hora de generación. Los nuevos resultados contados requieren una fuente OHLCV observada y aprobada; no son ejecuciones del bróker. Los valores históricos sin procedencia aprobada siguen visibles como filas de auditoría sin verificar y no cuentan. Los resultados contados incluyen TP, SL y cierres no nulos a 24 horas respaldados por fuente; excluyen datos simulados, filas bloqueadas, pendientes y marcadores de vencimiento forzado ausentes o cero. La suma sin dimensionar usa las filas contadas. El estudio modelado separado exige además un stop-loss registrado. La vista de difusión incluye solo aprobaciones registradas desde 2026-06-10. Son observaciones de señales, no operaciones de clientes ni retornos reales de cartera.',
   aria: { filterPair: 'Filtrar por par', viewSignal: 'Ver señal {pair} {direction} {time}', whatMeans: 'Qué significa {label}' },
 };
 
 const zh: TrackRecordTranslations = {
-  documentTitle: 'OHLCV 已解析信号记录 — TradeClaw',
+  documentTitle: '实测信号记录 — TradeClaw',
+  surfaces: {
+    ariaLabel: '选择证据页面',
+    recordLabel: '实测跟踪记录',
+    recordDescription: '有来源支持的 OHLCV 结果',
+    studyLabel: '模型化信号研究',
+    studyDescription: '仓位、成本与顺序权益',
+    studyBoundary: '模型输出——不是实测记录或券商表现',
+  },
   periods: { all: '全部' }, categories: { all: '全部', majors: '主流', thematic: '主题' },
   relativeTime: { minutesAgo: '{count} 分钟前', hoursAgo: '{count} 小时前', daysAgo: '{count} 天前' },
   window: { storedSince: '当前存档始于 {date}', currentArchive: '当前存档' },
@@ -290,7 +322,7 @@ const zh: TrackRecordTranslations = {
     resolvedSignals: '已解析信号', resolvedHelp: '已解析信号的含义', sequentialSimulation: '顺序模拟 · 1% 风险',
     simulationHelp: '顺序模拟的含义', maxDrawdown: '最大回撤 −{value}%', maxDrawdownHelp: '最大回撤的含义',
     latestOutcome: '最新计入结果', embed: '嵌入此内容', shareX: '分享到 X', shareLinkedIn: '分享到 LinkedIn',
-    headlineDisclosure: '标题数字是每条信号在仓位和成本之前的 OHLCV 价格结果算术和，并非投资组合回报。资金曲线卡片是另一项顺序模拟：每条符合条件且可定仓位的信号使用当前模拟权益的 1% 风险，并扣除各资产的费用和滑点假设。它不模拟券商成交、重叠敞口、保证金、杠杆、延迟、资金费率或订阅者选择。待定行、零值强制到期占位行和被风险门槛拦截的行会单独显示，不计入胜率统计。',
+    headlineDisclosure: '本页是实测信号结果记录，报告有来源支持的 OHLCV 结果、数量、胜率和未定仓位价格变动；这些都不是券商成交或投资组合回报。仓位规模、模型成本、回撤和顺序权益放在独立的模型化信号研究页面。待定行、零值强制到期占位行和被风险门槛拦截的行会单独显示，不计入胜率统计。',
     riskLabel: '风险提示：', riskBody: 'TradeClaw 提供教育用途的信号分析和历史研究。信号不构成财务建议、投资推荐或结果保证。交易存在重大风险，包括本金损失。过去表现不能预测未来结果。使用真实资金前，请务必先进行模拟交易并采用独立风险控制。',
   },
   rolling: { title: '滚动胜率 · {window}', onlyDays: '（仅 {count} 天数据）', resolved: '已解析 {count}', total: '共 {count}', historyAvailable: '仅有 {count} 天历史数据' },
@@ -318,9 +350,9 @@ const zh: TrackRecordTranslations = {
     averagePnl: 'OHLCV 解析的每条信号价格变动总和，除以计入的已解析信号数。不包含仓位大小或执行成本。',
     winRate24h: '24 小时 OHLCV 可用结果命中 TP 的计入信号，除以所有有可用结果的计入信号。排除待定、模拟、被门槛拦截以及零值或缺失的强制到期占位行。',
     winRate4h: '4 小时 OHLCV 结果命中 TP 的已解析信号，除以全部已解析信号。较短周期用于早期观察信号质量。',
-    resolved: '具有供应商 OHLCV 24 小时可用结果的信号：TP、SL 或非零收盘。排除未平仓、模拟、门槛拦截和零值或缺失的强制到期占位行。这是信号研究，不是订阅者成交账本。',
+    resolved: '具有供应商 OHLCV 24 小时可用结果的信号：TP、SL 或非零收盘。排除未平仓、模拟、门槛拦截和零值或缺失的强制到期占位行。这是实测信号结果记录，不是订阅者成交账本。',
     unusableOutcome: '解析器无法生成可用的 24 小时市场结果，并写入零值强制到期占位，或该行在周期后仍缺失。它不计入胜率。',
-    gateBlocked: '引擎已发出信号，但完整风险门槛拒绝入场。它不计入权益模拟。',
+    gateBlocked: '引擎已发出信号，但完整风险门槛拒绝入场。它不计入本页的结果统计。',
     pending: '信号仍处于 24 小时跟踪窗口内，结果尚未确定。',
     maxDrawdown: '该窗口的假设顺序权益模拟中，从峰值到谷值的最大下降。这是模型回撤，不是券商或订阅者账户的实际回撤。',
     streak: '连续已解析信号；连胜为正，连败为负。',
@@ -336,12 +368,20 @@ const zh: TrackRecordTranslations = {
     barOpenHelp: 'K 线开盘时间（按你的本地时区）。信号锚定此 K 线；引擎会在收盘后不久、下一次 5 分钟定时任务中记录，因此实际记录时间最多可能比显示值晚一个周期。',
     firstPage: '第一页', previousPage: '上一页', nextPage: '下一页', lastPage: '最后一页',
   },
-  populationBody: '已存储信号保留其生成时间。新的计入结果必须来自获准的实测 OHLCV 来源，并非券商成交。缺少获准来源证明的旧结果仍以未验证审计行显示，但不计入统计。计入结果包括有来源支持的止盈、止损和非零 24 小时收盘；排除模拟数据、门槛拦截、待定以及零值或缺失的强制到期占位。未定仓位价格变动总和使用计入行；顺序模拟还要求记录止损。推送视图仅包含自 2026-06-10 起记录的门槛批准。这些是信号研究，不是客户交易或实际投资组合回报。',
+  populationBody: '已存储信号保留其生成时间。新的计入结果必须来自获准的实测 OHLCV 来源，并非券商成交。缺少获准来源证明的旧结果仍以未验证审计行显示，但不计入统计。计入结果包括有来源支持的止盈、止损和非零 24 小时收盘；排除模拟数据、门槛拦截、待定以及零值或缺失的强制到期占位。未定仓位价格变动总和使用计入行。独立的模型化研究还要求记录止损。推送视图仅包含自 2026-06-10 起记录的门槛批准。这些是信号观测，不是客户交易或实际投资组合回报。',
   aria: { filterPair: '按交易对筛选', viewSignal: '查看信号 {pair} {direction} {time}', whatMeans: '{label} 的含义' },
 };
 
 const ms: TrackRecordTranslations = {
-  documentTitle: 'Rekod Isyarat Diselesaikan OHLCV — TradeClaw',
+  documentTitle: 'Rekod Isyarat Diperhati — TradeClaw',
+  surfaces: {
+    ariaLabel: 'Pilih permukaan bukti',
+    recordLabel: 'Rekod diperhati',
+    recordDescription: 'Hasil OHLCV yang disokong sumber',
+    studyLabel: 'Kajian isyarat bermodel',
+    studyDescription: 'Saiz, kos dan ekuiti berurutan',
+    studyBoundary: 'Output bermodel — bukan rekod diperhati atau prestasi broker',
+  },
   periods: { all: 'Semua' }, categories: { all: 'Semua', majors: 'Utama', thematic: 'Tematik' },
   relativeTime: { minutesAgo: '{count} min lalu', hoursAgo: '{count} jam lalu', daysAgo: '{count} hari lalu' },
   window: { storedSince: 'disimpan sejak {date}', currentArchive: 'arkib semasa' },
@@ -353,7 +393,7 @@ const ms: TrackRecordTranslations = {
     resolvedHelp: 'Maksud isyarat diselesaikan', sequentialSimulation: 'simulasi berurutan · risiko 1%',
     simulationHelp: 'Maksud simulasi berurutan', maxDrawdown: 'susutan maksimum −{value}%', maxDrawdownHelp: 'Maksud susutan maksimum',
     latestOutcome: 'Hasil terkini yang dikira', embed: 'Benamkan', shareX: 'Kongsi di X', shareLinkedIn: 'Kongsi di LinkedIn',
-    headlineDisclosure: 'Angka utama ialah jumlah aritmetik hasil harga OHLCV setiap isyarat sebelum saiz dan kos; ia bukan pulangan portfolio. Kad ekuiti ialah simulasi berurutan berasingan yang merisikokan 1% ekuiti model semasa pada setiap isyarat bersaiz yang layak serta menolak andaian yuran dan gelinciran setiap aset. Ia tidak memodelkan pengisian broker, pendedahan bertindih, margin, leveraj, kependaman, pendanaan atau pilihan pelanggan. Baris menunggu, pemegang tempat tamat paksa bernilai sifar dan baris disekat gerbang dipaparkan berasingan dan tidak dimasukkan ke statistik kadar menang.',
+    headlineDisclosure: 'Halaman ini ialah rekod hasil isyarat yang diperhati. Ia melaporkan hasil OHLCV yang disokong sumber, bilangan, kadar menang dan pergerakan harga tanpa saiz; semuanya bukan pengisian broker atau pulangan portfolio. Saiz posisi, kos bermodel, susutan dan ekuiti berurutan ditempatkan pada halaman Kajian Isyarat Bermodel yang berasingan. Baris menunggu, pemegang tempat tamat paksa bernilai sifar dan baris disekat gerbang dipaparkan berasingan dan tidak dimasukkan ke statistik kadar menang.',
     riskLabel: 'Notis risiko:', riskBody: 'TradeClaw menyediakan analitik isyarat pendidikan dan penyelidikan sejarah. Isyarat bukan nasihat kewangan, cadangan pelaburan atau hasil yang dijamin. Dagangan melibatkan risiko besar termasuk kehilangan modal. Prestasi lalu tidak meramalkan hasil masa depan. Sentiasa uji dengan dagangan kertas dan kawalan risiko bebas sebelum menggunakan wang sebenar.',
   },
   rolling: { title: 'Kadar menang bergerak · {window}', onlyDays: '(hanya {count} hari data)', resolved: '{count} diselesaikan', total: '{count} jumlah', historyAvailable: 'Hanya {count} hari sejarah tersedia' },
@@ -382,9 +422,9 @@ const ms: TrackRecordTranslations = {
     averagePnl: 'Jumlah aritmetik pergerakan harga setiap isyarat yang diselesaikan dengan OHLCV, dibahagi dengan isyarat diselesaikan yang dikira. Saiz kedudukan dan kos pelaksanaan tidak digunakan.',
     winRate24h: 'Isyarat dikira yang hasil OHLCV 24 jamnya mencapai TP, dibahagi dengan semua isyarat dikira yang mempunyai hasil boleh guna. Baris menunggu, simulasi, disekat gerbang dan pemegang tempat tamat paksa sifar atau hilang dikecualikan.',
     winRate4h: 'Isyarat diselesaikan yang hasil OHLCV 4 jamnya mencapai TP, dibahagi dengan semua isyarat diselesaikan. Tempoh lebih pendek ini memberi bacaan awal kualiti isyarat.',
-    resolved: 'Isyarat dengan hasil 24 jam OHLCV pembekal yang boleh digunakan: TP, SL atau penutupan bukan sifar. Baris masih terbuka, simulasi, disekat gerbang dan pemegang tempat tamat paksa sifar atau hilang dikecualikan. Ini kajian isyarat, bukan lejar pelaksanaan pelanggan.',
+    resolved: 'Isyarat dengan hasil 24 jam OHLCV pembekal yang boleh digunakan: TP, SL atau penutupan bukan sifar. Baris masih terbuka, simulasi, disekat gerbang dan pemegang tempat tamat paksa sifar atau hilang dikecualikan. Ini rekod hasil isyarat diperhati, bukan lejar pelaksanaan pelanggan.',
     unusableOutcome: 'Penyelesai tidak dapat menghasilkan hasil pasaran 24 jam yang boleh digunakan lalu menulis pemegang tempat tamat paksa sifar, atau baris masih tiada selepas tempoh. Ia dikecualikan daripada kadar menang.',
-    gateBlocked: 'Enjin mengeluarkan isyarat tetapi gerbang risiko penuh menolak kemasukan. Ia tidak dikira dalam simulasi ekuiti.',
+    gateBlocked: 'Enjin mengeluarkan isyarat tetapi gerbang risiko penuh menolak kemasukan. Ia dikecualikan daripada hasil dikira pada halaman ini.',
     pending: 'Isyarat masih berada dalam tetingkap penjejakan 24 jam, jadi hasilnya belum diketahui.',
     maxDrawdown: 'Kejatuhan puncak ke dasar terburuk dalam simulasi ekuiti berurutan andaian bagi tetingkap ini. Ia susutan model, bukan susutan yang diperhati dalam akaun broker atau pelanggan.',
     streak: 'Isyarat diselesaikan berturut-turut; positif untuk rentetan menang dan negatif untuk rentetan kalah.',
@@ -400,12 +440,20 @@ const ms: TrackRecordTranslations = {
     barOpenHelp: 'Masa bukaan bar lilin dalam zon waktu tempatan anda. Isyarat berpaut pada bar ini dan enjin merekodkannya sejurus selepas bar ditutup, dalam kitaran cron 5 minit seterusnya; oleh itu masa rekod boleh lewat sehingga satu tempoh rangka masa daripada nilai yang dipaparkan.',
     firstPage: 'Halaman pertama', previousPage: 'Halaman sebelumnya', nextPage: 'Halaman seterusnya', lastPage: 'Halaman terakhir',
   },
-  populationBody: 'Isyarat tersimpan mengekalkan masa penjanaannya. Hasil baharu yang dikira memerlukan sumber OHLCV diperhati dan diluluskan; ia bukan pengisian broker. Nilai hasil lama tanpa asal usul yang diluluskan kekal kelihatan sebagai baris audit belum disahkan dan tidak dikira. Hasil dikira merangkumi TP, SL dan penutupan 24 jam bukan sifar yang disokong sumber; data simulasi, baris disekat, menunggu serta pemegang tempat tamat paksa sifar atau hilang dikecualikan. Jumlah pergerakan tanpa saiz menggunakan baris dikira, manakala simulasi berurutan turut memerlukan henti rugi direkodkan. Paparan siaran hanya merangkumi kelulusan gerbang yang direkodkan sejak 2026-06-10. Populasi ini ialah kajian isyarat, bukan dagangan pelanggan atau pulangan portfolio sebenar.',
+  populationBody: 'Isyarat tersimpan mengekalkan masa penjanaannya. Hasil baharu yang dikira memerlukan sumber OHLCV diperhati dan diluluskan; ia bukan pengisian broker. Nilai hasil lama tanpa asal usul yang diluluskan kekal kelihatan sebagai baris audit belum disahkan dan tidak dikira. Hasil dikira merangkumi TP, SL dan penutupan 24 jam bukan sifar yang disokong sumber; data simulasi, baris disekat, menunggu serta pemegang tempat tamat paksa sifar atau hilang dikecualikan. Jumlah pergerakan tanpa saiz menggunakan baris dikira. Kajian bermodel yang berasingan turut memerlukan henti rugi direkodkan. Paparan siaran hanya merangkumi kelulusan gerbang yang direkodkan sejak 2026-06-10. Populasi ini ialah pemerhatian isyarat, bukan dagangan pelanggan atau pulangan portfolio sebenar.',
   aria: { filterPair: 'Tapis mengikut pasangan', viewSignal: 'Lihat isyarat {pair} {direction} {time}', whatMeans: 'Maksud {label}' },
 };
 
 const ar: TrackRecordTranslations = {
-  documentTitle: 'سجل الإشارات المحسومة ببيانات OHLCV — TradeClaw',
+  documentTitle: 'سجل الإشارات المرصودة — TradeClaw',
+  surfaces: {
+    ariaLabel: 'اختر سطح الأدلة',
+    recordLabel: 'السجل المرصود',
+    recordDescription: 'نتائج OHLCV مدعومة بالمصدر',
+    studyLabel: 'دراسة إشارات نموذجية',
+    studyDescription: 'التحجيم والتكاليف ومسار رأس المال',
+    studyBoundary: 'مخرجات نموذجية — ليست السجل المرصود أو أداء وسيط',
+  },
   periods: { all: 'الكل' }, categories: { all: 'الكل', majors: 'الرئيسية', thematic: 'الموضوعية' },
   relativeTime: { minutesAgo: 'قبل {count} د', hoursAgo: 'قبل {count} س', daysAgo: 'قبل {count} يوم' },
   window: { storedSince: 'محفوظ حاليًا منذ {date}', currentArchive: 'الأرشيف الحالي' },
@@ -417,7 +465,7 @@ const ar: TrackRecordTranslations = {
     resolvedHelp: 'معنى الإشارات المحسومة', sequentialSimulation: 'محاكاة متسلسلة · مخاطرة 1٪',
     simulationHelp: 'معنى المحاكاة المتسلسلة', maxDrawdown: 'أقصى تراجع −{value}٪', maxDrawdownHelp: 'معنى أقصى تراجع',
     latestOutcome: 'أحدث نتيجة محتسبة', embed: 'تضمين', shareX: 'مشاركة على X', shareLinkedIn: 'مشاركة على LinkedIn',
-    headlineDisclosure: 'الرقم الرئيسي هو مجموع حسابي لنتائج حركة السعر المستخرجة من OHLCV لكل إشارة قبل التحجيم والتكاليف، وليس عائد محفظة. بطاقة رأس المال محاكاة متسلسلة منفصلة تخاطر بنسبة 1٪ من رأس المال النموذجي الحالي في كل إشارة مؤهلة قابلة للتحجيم، وتخصم افتراضات الرسوم والانزلاق لكل أصل. لا تحاكي تنفيذات الوسيط أو التعرضات المتداخلة أو الهامش أو الرافعة أو التأخير أو التمويل أو اختيار المشترك. تُعرض الصفوف المعلقة وعناصر انتهاء الصلاحية ذات القيمة الصفرية والصفوف المحجوبة بالبوابة منفصلة ولا تُضم إلى إحصاءات الفوز.',
+    headlineDisclosure: 'هذه الصفحة هي سجل نتائج الإشارات المرصودة. تعرض نتائج OHLCV المدعومة بالمصدر والأعداد ونسبة الفوز وتحركات السعر بلا تحجيم؛ ولا يمثل أي منها تنفيذات وسيط أو عوائد محفظة. يوجد تحجيم المراكز والتكاليف النموذجية والتراجع ومسار رأس المال المتسلسل في صفحة دراسة الإشارات النموذجية المنفصلة. تُعرض الصفوف المعلقة وعناصر انتهاء الصلاحية ذات القيمة الصفرية والصفوف المحجوبة بالبوابة منفصلة ولا تُضم إلى إحصاءات الفوز.',
     riskLabel: 'تنبيه مخاطر:', riskBody: 'تقدم TradeClaw تحليلات إشارات تعليمية وأبحاثًا تاريخية. الإشارات ليست نصيحة مالية أو توصية استثمارية أو ضمانًا للنتائج. ينطوي التداول على مخاطر كبيرة، بما فيها خسارة رأس المال. الأداء السابق لا يتنبأ بالنتائج المستقبلية. اختبر دائمًا بالتداول التجريبي وضوابط مخاطر مستقلة قبل استخدام أموال حقيقية.',
   },
   rolling: { title: 'نسبة الفوز المتحركة · {window}', onlyDays: '(بيانات {count} يوم فقط)', resolved: '{count} محسومة', total: '{count} إجمالي', historyAvailable: 'يتوفر سجل {count} يوم فقط' },
@@ -446,9 +494,9 @@ const ar: TrackRecordTranslations = {
     averagePnl: 'مجموع تحركات السعر المحسومة بـ OHLCV لكل إشارة، مقسومًا على عدد الإشارات المحسومة المحتسبة. لا يطبق تحجيم المراكز أو تكاليف التنفيذ.',
     winRate24h: 'الإشارات المحتسبة التي بلغت TP في نتيجة OHLCV الصالحة خلال 24 ساعة، مقسومة على كل الإشارات ذات النتيجة الصالحة. تستبعد الصفوف المعلقة والمحاكاة والمحجوبة وعناصر الانتهاء القسري الصفرية أو المفقودة.',
     winRate4h: 'الإشارات المحسومة التي بلغت TP في نتيجة OHLCV لأربع ساعات، مقسومة على إجمالي الإشارات المحسومة. يوفر هذا الأفق الأقصر قراءة مبكرة لجودة الإشارة.',
-    resolved: 'إشارات لها نتيجة OHLCV صالحة لمدة 24 ساعة: TP أو SL أو إغلاق غير صفري. تستبعد المفتوحة والمحاكاة والمحجوبة وعناصر الانتهاء القسري الصفرية أو المفقودة. هذه دراسة إشارات وليست سجل تنفيذ للمشتركين.',
+    resolved: 'إشارات لها نتيجة OHLCV صالحة لمدة 24 ساعة: TP أو SL أو إغلاق غير صفري. تستبعد المفتوحة والمحاكاة والمحجوبة وعناصر الانتهاء القسري الصفرية أو المفقودة. هذا سجل نتائج إشارات مرصود وليس سجل تنفيذ للمشتركين.',
     unusableOutcome: 'لم يتمكن المحلل من إنتاج نتيجة سوق صالحة خلال 24 ساعة فكتب عنصر انتهاء قسري صفري، أو بقي الصف مفقودًا بعد الأفق. يستبعد من نسبة الفوز.',
-    gateBlocked: 'أصدر المحرك الإشارة، لكن بوابة المخاطر الكاملة رفضت الدخول. لا تحتسب في محاكاة رأس المال.',
+    gateBlocked: 'أصدر المحرك الإشارة، لكن بوابة المخاطر الكاملة رفضت الدخول. تُستبعد من النتائج المحتسبة في هذه الصفحة.',
     pending: 'ما زالت الإشارة ضمن نافذة التتبع لمدة 24 ساعة، لذلك لم تُعرف نتيجتها بعد.',
     maxDrawdown: 'أسوأ انخفاض من القمة إلى القاع في محاكاة رأس المال الافتراضية المتسلسلة لهذه النافذة. هو تراجع نموذجي، لا تراجع مرصود في حساب وسيط أو مشترك.',
     streak: 'إشارات محسومة متتالية؛ موجبة لسلسلة فوز وسالبة لسلسلة خسارة.',
@@ -464,7 +512,7 @@ const ar: TrackRecordTranslations = {
     barOpenHelp: 'وقت افتتاح شمعة السعر حسب منطقتك الزمنية المحلية. ترتبط الإشارة بهذه الشمعة ويسجلها المحرك بعد إغلاقها بقليل ضمن دورة المهمة المجدولة التالية ذات الخمس دقائق؛ لذلك قد يتأخر وقت التسجيل الفعلي حتى مدة إطار زمني واحدة عن القيمة المعروضة.',
     firstPage: 'الصفحة الأولى', previousPage: 'الصفحة السابقة', nextPage: 'الصفحة التالية', lastPage: 'الصفحة الأخيرة',
   },
-  populationBody: 'تحمل الإشارات المخزنة وقت توليدها. تتطلب النتائج الجديدة المحتسبة مصدر OHLCV مرصودًا ومعتمدًا، وليست تنفيذات وسيط. تبقى النتائج القديمة التي تفتقر إلى مصدر معتمد ظاهرة كصفوف تدقيق غير متحقق منها ولا تُحتسب. تشمل النتائج المحتسبة أهداف الربح ووقف الخسارة وإغلاقات 24 ساعة غير الصفرية المدعومة بمصدر، وتستبعد البيانات المحاكاة والصفوف المحجوبة والمعلقة وعناصر الانتهاء القسري الصفرية أو المفقودة. يستخدم مجموع الحركة بلا تحجيم الصفوف المحتسبة، وتتطلب المحاكاة المتسلسلة أيضًا وقف خسارة مسجلًا. يشمل عرض البث موافقات البوابة المسجلة منذ 2026-06-10 فقط. هذه دراسات إشارات وليست تداولات عملاء أو عوائد محافظ فعلية.',
+  populationBody: 'تحمل الإشارات المخزنة وقت توليدها. تتطلب النتائج الجديدة المحتسبة مصدر OHLCV مرصودًا ومعتمدًا، وليست تنفيذات وسيط. تبقى النتائج القديمة التي تفتقر إلى مصدر معتمد ظاهرة كصفوف تدقيق غير متحقق منها ولا تُحتسب. تشمل النتائج المحتسبة أهداف الربح ووقف الخسارة وإغلاقات 24 ساعة غير الصفرية المدعومة بمصدر، وتستبعد البيانات المحاكاة والصفوف المحجوبة والمعلقة وعناصر الانتهاء القسري الصفرية أو المفقودة. يستخدم مجموع الحركة بلا تحجيم الصفوف المحتسبة. تتطلب الدراسة النموذجية المنفصلة أيضًا وقف خسارة مسجلًا. يشمل عرض البث موافقات البوابة المسجلة منذ 2026-06-10 فقط. هذه ملاحظات إشارات وليست تداولات عملاء أو عوائد محافظ فعلية.',
   aria: { filterPair: 'تصفية حسب الزوج', viewSignal: 'عرض إشارة {pair} {direction} {time}', whatMeans: 'معنى {label}' },
 };
 

--- a/apps/web/lib/rolling-win-rates.ts
+++ b/apps/web/lib/rolling-win-rates.ts
@@ -1,0 +1,40 @@
+import { isCountedResolved, type SignalHistoryRecord } from './signal-history';
+
+export interface RollingWinRateSummary {
+  totalSignals: number;
+  resolvedSignals: number;
+  winRate: number;
+}
+
+export interface RollingWinRates {
+  '7d': RollingWinRateSummary;
+  '30d': RollingWinRateSummary;
+  '90d': RollingWinRateSummary;
+}
+
+function computeWinRateSummary(records: SignalHistoryRecord[]): RollingWinRateSummary {
+  const resolvedSignals = records.filter(isCountedResolved);
+  const wins = resolvedSignals.filter((record) => record.outcomes['24h']!.hit).length;
+
+  return {
+    totalSignals: records.length,
+    resolvedSignals: resolvedSignals.length,
+    winRate: resolvedSignals.length > 0
+      ? +((wins / resolvedSignals.length) * 100).toFixed(1)
+      : 0,
+  };
+}
+
+export function computeRollingWinRates(
+  records: SignalHistoryRecord[],
+  now: number = Date.now(),
+): RollingWinRates {
+  const windows = [7, 30, 90] as const;
+
+  return windows.reduce((acc, days) => {
+    const cutoff = now - days * 86_400_000;
+    const key = `${days}d` as const;
+    acc[key] = computeWinRateSummary(records.filter((record) => record.timestamp >= cutoff));
+    return acc;
+  }, {} as RollingWinRates);
+}

--- a/apps/web/tests/e2e/features/generated-product-hero-art.spec.ts
+++ b/apps/web/tests/e2e/features/generated-product-hero-art.spec.ts
@@ -9,6 +9,7 @@ const HERO_PAGES = [
   { path: '/backtest', testId: 'backtest-hero-art' },
   { path: '/leaderboard', testId: 'leaderboard-hero-art' },
   { path: '/track-record', testId: 'track-record-hero-art' },
+  { path: '/track-record/study', testId: 'signal-study-hero-art' },
 ] as const;
 
 const FOCUSABLE_SELECTOR = [

--- a/apps/web/tests/e2e/features/product-localization.spec.ts
+++ b/apps/web/tests/e2e/features/product-localization.spec.ts
@@ -13,6 +13,7 @@ const localeCases: Array<{
   screenerTitle: string;
   dashboardTitle: RegExp;
   trackRecordEyebrow: string;
+  trackRecordTitle: string;
 }> = [
   {
     locale: 'en',
@@ -21,6 +22,7 @@ const localeCases: Array<{
     screenerTitle: 'Asset Screener',
     dashboardTitle: /TradeClaw — Live Signals/,
     trackRecordEyebrow: 'OHLCV-Resolved Signal Record',
+    trackRecordTitle: 'Observed Signal Track Record',
   },
   {
     locale: 'es',
@@ -29,6 +31,7 @@ const localeCases: Array<{
     screenerTitle: 'Analizador de activos',
     dashboardTitle: /TradeClaw — Señales en vivo/,
     trackRecordEyebrow: 'Registro de señales resuelto con OHLCV',
+    trackRecordTitle: 'Registro observado de señales',
   },
   {
     locale: 'zh',
@@ -37,6 +40,7 @@ const localeCases: Array<{
     screenerTitle: '资产筛选器',
     dashboardTitle: /TradeClaw — 实时信号/,
     trackRecordEyebrow: 'OHLCV 已解析信号记录',
+    trackRecordTitle: '实测信号记录',
   },
   {
     locale: 'ms',
@@ -45,6 +49,7 @@ const localeCases: Array<{
     screenerTitle: 'Penyaring Aset',
     dashboardTitle: /TradeClaw — Isyarat Langsung/,
     trackRecordEyebrow: 'Rekod Isyarat Diselesaikan OHLCV',
+    trackRecordTitle: 'Rekod Isyarat Diperhati',
   },
   {
     locale: 'ar',
@@ -53,6 +58,7 @@ const localeCases: Array<{
     screenerTitle: 'ماسح الأصول',
     dashboardTitle: /TradeClaw — إشارات مباشرة/,
     trackRecordEyebrow: 'سجل الإشارات المحسومة ببيانات OHLCV',
+    trackRecordTitle: 'سجل الإشارات المرصودة',
   },
 ];
 
@@ -135,7 +141,7 @@ test.describe('product localization', () => {
 
       await page.goto('/track-record', { waitUntil: 'domcontentloaded' });
       await expect(page.getByText(localeCase.trackRecordEyebrow, { exact: true })).toBeVisible({ timeout: LOCALE_EXPECT_TIMEOUT });
-      await expect(page).toHaveTitle(new RegExp(localeCase.trackRecordEyebrow), { timeout: LOCALE_EXPECT_TIMEOUT });
+      await expect(page).toHaveTitle(new RegExp(localeCase.trackRecordTitle), { timeout: LOCALE_EXPECT_TIMEOUT });
     }
   });
 

--- a/apps/web/tests/e2e/track-record/track-record.spec.ts
+++ b/apps/web/tests/e2e/track-record/track-record.spec.ts
@@ -92,7 +92,11 @@ test.describe('Track Record page', () => {
     await dismissStarMilestoneModal(page);
 
     await expect(
-      page.getByRole('heading', { name: /Signal Study.*Sequential Simulation/i })
+      page.getByRole('heading', {
+        name: 'Signal Study — Sequential Simulation',
+        exact: true,
+        level: 1,
+      })
     ).toBeVisible({ timeout: 15_000 });
 
     const canvas = page.locator('canvas').first();

--- a/apps/web/tests/e2e/track-record/track-record.spec.ts
+++ b/apps/web/tests/e2e/track-record/track-record.spec.ts
@@ -69,16 +69,30 @@ test.describe('Track Record page', () => {
     }
   });
 
-  // Test 3: The sequential simulation reports either a real curve or the
-  // explicit no-evidence state. A zero-return canvas is intentionally omitted.
-  test('sequential simulation renders an evidence-backed state', async ({ page }) => {
+  // Test 3: The observed record must not mix modeled equity into its evidence.
+  test('observed record links to but does not render the modeled study', async ({ page }) => {
     await dismissStarMilestoneModal(page);
     await page.goto('/track-record');
     await dismissStarMilestoneModal(page);
 
-    // Section heading from EquityCurve component h2.
+    const studyLink = page.getByRole('link', { name: /Modeled signal study/i }).first();
+    await expect(studyLink).toBeVisible({ timeout: 15_000 });
+    await expect(studyLink).toHaveAttribute('href', '/track-record/study');
     await expect(
       page.getByText(/Signal Study.*Sequential Simulation/i)
+    ).toHaveCount(0);
+    await expect(page.locator('canvas')).toHaveCount(0);
+  });
+
+  // Test 4: The separate study reports either a real curve or the explicit
+  // no-evidence state. A zero-return placeholder is intentionally omitted.
+  test('modeled study renders an evidence-backed state', async ({ page }) => {
+    await dismissStarMilestoneModal(page);
+    await page.goto('/track-record/study');
+    await dismissStarMilestoneModal(page);
+
+    await expect(
+      page.getByRole('heading', { name: /Signal Study.*Sequential Simulation/i })
     ).toBeVisible({ timeout: 15_000 });
 
     const canvas = page.locator('canvas').first();
@@ -86,7 +100,7 @@ test.describe('Track Record page', () => {
     await expect(canvas.or(noEvidence)).toBeVisible({ timeout: 20_000 });
   });
 
-  // Test 4: Category breakdown buttons (All / Majors / Thematic) are present.
+  // Test 5: Category breakdown buttons (All / Majors / Thematic) are present.
   // No "strategy breakdown" section exists on this page. The closest equivalent
   // is CategoryBreakdownRow, which renders 3 clickable cells for category segmentation.
   test('category breakdown controls are present', async ({ page }) => {
@@ -102,7 +116,7 @@ test.describe('Track Record page', () => {
     await expect(page.getByRole('button', { name: /^Thematic$/i }).first()).toBeVisible();
   });
 
-  // Test 5: /api/leaderboard returns 200 with usable shape.
+  // Test 6: /api/leaderboard returns 200 with usable shape.
   // This is the actual endpoint consumed by TrackRecordClient (not /api/strategy-breakdown,
   // which does not appear in this page's fetch calls).
   test('GET /api/leaderboard returns 200 with usable shape', async ({ request }: { request: APIRequestContext }) => {
@@ -120,7 +134,7 @@ test.describe('Track Record page', () => {
     expect(Array.isArray(typed['assets'])).toBe(true);
   });
 
-  // Test 6: No error boundary fallback is shown at page load.
+  // Test 7: No error boundary fallback is shown at page load.
   // Made permissive — only checks top-level catastrophic failures, not async data errors.
   test('page does not show error boundary fallback', async ({ page }) => {
     await dismissStarMilestoneModal(page);


### PR DESCRIPTION
## What changed

- split the public evidence surface into an observed `/track-record` and a modeled `/track-record/study`
- make counted resolved signals the observed-record headline instead of the raw unsized price-move sum
- keep sizing, fee/slippage assumptions, drawdown, expectancy, premium-band comparison, and sequential equity on the modeled study only
- preserve direct two-way navigation and explicit non-broker/non-portfolio claim boundaries
- move rolling observed rates onto the history response so the record no longer fetches the equity model
- preserve all supported periods exactly, including 90d, 180d, 1y, and 5y
- update five locales, metadata, sitemap, README, embed/share copy, and regression contracts

## Why

The previous page placed an unsized arithmetic OHLCV price-move sum beside a hypothetical fixed-fractional equity simulation. Those metrics answer different questions and could be read as contradictory portfolio performance. The split makes the evidence class explicit without hiding the adverse modeled result.

## User impact

Visitors can inspect the observed signal-outcome archive independently from the cost-adjusted study. The modeled study remains one click away, retains negative results, and renders em dashes rather than a false zero-return placeholder when no trade is sized.

## Validation

- focused Jest: 55/55
- full Jest: 233 suites passed, 3 skipped; 1,843 tests passed, 26 skipped
- web typecheck: pass
- lint: 0 errors; 23 pre-existing warnings
- production build: 325/325 pages
- STATE.yaml parse and diff check: pass
- CLI-first browser verification: both routes 200; 0 console errors/warnings
- observed route: no modeled heading, canvas, or equity API request after navigation
- CI follow-up: separated localized eyebrow/title expectations and made the modeled-study heading selector exact after the first E2E run exposed test drift
- affected local Chromium rerun: setup + 14/14 browser checks passed; GitHub CI remains authoritative for mobile/WebKit
