### PR TITLE
chore: close track record study release state

### DIFF
--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-08-09T13:45:58+08:00
+updated: 2026-08-09T14:04:09+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -4413,5 +4413,17 @@ next_actions:
       installer did not complete within a bounded wait; the protected GitHub
       runner remains the authoritative pending desktop/mobile check. One unrelated
       dashboard hero-art duplicate was reported flaky and passed on retry; no
-      out-of-scope product change was made for it. Merge and deploy remain blocked
-      until the replacement PR head passes every required gate.
+      out-of-scope product change was made for it. Replacement head
+      2e2998a4a9253627f494dc1f8442b31cb7b29a4b then passed all six CI jobs in
+      run 31297469324: Lint & Type Check, Build, Unit Tests, Strategy Backtests,
+      Docker Build, and Playwright E2E. The protected E2E runner reported 245
+      passed and 11 skipped across desktop/mobile; the unrelated dashboard
+      hero-art check was again classified flaky after succeeding on retry, and
+      the job finished SUCCESS. PR #207 was marked ready only after the exact
+      head was green, then squash-merged at 2026-08-09T06:03:23Z as
+      0c069e5153f97ba8dcd212a3bc12acb2a2cf39de. A fresh fetch confirmed
+      origin/main equals that returned merge SHA. This closure is isolated in
+      state-only branch agent/track-record-study-state from the exact merged
+      commit. Railway production deployment remains pending until this truthful
+      state update clears the protected path and establishes the exact final-main
+      commit to deploy.


### PR DESCRIPTION
## What changed

- record PR #207's exact green replacement head, CI run, and squash merge SHA in `STATE.yaml`
- record the recovered dashboard hero-art flake without misclassifying it as a product regression
- preserve Railway deployment as pending until this state-only protected PR establishes the exact final `main`

## Why

TradeClaw's project policy requires release state to remain truthful at each step. PR #207 merged the implementation; this one-file closure records that merge before production deployment so Railway can receive one exact final-main commit.

## Validation

- standalone clean worktree from exact merged main `0c069e5153f97ba8dcd212a3bc12acb2a2cf39de`
- `STATE.yaml` parse: pass
- diff check: pass
- production build: 325/325 pages
- only `STATE.yaml` changed
