### PR TITLE
Publish anti-survivorship strategy study catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Read this in other languages: [日本語](README.ja.md) · [한국어](README.ko
 
 ---
 
-TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (RSI, MACD, EMA, Bollinger Bands, Stochastic, ADX, Volume). Eligible signals and their OHLCV-derived outcomes are recorded in PostgreSQL. The [track record](https://tradeclaw.win/track-record) exposes only observed outcome counts, rates, unsized price moves, exclusions, and row-level evidence. The separate [modeled signal study](https://tradeclaw.win/track-record/study) applies fixed-fractional sizing and fee/slippage assumptions. Neither surface is a broker-fill or customer-portfolio ledger.
+TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (RSI, MACD, EMA, Bollinger Bands, Stochastic, ADX, Volume). Eligible signals and their OHLCV-derived outcomes are recorded in PostgreSQL. The [track record](https://tradeclaw.win/track-record) exposes only observed outcome counts, rates, unsized price moves, exclusions, and row-level evidence. The separate [strategy study catalog](https://tradeclaw.win/track-record/study) shows seven artifact-backed modeled studies, keeps every committed experiment on an accessible shelf, and retains the aggregate fixed-fractional signal simulation. Its default is selected by evidence tier rather than return. Neither surface is a broker-fill or customer-portfolio ledger.
 
 > Status: pre-1.0 (`0.1.0`). The signal engine, dashboard, backtester, and self-host path are usable today; APIs and schema may still change between releases.
 

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -4427,3 +4427,72 @@ next_actions:
       commit. Railway production deployment remains pending until this truthful
       state update clears the protected path and establishes the exact final-main
       commit to deploy.
+
+  - id: TC-253
+    title: "Publish an anti-survivorship strategy-study catalog"
+    status: in-progress
+    owner: pm-tradeclaw
+    notes: >
+      Started 2026-08-09 after the owner asked for a profitable default and at
+      least seven displayed strategy records while explicitly identifying the
+      risk of survivorship bias. Work is isolated in clean stacked branch
+      agent/strategy-study-catalog from exact current main
+      528aa99df1771186ed6444a485d9acf90610fdd8; the broad dirty primary checkout
+      remains excluded. Existing experiment results had
+      already been observed before this task, so this catalog will be labeled
+      retrospective and will not claim that its display order was preregistered.
+      The frozen publication contract is: preserve every committed experiment in
+      an accessible shelf; never rank, hide, or promote by positive return; use
+      the canonical production-cost artifact when duplicate cost models exist;
+      exclude superseded zero-cost runs, structural diagnostics, invalid
+      production comparisons, and duplicate predecessor studies from the seven
+      featured cards only, with a visible reason and artifact link for each;
+      choose the default by evidence tier, then validation timestamp and stable
+      id, never by P&L; and label a green result as a modeled paper-pass rather
+      than a live or broker return. The seven fixed featured strategy records are
+      D1 slow gate, Classic H1, Regime-aware H1, VWAP+EMA+BB H1, daily momentum,
+      carry, and cross-sectional momentum. The observed /track-record remains the
+      canonical all-signal record. New strategy discovery or parameter sweeps are
+      out of scope until separately preregistered; this change catalogs existing
+      evidence and establishes prospective promotion rules without altering
+      signals, allocation, execution, database/schema, auth, billing, cron,
+      dependencies, Docker, or production activation.
+      Implemented locally on the isolated branch. /track-record/study now opens
+      on the D1 slow-gate paper-pass because it is the only pre-registered
+      frozen-gate PASS, labels +636.83% as modeled historical return rather than
+      live performance, and states that prospective tracking began without
+      backfill. Seven selectable cards remain simultaneously visible: rejected
+      and thin results retain their adverse metrics, while positive-but-failed
+      Carry and positive-but-thin Regime-aware figures use a neutral tone rather
+      than pass green. Selecting a card writes its stable id to the URL. The
+      collapsible shelf contains all 11 committed JSON artifacts in reverse
+      chronology with a disposition, exclusion reason, and direct source link;
+      a contract test fails if any committed JSON is omitted. The prior losing
+      aggregate eligible-signal simulation remains on the same page under an
+      explicit adverse-result heading. No new outcome-seeking parameter sweep
+      or backtest was run. Verification passed 12 focused catalog/separation
+      tests; full Jest with four workers (235 suites, 1,852 tests passed; 3
+      suites and 26 tests skipped); web typecheck; full lint with zero errors and
+      23 pre-existing warnings; strategy backtests (14 suites, 103 tests, one
+      snapshot); the required production build (325/325 pages); and diff check.
+      CLI-first Playwright QA on the final build passed at 1440x1000 and 390x844:
+      seven cards and 11 shelf entries rendered, D1 was the default, Carry stayed
+      neutral, the adverse aggregate section remained present, mobile had no
+      horizontal overflow, and the browser reported zero errors or warnings.
+      After PR #207 advanced, the branch was safely restacked from 9d8e6074 to
+      exact predecessor head 2e2998a4. When #207 squash-merged, its head and
+      merge trees were verified identical and this branch was aligned to exact
+      merged main 0c069e51; its release-test fixes had no runtime overlap. The
+      affected production-build Chromium E2E file was updated for
+      the catalog h1 plus retained aggregate h2 and passed 8/8. The local mobile
+      Playwright project could not launch its six browser cases because WebKit
+      2272 is not installed; setup/API checks passed, page assertions did not
+      run, and protected CI remains authoritative for that WebKit matrix. The
+      independent 390x844 Chromium browser check remains green.
+      Screenshots are retained under ignored output/playwright. On 2026-08-10 the
+      owner explicitly authorized commit, push, merge, and production deployment.
+      The branch was advanced from merged implementation base 0c069e51 to exact
+      current main 528aa99d while preserving TC-252's state-only closure. Release
+      is in progress; no live claim is valid until protected CI passes, the exact
+      merged main is deployed, Railway reaches SUCCESS, and production browser,
+      health, route, artifact, and bounded-log checks pass.

--- a/apps/web/app/track-record/study/SignalStudyClient.tsx
+++ b/apps/web/app/track-record/study/SignalStudyClient.tsx
@@ -15,6 +15,17 @@ import { getTrackRecordTranslations } from '@/lib/product-i18n/track-record';
 import { getTrackRecordWidgetTranslations } from '@/lib/product-i18n/track-record-widgets';
 import { formatMessage } from '@/lib/product-i18n/format';
 import {
+  DEFAULT_STRATEGY_STUDY_ID,
+  EXPERIMENT_SHELF,
+  FEATURED_STRATEGY_STUDIES,
+  STRATEGY_STUDY_SELECTION_POLICY,
+  getStrategyStudy,
+  strategyArtifactUrl,
+  type StrategyStudyMetric,
+  type StrategyStudyRecord,
+  type StrategyStudyStatus,
+} from '@/lib/strategy-study-catalog';
+import {
   EvidenceFilters,
   EvidenceSurfaceNav,
   type EvidencePeriod,
@@ -63,6 +74,81 @@ function rMultiple(language: string, value: number): string {
   }).format(value)}R`;
 }
 
+function formatStudyMetric(language: string, metric: StrategyStudyMetric): string {
+  if (metric.format === 'text') return String(metric.value);
+
+  const value = Number(metric.value);
+  const digits = metric.digits ?? 2;
+  let formatted: string;
+
+  switch (metric.format) {
+    case 'signed-ratio-percent':
+      formatted = new Intl.NumberFormat(language, {
+        style: 'percent',
+        signDisplay: 'always',
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(value);
+      break;
+    case 'ratio-percent':
+      formatted = new Intl.NumberFormat(language, {
+        style: 'percent',
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(value);
+      break;
+    case 'signed-percent-points':
+      formatted = new Intl.NumberFormat(language, {
+        style: 'percent',
+        signDisplay: 'always',
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(value / 100);
+      break;
+    case 'percent-points':
+      formatted = new Intl.NumberFormat(language, {
+        style: 'percent',
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(value / 100);
+      break;
+    case 'integer':
+      formatted = new Intl.NumberFormat(language, { maximumFractionDigits: 0 }).format(value);
+      break;
+    case 'decimal':
+    default:
+      formatted = new Intl.NumberFormat(language, {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(value);
+      break;
+  }
+
+  return `${formatted}${metric.suffix ?? ''}`;
+}
+
+function metricToneClass(tone: StrategyStudyMetric['tone']): string {
+  if (tone === 'positive') return 'text-emerald-400';
+  if (tone === 'negative') return 'text-red-400';
+  return 'text-[var(--foreground)]';
+}
+
+function statusClasses(status: StrategyStudyStatus, selected = false): string {
+  if (status === 'paper-pass') {
+    return selected
+      ? 'border-emerald-400/55 bg-emerald-500/[0.12] text-emerald-300'
+      : 'border-emerald-500/25 bg-emerald-500/[0.06] text-emerald-400';
+  }
+  if (status === 'inconclusive') {
+    return selected
+      ? 'border-amber-400/45 bg-amber-500/[0.1] text-amber-300'
+      : 'border-amber-500/20 bg-amber-500/[0.05] text-amber-400';
+  }
+  return selected
+    ? 'border-red-400/45 bg-red-500/[0.09] text-red-300'
+    : 'border-white/[0.08] bg-white/[0.025] text-[var(--text-secondary)]';
+}
+
 export function SignalStudyClient() {
   const { locale } = useLocale();
   const t = getTrackRecordTranslations(locale);
@@ -80,6 +166,7 @@ export function SignalStudyClient() {
   const [loading, setLoading] = useState(true);
   const requestedBand = parseEquityBand(searchParams.get('band'));
   const band = scope === 'pro' ? requestedBand : 'all';
+  const selectedStudy = getStrategyStudy(searchParams.get('strategy'));
 
   useEffect(() => {
     let cancelled = false;
@@ -139,13 +226,26 @@ export function SignalStudyClient() {
     return t.categoryCaption.eligible;
   }, [category, scope, t]);
 
-  const handleBandChange = useCallback((nextBand: EquityBand) => {
+  const replaceQuery = useCallback((mutate: (params: URLSearchParams) => void) => {
     const params = new URLSearchParams(searchParams.toString());
-    if (nextBand === 'all') params.delete('band');
-    else params.set('band', nextBand);
+    mutate(params);
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
   }, [pathname, router, searchParams]);
+
+  const handleBandChange = useCallback((nextBand: EquityBand) => {
+    replaceQuery((params) => {
+      if (nextBand === 'all') params.delete('band');
+      else params.set('band', nextBand);
+    });
+  }, [replaceQuery]);
+
+  const handleStudyChange = useCallback((study: StrategyStudyRecord) => {
+    replaceQuery((params) => {
+      if (study.id === DEFAULT_STRATEGY_STUDY_ID) params.delete('strategy');
+      else params.set('strategy', study.id);
+    });
+  }, [replaceQuery]);
 
   const expectancy = summary?.netExpectancyR ?? summary?.expectancyR ?? null;
   const hasSizedStudy = Boolean(summary && summary.sizedTrades > 0);
@@ -169,7 +269,7 @@ export function SignalStudyClient() {
       <main className="mx-auto max-w-5xl px-4 py-8 pb-20 md:pb-8">
         <EvidenceSurfaceNav active="study" />
 
-        <section className="relative isolate mb-6">
+        <section className="relative isolate mb-7">
           <ProductHeroBackdrop
             src="/brand/hero/tradeclaw-replay-evidence-chamber-v1.webp"
             testId="signal-study-hero-art"
@@ -177,76 +277,118 @@ export function SignalStudyClient() {
           />
           <div className="relative z-10">
             <div className="mb-2 font-mono text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-              {t.surfaces.studyBoundary}
+              Modeled strategy studies / retrospective catalog
             </div>
             <h1 className="text-3xl font-bold tracking-tight text-[var(--foreground)] sm:text-4xl">
-              {studyT.title}
+              Strategy Study Catalog
             </h1>
             <p className="mt-3 max-w-4xl text-sm leading-relaxed text-[var(--text-secondary)]">
-              {studyT.sequentialHint}
+              Seven fixed, artifact-backed strategy records are shown together. The default is the
+              highest-evidence paper-pass, not the highest return found after testing. Failed, thin,
+              superseded, and diagnostic runs remain in the experiment shelf below.
             </p>
 
-            <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              <StudyMetric
-                label={studyT.sequentialResult}
-                value={hasSizedStudy && summary ? signedPercent(language, summary.totalReturn) : '—'}
-                tone={hasSizedStudy && summary && summary.totalReturn > 0 ? 'positive' : hasSizedStudy && summary && summary.totalReturn < 0 ? 'negative' : 'neutral'}
-                loading={loading}
-              />
-              <StudyMetric
-                label={studyT.simulatedMaxDrawdown}
-                value={hasSizedStudy && summary ? `−${percent(language, summary.maxDrawdown)}` : '—'}
-                tone={hasSizedStudy && summary && summary.maxDrawdown > 0 ? 'negative' : 'neutral'}
-                loading={loading}
-              />
-              <StudyMetric
-                label={studyT.expectancyNet}
-                value={expectancy !== null ? rMultiple(language, expectancy) : '—'}
-                tone={expectancy !== null && expectancy > 0 ? 'positive' : expectancy !== null && expectancy < 0 ? 'negative' : 'neutral'}
-                loading={loading}
-              />
-              <StudyMetric
-                label={studyT.resolvedSignals}
-                value={summary ? numberFormatter.format(summary.totalSignals) : '—'}
-                tone="neutral"
-                loading={loading}
-                detail={sizedTradeNote ?? undefined}
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <CatalogCount label="Featured records" value={FEATURED_STRATEGY_STUDIES.length} />
+              <CatalogCount label="Committed JSON artifacts" value={EXPERIMENT_SHELF.length} />
+              <CatalogCount
+                label="Frozen-gate paper-passes"
+                value={FEATURED_STRATEGY_STUDIES.filter((study) => study.status === 'paper-pass').length}
+                tone="positive"
               />
             </div>
 
-            <p className="mt-4 rounded-md border border-zinc-600/30 bg-zinc-800/20 px-3 py-2 text-[11px] leading-relaxed text-[var(--text-secondary)]">
-              <strong className="font-semibold text-[var(--foreground)]">{t.header.riskLabel}</strong>{' '}
-              {t.header.riskBody}
+            <p className="mt-4 rounded-md border border-amber-500/25 bg-amber-500/[0.06] px-3 py-2 text-[11px] leading-relaxed text-amber-100/80">
+              <strong className="font-semibold text-amber-200">Selection rule:</strong>{' '}
+              {STRATEGY_STUDY_SELECTION_POLICY} This catalog was assembled after the historical
+              outcomes were known, so it is explicitly retrospective.
             </p>
           </div>
         </section>
 
-        <EvidenceFilters
-          period={period}
-          onPeriodChange={setPeriod}
-          earliestTimestamp={earliestTimestamp}
-          scope={scope}
-          onScopeChange={setScope}
-          category={category}
-          onCategoryChange={setCategory}
-          t={t}
+        <StrategyCatalog
+          language={language}
+          selectedStudy={selectedStudy}
+          onSelect={handleStudyChange}
         />
-        <p className="mb-4 text-xs text-[var(--text-secondary)]">{categoryCaption}</p>
 
-        {scope === 'pro' && <TrailingWeekBandCallout category={category} />}
+        <ExperimentShelf />
 
-        <EquityCurve
-          period={period}
-          scope={scope}
-          category={category}
-          band={band}
-          onBandChange={scope === 'pro' ? handleBandChange : undefined}
-        />
+        <section
+          id="aggregate-signal-stream"
+          className="mt-10 border-t border-white/[0.08] pt-10"
+          aria-labelledby="aggregate-study-title"
+        >
+          <div className="mb-5">
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-red-300/75">
+              Adverse result retained
+            </p>
+            <h2 id="aggregate-study-title" className="mt-2 text-xl font-semibold tracking-tight">
+              {studyT.title}
+            </h2>
+            <p className="mt-2 max-w-4xl text-xs leading-relaxed text-[var(--text-secondary)]">
+              This is the existing aggregate eligible-signal simulation, not the selected strategy
+              above. It stays on the page so changing the default cannot erase the losing record.
+              {` ${studyT.sequentialHint}`}
+            </p>
+          </div>
+
+          <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <StudyMetric
+              label={studyT.sequentialResult}
+              value={hasSizedStudy && summary ? signedPercent(language, summary.totalReturn) : '—'}
+              tone={hasSizedStudy && summary && summary.totalReturn > 0 ? 'positive' : hasSizedStudy && summary && summary.totalReturn < 0 ? 'negative' : 'neutral'}
+              loading={loading}
+            />
+            <StudyMetric
+              label={studyT.simulatedMaxDrawdown}
+              value={hasSizedStudy && summary ? `−${percent(language, summary.maxDrawdown)}` : '—'}
+              tone={hasSizedStudy && summary && summary.maxDrawdown > 0 ? 'negative' : 'neutral'}
+              loading={loading}
+            />
+            <StudyMetric
+              label={studyT.expectancyNet}
+              value={expectancy !== null ? rMultiple(language, expectancy) : '—'}
+              tone={expectancy !== null && expectancy > 0 ? 'positive' : expectancy !== null && expectancy < 0 ? 'negative' : 'neutral'}
+              loading={loading}
+            />
+            <StudyMetric
+              label={studyT.resolvedSignals}
+              value={summary ? numberFormatter.format(summary.totalSignals) : '—'}
+              tone="neutral"
+              loading={loading}
+              detail={sizedTradeNote ?? undefined}
+            />
+          </div>
+
+          <EvidenceFilters
+            period={period}
+            onPeriodChange={setPeriod}
+            earliestTimestamp={earliestTimestamp}
+            scope={scope}
+            onScopeChange={setScope}
+            category={category}
+            onCategoryChange={setCategory}
+            t={t}
+          />
+          <p className="mb-4 text-xs text-[var(--text-secondary)]">{categoryCaption}</p>
+
+          {scope === 'pro' && <TrailingWeekBandCallout category={category} />}
+
+          <EquityCurve
+            period={period}
+            scope={scope}
+            category={category}
+            band={band}
+            onBandChange={scope === 'pro' ? handleBandChange : undefined}
+          />
+        </section>
 
         <section className="glass-card mb-8 rounded-2xl border-s-2 border-emerald-500/50 p-5">
-          <h2 className="text-sm font-semibold">{t.sections.population}</h2>
+          <h2 className="text-sm font-semibold">Evidence boundaries</h2>
           <p className="mt-1 text-xs leading-relaxed text-[var(--text-secondary)]">
-            {studyT.sequentialHint}
+            Strategy cards are historical modeled studies. The observed record remains the complete,
+            source-backed signal population; the research ledger holds full specifications and verdicts.
           </p>
           <div className="mt-4 flex flex-wrap gap-2">
             <Link
@@ -265,6 +407,246 @@ export function SignalStudyClient() {
         </section>
       </main>
     </div>
+  );
+}
+
+function CatalogCount({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string;
+  value: number;
+  tone?: 'positive' | 'neutral';
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.08] bg-black/20 px-4 py-3">
+      <div className={`font-mono text-2xl font-bold tabular-nums ${tone === 'positive' ? 'text-emerald-400' : 'text-[var(--foreground)]'}`}>
+        {value}
+      </div>
+      <div className="mt-0.5 text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function StrategyCatalog({
+  language,
+  selectedStudy,
+  onSelect,
+}: {
+  language: string;
+  selectedStudy: StrategyStudyRecord;
+  onSelect: (study: StrategyStudyRecord) => void;
+}) {
+  return (
+    <section aria-labelledby="featured-strategy-studies">
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+            Fixed featured set / 7 of 7 visible
+          </p>
+          <h2 id="featured-strategy-studies" className="mt-1 text-xl font-semibold tracking-tight">
+            Compare the study records
+          </h2>
+        </div>
+        <span className="rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-1 font-mono text-[10px] text-[var(--text-secondary)]">
+          DEFAULT: EVIDENCE RANK
+        </span>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        {FEATURED_STRATEGY_STUDIES.map((study) => {
+          const selected = study.id === selectedStudy.id;
+          return (
+            <button
+              key={study.id}
+              type="button"
+              aria-pressed={selected}
+              data-study-id={study.id}
+              onClick={() => onSelect(study)}
+              className={`min-h-36 rounded-xl border p-4 text-start transition-colors ${statusClasses(study.status, selected)}`}
+            >
+              <span className="block text-[9px] font-semibold uppercase tracking-wider opacity-80">
+                {study.statusLabel}
+              </span>
+              <span className="mt-2 block text-sm font-semibold text-[var(--foreground)]">
+                {study.shortName}
+              </span>
+              <span className={`mt-3 block font-mono text-xl font-bold tabular-nums ${metricToneClass(study.headline.tone)}`}>
+                <bdi dir="ltr">{formatStudyMetric(language, study.headline)}</bdi>
+              </span>
+              <span className="mt-1 block text-[9px] leading-relaxed text-[var(--text-secondary)]">
+                {study.headline.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <article
+        className={`mt-4 rounded-2xl border p-5 sm:p-6 ${statusClasses(selectedStudy.status, true)}`}
+        data-testid="selected-strategy-study"
+        aria-live="polite"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] opacity-80">
+              {selectedStudy.evidence}
+            </p>
+            <h3 className="mt-2 text-2xl font-bold tracking-tight text-[var(--foreground)]">
+              {selectedStudy.name}
+            </h3>
+            <p className="mt-1 text-xs font-semibold uppercase tracking-wide">
+              {selectedStudy.statusLabel}
+            </p>
+          </div>
+          <div className="text-end">
+            <div className={`font-mono text-3xl font-bold tabular-nums sm:text-4xl ${metricToneClass(selectedStudy.headline.tone)}`}>
+              <bdi dir="ltr">{formatStudyMetric(language, selectedStudy.headline)}</bdi>
+            </div>
+            <div className="mt-1 text-[10px] text-[var(--text-secondary)]">
+              {selectedStudy.headline.label}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          {selectedStudy.metrics.map((metric) => (
+            <div key={metric.label} className="rounded-lg border border-white/[0.08] bg-black/20 px-3 py-3">
+              <div className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">
+                {metric.label}
+              </div>
+              <div className={`mt-1 font-mono text-base font-semibold tabular-nums ${metricToneClass(metric.tone)}`}>
+                <bdi dir="ltr">{formatStudyMetric(language, metric)}</bdi>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <dl className="mt-5 grid gap-x-6 gap-y-3 text-xs sm:grid-cols-2">
+          <StudyDefinition label="Universe" value={selectedStudy.universe} />
+          <StudyDefinition label="Window" value={selectedStudy.window} />
+          <StudyDefinition label="Rule" value={selectedStudy.rule} />
+          <StudyDefinition label="Modeled costs" value={selectedStudy.costs} />
+        </dl>
+
+        <div className="mt-5 grid gap-3 lg:grid-cols-2">
+          <div className="rounded-lg border border-white/[0.08] bg-black/20 p-4">
+            <div className="text-[9px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+              Frozen decision
+            </div>
+            <p className="mt-2 text-xs leading-relaxed text-[var(--foreground)]">
+              {selectedStudy.decision}
+            </p>
+          </div>
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.05] p-4">
+            <div className="text-[9px] font-semibold uppercase tracking-wider text-amber-300/80">
+              Claim boundary
+            </div>
+            <p className="mt-2 text-xs leading-relaxed text-amber-50/75">
+              {selectedStudy.caveat}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap gap-3">
+          <a
+            href={strategyArtifactUrl(selectedStudy.artifactFile)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-white/[0.07] px-4 py-2 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-white/[0.11]"
+          >
+            Inspect source JSON
+          </a>
+          <Link
+            href="/research"
+            className="rounded-lg px-4 py-2 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-white/[0.05] hover:text-[var(--foreground)]"
+          >
+            Read the full verdict
+          </Link>
+        </div>
+      </article>
+    </section>
+  );
+}
+
+function StudyDefinition({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">
+        {label}
+      </dt>
+      <dd className="mt-1 leading-relaxed text-[var(--foreground)]">{value}</dd>
+    </div>
+  );
+}
+
+function ExperimentShelf() {
+  return (
+    <details
+      className="group mt-6 rounded-2xl border border-white/[0.08] bg-black/20"
+      data-testid="experiment-shelf"
+    >
+      <summary className="cursor-pointer list-none px-5 py-4 marker:hidden sm:px-6">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <span className="block text-sm font-semibold text-[var(--foreground)]">
+              Experiment shelf - all {EXPERIMENT_SHELF.length} committed JSON artifacts
+            </span>
+            <span className="mt-1 block text-[10px] leading-relaxed text-[var(--text-secondary)]">
+              Failures, diagnostics, duplicate predecessors, and zero-cost references stay one click away.
+            </span>
+          </div>
+          <span aria-hidden="true" className="font-mono text-lg text-[var(--text-secondary)] transition-transform group-open:rotate-45">
+            +
+          </span>
+        </div>
+      </summary>
+
+      <div className="border-t border-white/[0.08] px-5 py-2 sm:px-6">
+        <ul className="divide-y divide-white/[0.07]">
+          {EXPERIMENT_SHELF.map((entry) => (
+            <li key={entry.file} className="grid gap-2 py-4 sm:grid-cols-[7rem_minmax(0,1fr)_auto] sm:items-start">
+              <div className="font-mono text-[10px] text-[var(--text-secondary)]">{entry.runDate}</div>
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs font-semibold text-[var(--foreground)]">{entry.label}</span>
+                  <span className={`rounded-full border px-2 py-0.5 font-mono text-[8px] uppercase tracking-wider ${entry.disposition === 'featured-source' ? 'border-emerald-500/25 text-emerald-400' : 'border-white/[0.1] text-[var(--text-secondary)]'}`}>
+                    {entry.disposition === 'featured-source' ? 'featured source' : 'shelved'}
+                  </span>
+                </div>
+                <p className="mt-1 text-[10px] leading-relaxed text-[var(--text-secondary)]">
+                  {entry.reason}
+                </p>
+              </div>
+              <a
+                href={strategyArtifactUrl(entry.file)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] font-medium text-emerald-400 underline decoration-emerald-500/30 underline-offset-4 hover:text-emerald-300"
+              >
+                JSON
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="border-t border-white/[0.07] py-4 text-[10px] leading-relaxed text-[var(--text-secondary)]">
+          Shelf order is reverse chronological, not return-ranked. Individual variants that share one
+          artifact remain inspectable inside that JSON. The append-only ledger is on the{' '}
+          <a
+            href="https://github.com/naimkatiman/tradeclaw/blob/main/docs/research/experiments/REGISTRY.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-emerald-400 underline decoration-emerald-500/30 underline-offset-4"
+          >
+            experiment registry
+          </a>
+          .
+        </p>
+      </div>
+    </details>
   );
 }
 

--- a/apps/web/app/track-record/study/page.tsx
+++ b/apps/web/app/track-record/study/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { getTrackRecordWidgetTranslations } from '../../../lib/product-i18n/track-record-widgets';
-import { getPreferredLocaleFromCookie } from '../../../lib/product-i18n/server-locale';
 
 const SignalStudyClient = dynamic(
   () => import('./SignalStudyClient').then((module) => ({ default: module.SignalStudyClient })),
@@ -14,11 +12,10 @@ const SignalStudyClient = dynamic(
   },
 );
 
-export async function generateMetadata(): Promise<Metadata> {
-  const locale = await getPreferredLocaleFromCookie();
-  const title = `${getTrackRecordWidgetTranslations(locale).equity.title} | TradeClaw`;
+export function generateMetadata(): Metadata {
+  const title = `Strategy Study Catalog | TradeClaw`;
   const description =
-    'A hypothetical, fee/slippage-adjusted sequential equity study built from OHLCV-resolved signals. It is not the observed track record, broker fills, or customer portfolio performance.';
+    'Seven artifact-backed modeled strategy studies, an evidence-ranked paper-pass default, and the complete experiment shelf. It is not the observed track record, broker fills, or customer portfolio returns.';
 
   return {
     title,

--- a/apps/web/lib/__tests__/strategy-study-catalog-surface.test.ts
+++ b/apps/web/lib/__tests__/strategy-study-catalog-surface.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function source(path: string): string {
+  return readFileSync(resolve(__dirname, '../..', path), 'utf8');
+}
+
+describe('strategy study catalog surface', () => {
+  const page = source('app/track-record/study/SignalStudyClient.tsx');
+
+  it('renders the fixed catalog, evidence-ranked default, and complete shelf', () => {
+    expect(page).toContain('FEATURED_STRATEGY_STUDIES.map');
+    expect(page).toContain('DEFAULT: EVIDENCE RANK');
+    expect(page).toContain('STRATEGY_STUDY_SELECTION_POLICY');
+    expect(page).toContain('data-testid="selected-strategy-study"');
+    expect(page).toContain('data-testid="experiment-shelf"');
+    expect(page).toContain('all {EXPERIMENT_SHELF.length} committed JSON artifacts');
+  });
+
+  it('keeps adverse aggregate evidence on the same page instead of shelving it away', () => {
+    expect(page).toContain('Adverse result retained');
+    expect(page).toContain('changing the default cannot erase the losing record');
+    expect(page).toContain('<TrailingWeekBandCallout');
+    expect(page).toContain('<EquityCurve');
+  });
+
+  it('states the green result boundary and links the observed record', () => {
+    const catalog = source('lib/strategy-study-catalog.ts');
+    expect(catalog).toMatch(/not live performance/i);
+    expect(catalog).toMatch(/prospective tracking began without backfilling/i);
+    expect(page).toContain('href="/track-record"');
+    expect(page).toContain('historical modeled studies');
+  });
+});

--- a/apps/web/lib/__tests__/strategy-study-catalog.test.ts
+++ b/apps/web/lib/__tests__/strategy-study-catalog.test.ts
@@ -1,0 +1,205 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  DEFAULT_STRATEGY_STUDY_ID,
+  EXPERIMENT_SHELF,
+  FEATURED_STRATEGY_STUDIES,
+  STRATEGY_STUDY_SELECTION_POLICY,
+  getStrategyStudy,
+} from '../strategy-study-catalog';
+
+const experimentDir = resolve(__dirname, '../../../..', 'docs/research/experiments');
+
+interface ReturnMetrics {
+  totalReturn: number;
+  cagr: number;
+  maxDrawdown: number;
+}
+
+interface D1Artifact {
+  results: { portfolio: { full: { strategy: ReturnMetrics; benchmark: ReturnMetrics } } };
+  decision: { verdict: string; calmarFoldPasses: number };
+}
+
+interface H1Result {
+  totalReturn: number;
+  totalTrades: number;
+  winRate: number;
+  profitFactor: number;
+}
+
+interface H1Artifact {
+  results: Record<'classic' | 'regime-aware' | 'vwap-ema-bb', { full: H1Result }>;
+}
+
+interface DailyArtifact {
+  aggregate: {
+    'signal-flip': {
+      meanCostedReturnExFlukes: number;
+      meanCostedReturn: number;
+      foldStability: number;
+      verdict: string;
+    };
+  };
+}
+
+interface CarryArtifact {
+  results: {
+    A1: {
+      full: { annualizedReturn: number; returnOnCapital: number };
+      recent: { annualizedReturn: number };
+      gates: { pass: boolean };
+    };
+  };
+}
+
+interface CrossSectionArtifact {
+  full: {
+    b1: { totalReturn: number };
+    gates: { B1: { pass: boolean } };
+  };
+  subwindow: {
+    b1: { totalReturn: number };
+    gates: { B1: { pass: boolean } };
+  };
+}
+
+function artifact<T>(file: string): T {
+  return JSON.parse(readFileSync(resolve(experimentDir, file), 'utf8')) as T;
+}
+
+function study(id: string) {
+  const record = FEATURED_STRATEGY_STUDIES.find((candidate) => candidate.id === id);
+  if (!record) throw new Error(`Missing featured study: ${id}`);
+  return record;
+}
+
+function metricValue(id: string, label: string): number | string {
+  const metric = study(id).metrics.find((candidate) => candidate.label === label);
+  if (!metric) throw new Error(`Missing metric ${label} on ${id}`);
+  return metric.value;
+}
+
+describe('strategy study catalog integrity', () => {
+  it('freezes exactly seven featured records and defaults by evidence tier', () => {
+    expect(FEATURED_STRATEGY_STUDIES.map((record) => record.id)).toEqual([
+      'd1-slow-gate',
+      'classic-h1',
+      'regime-aware-h1',
+      'vwap-ema-bb-h1',
+      'daily-momentum',
+      'funding-carry',
+      'cross-sectional-momentum',
+    ]);
+    expect(DEFAULT_STRATEGY_STUDY_ID).toBe('d1-slow-gate');
+    expect(getStrategyStudy(null).id).toBe(DEFAULT_STRATEGY_STUDY_ID);
+    expect(getStrategyStudy('unknown-after-positive-result').id).toBe(DEFAULT_STRATEGY_STUDY_ID);
+    expect(STRATEGY_STUDY_SELECTION_POLICY).toMatch(/evidence tier/i);
+    expect(STRATEGY_STUDY_SELECTION_POLICY).toMatch(/Return is never/i);
+  });
+
+  it('publishes the exact D1 slow-gate paper-pass values and claim boundary', () => {
+    const file = 'd1-slow-gate-walk-forward-BTCUSD_ETHUSD-D1-2017-09-01-2026-07-16-f4.json';
+    const source = artifact<D1Artifact>(file);
+    const record = study('d1-slow-gate');
+
+    expect(record.artifactFile).toBe(file);
+    expect(record.status).toBe('paper-pass');
+    expect(record.headline.value).toBe(source.results.portfolio.full.strategy.totalReturn);
+    expect(metricValue(record.id, 'Identically costed hold')).toBe(
+      source.results.portfolio.full.benchmark.totalReturn,
+    );
+    expect(metricValue(record.id, 'Modeled CAGR')).toBe(
+      source.results.portfolio.full.strategy.cagr,
+    );
+    expect(metricValue(record.id, 'Modeled max drawdown')).toBe(
+      -source.results.portfolio.full.strategy.maxDrawdown,
+    );
+    expect(source.decision.verdict).toBe('PASS');
+    expect(source.decision.calmarFoldPasses).toBe(3);
+    expect(record.caveat).toMatch(/not live performance|not .*broker return/i);
+  });
+
+  it('cross-checks all three featured H1 cards against the production-cost artifact', () => {
+    const file = 'BTCUSD-H1-2024-06-10-2026-06-09-live-crypto-classic_regime-aware_hmm-top3_vwap-ema-bb_full-risk-f4.json';
+    const source = artifact<H1Artifact>(file);
+    const mappings = [
+      ['classic-h1', 'classic'],
+      ['regime-aware-h1', 'regime-aware'],
+      ['vwap-ema-bb-h1', 'vwap-ema-bb'],
+    ] as const;
+
+    for (const [studyId, resultId] of mappings) {
+      const record = study(studyId);
+      const result = source.results[resultId].full;
+      expect(record.artifactFile).toBe(file);
+      expect(record.headline.value).toBe(result.totalReturn);
+      expect(metricValue(studyId, 'Trades')).toBe(result.totalTrades);
+      expect(metricValue(studyId, 'Win rate')).toBe(result.winRate);
+      expect(metricValue(studyId, 'Profit factor')).toBe(result.profitFactor);
+    }
+  });
+
+  it('uses the registered robustness readings for daily momentum, carry, and cross-section', () => {
+    const daily = artifact<DailyArtifact>(
+      'daily-momentum-validation-BTCUSD_ETHUSD_SOLUSD_BNBUSD_XRPUSD_ADAUSD_DOGEUSD_DOTUSD_LINKUSD_AVAXUSD-D1-f4.json',
+    ).aggregate['signal-flip'];
+    expect(study('daily-momentum').headline.value).toBe(daily.meanCostedReturnExFlukes);
+    expect(metricValue('daily-momentum', 'Raw mean return')).toBe(daily.meanCostedReturn);
+    expect(metricValue('daily-momentum', 'Fold stability')).toBe(daily.foldStability);
+    expect(daily.verdict).toBe('MARGINAL');
+
+    const carry = artifact<CarryArtifact>('carry-validation-10majors-f4.json').results.A1;
+    expect(study('funding-carry').headline.value).toBe(carry.full.annualizedReturn);
+    expect(metricValue('funding-carry', 'Full-window return')).toBe(carry.full.returnOnCapital);
+    expect(metricValue('funding-carry', 'Recent 24-month annualized')).toBe(
+      carry.recent.annualizedReturn,
+    );
+    expect(carry.gates.pass).toBe(false);
+
+    const crossSection = artifact<CrossSectionArtifact>(
+      'xsection-validation-30majors-D1-lb14-rb7-top5-f4.json',
+    );
+    expect(study('cross-sectional-momentum').headline.value).toBe(
+      crossSection.subwindow.b1.totalReturn,
+    );
+    expect(metricValue('cross-sectional-momentum', 'Full-window return')).toBe(
+      crossSection.full.b1.totalReturn,
+    );
+    expect(crossSection.full.gates.B1.pass).toBe(false);
+    expect(crossSection.subwindow.gates.B1.pass).toBe(false);
+  });
+
+  it('never paints a positive rejected or inconclusive headline as a pass', () => {
+    const positiveNonPasses = FEATURED_STRATEGY_STUDIES.filter(
+      (record) => record.status !== 'paper-pass' && Number(record.headline.value) > 0,
+    );
+
+    expect(positiveNonPasses.map((record) => record.id)).toEqual([
+      'regime-aware-h1',
+      'funding-carry',
+    ]);
+    for (const record of positiveNonPasses) {
+      expect(record.headline.tone).toBe('neutral');
+      expect(record.statusLabel).not.toMatch(/^pass/i);
+    }
+  });
+
+  it('keeps every committed JSON experiment in a unique, reasoned shelf entry', () => {
+    const committedFiles = readdirSync(experimentDir)
+      .filter((file) => file.endsWith('.json'))
+      .sort();
+    const shelfFiles = EXPERIMENT_SHELF.map((entry) => entry.file).sort();
+
+    expect(shelfFiles).toEqual(committedFiles);
+    expect(new Set(shelfFiles).size).toBe(shelfFiles.length);
+    expect(EXPERIMENT_SHELF.every((entry) => entry.reason.length >= 40)).toBe(true);
+
+    const legacy = EXPERIMENT_SHELF.find((entry) => entry.file.includes('legacy-zero'));
+    const hmm = EXPERIMENT_SHELF.find((entry) => entry.file.startsWith('regime-hmm'));
+    expect(legacy).toMatchObject({ disposition: 'shelved' });
+    expect(legacy?.reason).toMatch(/zero-cost|production cost/i);
+    expect(hmm).toMatchObject({ disposition: 'shelved' });
+    expect(hmm?.reason).toMatch(/diagnostic|no standalone trading return/i);
+  });
+});

--- a/apps/web/lib/strategy-study-catalog.ts
+++ b/apps/web/lib/strategy-study-catalog.ts
@@ -1,0 +1,356 @@
+export type StrategyStudyStatus = 'paper-pass' | 'rejected' | 'inconclusive';
+
+export type StrategyMetricFormat =
+  | 'signed-ratio-percent'
+  | 'ratio-percent'
+  | 'signed-percent-points'
+  | 'percent-points'
+  | 'decimal'
+  | 'integer'
+  | 'text';
+
+export interface StrategyStudyMetric {
+  label: string;
+  value: number | string;
+  format: StrategyMetricFormat;
+  digits?: number;
+  suffix?: string;
+  tone?: 'positive' | 'negative' | 'neutral';
+}
+
+export interface StrategyStudyRecord {
+  id: string;
+  name: string;
+  shortName: string;
+  status: StrategyStudyStatus;
+  statusLabel: string;
+  evidence: string;
+  headline: StrategyStudyMetric;
+  metrics: readonly StrategyStudyMetric[];
+  universe: string;
+  window: string;
+  rule: string;
+  costs: string;
+  decision: string;
+  caveat: string;
+  artifactFile: string;
+}
+
+export interface ExperimentShelfEntry {
+  file: string;
+  runDate: string;
+  label: string;
+  disposition: 'featured-source' | 'shelved';
+  reason: string;
+}
+
+export const EXPERIMENT_ARTIFACT_BASE =
+  'https://github.com/naimkatiman/tradeclaw/blob/main/docs/research/experiments';
+
+export const DEFAULT_STRATEGY_STUDY_ID = 'd1-slow-gate';
+
+export const STRATEGY_STUDY_SELECTION_POLICY =
+  'Default selection uses evidence tier first, then validation date and stable id. Return is never a sorting or promotion field.';
+
+export const FEATURED_STRATEGY_STUDIES: readonly StrategyStudyRecord[] = [
+  {
+    id: 'd1-slow-gate',
+    name: 'D1 Slow Gate 50/50',
+    shortName: 'D1 Slow Gate',
+    status: 'paper-pass',
+    statusLabel: 'Paper-pass / tracked prospectively',
+    evidence: 'Pre-registered walk-forward',
+    headline: {
+      label: 'Modeled total return',
+      value: 6.36828512,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      tone: 'positive',
+    },
+    metrics: [
+      { label: 'Identically costed hold', value: 2.39124529, format: 'signed-ratio-percent', digits: 2 },
+      { label: 'Modeled CAGR', value: 0.25222516, format: 'signed-ratio-percent', digits: 2 },
+      { label: 'Modeled max drawdown', value: -0.56166088, format: 'signed-ratio-percent', digits: 2, tone: 'negative' },
+      { label: 'Calmar / fold gate', value: '0.449 / 3 of 4', format: 'text' },
+    ],
+    universe: 'BTCUSD + ETHUSD / D1 / fixed 50-50 independent sleeves',
+    window: '2017-09-01 to 2026-07-16 / 3,241 bars per symbol',
+    rule: 'Close above EMA200, long/flat; ATR14 x 2.5 stop with a 4.0% floor',
+    costs: '0.05% fee + 0.15% slippage per side + fixed funding assumption',
+    decision:
+      'PASS under the frozen rule: integrity QA, positive net return, Calmar at least hold in 3 of 4 folds, and frequency ceilings all cleared.',
+    caveat:
+      'This green figure is a historical OHLCV simulation with modeled fills and funding. It is not live performance or a broker return. The BTC/ETH-only universe carries survivor-selection risk; prospective tracking began without backfilling historical rows.',
+    artifactFile:
+      'd1-slow-gate-walk-forward-BTCUSD_ETHUSD-D1-2017-09-01-2026-07-16-f4.json',
+  },
+  {
+    id: 'classic-h1',
+    name: 'Classic Momentum H1',
+    shortName: 'Classic H1',
+    status: 'rejected',
+    statusLabel: 'Rejected',
+    evidence: 'Registered costed comparison',
+    headline: {
+      label: 'Costed total return',
+      value: -0.1112,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      tone: 'negative',
+    },
+    metrics: [
+      { label: 'Trades', value: 375, format: 'integer' },
+      { label: 'Win rate', value: 0.3307, format: 'ratio-percent', digits: 2 },
+      { label: 'Profit factor', value: 0.809, format: 'decimal', digits: 3 },
+      { label: 'Modeled max drawdown', value: -0.1417, format: 'signed-ratio-percent', digits: 2, tone: 'negative' },
+    ],
+    universe: 'BTCUSD / H1 / 17,497 bars',
+    window: '2024-06-10 to 2026-06-09 / four folds',
+    rule: 'Classic momentum entry; ATR14 x 2.5 stop and 2R target',
+    costs: 'Production crypto-perpetual fee, slippage, and funding assumptions',
+    decision: 'REJECTED: the registered production-cost comparison was net-negative.',
+    caveat: 'One BTC historical window; modeled OHLCV fills, not an execution ledger.',
+    artifactFile:
+      'BTCUSD-H1-2024-06-10-2026-06-09-live-crypto-classic_regime-aware_hmm-top3_vwap-ema-bb_full-risk-f4.json',
+  },
+  {
+    id: 'regime-aware-h1',
+    name: 'Regime-aware H1',
+    shortName: 'Regime-aware',
+    status: 'inconclusive',
+    statusLabel: 'Inconclusive / thin',
+    evidence: 'Registered costed comparison',
+    headline: {
+      label: 'Costed total return',
+      value: 0.0063,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      tone: 'neutral',
+    },
+    metrics: [
+      { label: 'Trades', value: 6, format: 'integer' },
+      { label: 'Win rate', value: 0.5, format: 'ratio-percent', digits: 1 },
+      { label: 'Profit factor', value: 2.028, format: 'decimal', digits: 3 },
+      { label: 'Average modeled cost', value: 0.441, format: 'percent-points', digits: 3 },
+    ],
+    universe: 'BTCUSD / H1 / 17,497 bars',
+    window: '2024-06-10 to 2026-06-09 / four folds',
+    rule: 'Regime-aware entry; ATR14 x 2.5 stop and 2R target',
+    costs: 'Production crypto-perpetual fee, slippage, and funding assumptions',
+    decision:
+      'INCONCLUSIVE: the positive full-window cell contains only six trades and cannot support promotion.',
+    caveat: 'A positive number is not painted green when the sample is too thin to establish an edge.',
+    artifactFile:
+      'BTCUSD-H1-2024-06-10-2026-06-09-live-crypto-classic_regime-aware_hmm-top3_vwap-ema-bb_full-risk-f4.json',
+  },
+  {
+    id: 'vwap-ema-bb-h1',
+    name: 'VWAP + EMA + Bollinger H1',
+    shortName: 'VWAP + EMA + BB',
+    status: 'rejected',
+    statusLabel: 'Rejected / thin',
+    evidence: 'Registered costed comparison',
+    headline: {
+      label: 'Costed total return',
+      value: -0.0081,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      tone: 'negative',
+    },
+    metrics: [
+      { label: 'Trades', value: 6, format: 'integer' },
+      { label: 'Win rate', value: 0.1667, format: 'ratio-percent', digits: 2 },
+      { label: 'Profit factor', value: 0.345, format: 'decimal', digits: 3 },
+      { label: 'Modeled max drawdown', value: -0.0081, format: 'signed-ratio-percent', digits: 2, tone: 'negative' },
+    ],
+    universe: 'BTCUSD / H1 / 17,497 bars',
+    window: '2024-06-10 to 2026-06-09 / four folds',
+    rule: 'VWAP, EMA, and Bollinger mean-reversion entry; ATR14 x 2.5 stop and 2R target',
+    costs: 'Production crypto-perpetual fee, slippage, and funding assumptions',
+    decision: 'REJECTED: negative after modeled costs, with only six full-window trades.',
+    caveat: 'Thin sample and one BTC historical window; not evidence of live execution performance.',
+    artifactFile:
+      'BTCUSD-H1-2024-06-10-2026-06-09-live-crypto-classic_regime-aware_hmm-top3_vwap-ema-bb_full-risk-f4.json',
+  },
+  {
+    id: 'daily-momentum',
+    name: 'Daily Momentum / 10 Majors',
+    shortName: 'Daily Momentum',
+    status: 'rejected',
+    statusLabel: 'Marginal / rejected',
+    evidence: 'Registered four-fold validation',
+    headline: {
+      label: 'Mean return excluding two flukes',
+      value: -0.052474,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      tone: 'negative',
+    },
+    metrics: [
+      { label: 'Raw mean return', value: 0.249158, format: 'signed-ratio-percent', digits: 2, tone: 'neutral' },
+      { label: 'Positive and adequate symbols', value: '4 of 10', format: 'text' },
+      { label: 'Fold stability', value: 0.375, format: 'ratio-percent', digits: 1 },
+      { label: 'Thin fold cells', value: '32 of 40', format: 'text' },
+    ],
+    universe: 'BTC, ETH, SOL, BNB, XRP, ADA, DOGE, DOT, LINK, AVAX / D1',
+    window: 'Approximately 2020-06 to 2026-06 / four folds',
+    rule: '28-day time-series momentum, signal-flip exit',
+    costs: 'Production crypto-perpetual fee, slippage, and funding assumptions',
+    decision:
+      'MARGINAL-REJECTED: only 4 of 10 symbols cleared breadth and fold stability was 37.5%; SOL and AVAX drove the positive raw mean.',
+    caveat: 'The raw +24.92% mean is retained beside the bias check; it is not used as the headline.',
+    artifactFile:
+      'daily-momentum-validation-BTCUSD_ETHUSD_SOLUSD_BNBUSD_XRPUSD_ADAUSD_DOGEUSD_DOTUSD_LINKUSD_AVAXUSD-D1-f4.json',
+  },
+  {
+    id: 'funding-carry',
+    name: 'Funding-rate Carry',
+    shortName: 'Funding Carry',
+    status: 'rejected',
+    statusLabel: 'Positive / failed gate',
+    evidence: 'Registered four-fold validation',
+    headline: {
+      label: 'Full-window annualized return',
+      value: 0.0584356573,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      suffix: '/yr',
+      tone: 'neutral',
+    },
+    metrics: [
+      { label: 'Full-window return', value: 0.39501437, format: 'signed-ratio-percent', digits: 2, tone: 'neutral' },
+      { label: 'Recent 24-month annualized', value: 0.0235013825, format: 'signed-ratio-percent', digits: 2, suffix: '/yr', tone: 'neutral' },
+      { label: 'Modeled max drawdown', value: -0.0072643929, format: 'signed-ratio-percent', digits: 2, tone: 'negative' },
+      { label: 'Positive folds', value: '4 of 4', format: 'text' },
+    ],
+    universe: 'BTC always-on delta-neutral reference; 10-major variants also tested',
+    window: '2019-09 to 2026-06 / four folds',
+    rule: 'Short perpetual, hold spot, unlevered two-leg capital model',
+    costs: '0.70% modeled two-leg round trip',
+    decision:
+      'FAILED MAGNITUDE GATE: 5.84% annualized was below 8%, and recent 2.35% was below 5%.',
+    caveat: 'Profitable in the historical model, but positive is not equivalent to passing the predeclared bar.',
+    artifactFile: 'carry-validation-10majors-f4.json',
+  },
+  {
+    id: 'cross-sectional-momentum',
+    name: 'Cross-sectional Momentum',
+    shortName: 'Cross-section',
+    status: 'rejected',
+    statusLabel: 'Rejected / survivor-sensitive',
+    evidence: 'Registered four-fold validation',
+    headline: {
+      label: 'Bias-mitigated subwindow return',
+      value: -0.4699112906,
+      format: 'signed-ratio-percent',
+      digits: 2,
+      tone: 'negative',
+    },
+    metrics: [
+      { label: 'Full-window return', value: 13.2548123746, format: 'signed-ratio-percent', digits: 2, tone: 'neutral' },
+      { label: 'Subwindow basket return', value: -0.502903544, format: 'signed-ratio-percent', digits: 2, tone: 'negative' },
+      { label: 'Full-window excess folds', value: '2 of 4', format: 'text' },
+      { label: 'Subwindow excess folds', value: '1 of 4', format: 'text' },
+    ],
+    universe: 'Current 30-major universe / D1 / listing-date-aware inputs',
+    window: 'Full: 2020-06 to 2026-06; bias check: 2024-06 onward',
+    rule: '14-day rank, weekly rebalance, long-only top five',
+    costs: '0.20% per side on actual turnover, also charged to the benchmark',
+    decision:
+      'REJECTED: fold stability failed, and the current-survivor full window did not survive the bias-mitigated subwindow.',
+    caveat: 'The +1,325.48% full-window result remains visible, but is not the headline because it is survivor-sensitive.',
+    artifactFile: 'xsection-validation-30majors-D1-lb14-rb7-top5-f4.json',
+  },
+] as const;
+
+export const EXPERIMENT_SHELF: readonly ExperimentShelfEntry[] = [
+  {
+    file: 'd1-slow-gate-walk-forward-BTCUSD_ETHUSD-D1-2017-09-01-2026-07-16-f4.json',
+    runDate: '2026-08-08',
+    label: 'D1 slow-gate walk-forward',
+    disposition: 'featured-source',
+    reason: 'Canonical source for the featured paper-pass; historical model only.',
+  },
+  {
+    file: 'regime-expectancy-live-record-crypto-D1-2026-08-05.json',
+    runDate: '2026-08-05',
+    label: 'Regime expectancy on the observed signal record',
+    disposition: 'shelved',
+    reason: 'Hypothesis test on the aggregate observed stream, not a standalone strategy equity record; both directional hypotheses were refuted.',
+  },
+  {
+    file: 'slow-gate-BTCUSD_ETHUSD-D1-2017-09-01-2026-07-16-f4.json',
+    runDate: '2026-07-17',
+    label: 'Slow-gate sandbox predecessor',
+    disposition: 'shelved',
+    reason: 'Predecessor sandbox with different spot-cost and sizing assumptions; superseded for the tracked lane by the frozen build artifact.',
+  },
+  {
+    file: 'xsection-validation-30majors-D1-lb14-rb7-top5-f4.json',
+    runDate: '2026-06-13',
+    label: 'Cross-sectional momentum validation',
+    disposition: 'featured-source',
+    reason: 'Canonical source for the featured cross-sectional momentum card; failed its registered stability gate.',
+  },
+  {
+    file: 'carry-validation-10majors-f4.json',
+    runDate: '2026-06-13',
+    label: 'Funding-rate carry validation',
+    disposition: 'featured-source',
+    reason: 'Canonical source for the featured carry card; positive history but below both registered magnitude gates.',
+  },
+  {
+    file: 'daily-momentum-validation-BTCUSD_ETHUSD_SOLUSD_BNBUSD_XRPUSD_ADAUSD_DOGEUSD_DOTUSD_LINKUSD_AVAXUSD-D1-f4.json',
+    runDate: '2026-06-12',
+    label: 'Daily momentum / ten-major validation',
+    disposition: 'featured-source',
+    reason: 'Canonical source for the featured daily-momentum card; marginal result rejected on breadth and fold stability.',
+  },
+  {
+    file: 'daily-momentum-validation-BTCUSD-D1-f4.json',
+    runDate: '2026-06-12',
+    label: 'Daily momentum / BTC-only predecessor',
+    disposition: 'shelved',
+    reason: 'Superseded single-symbol predecessor; the ten-major validation is the canonical breadth test.',
+  },
+  {
+    file: 'regime-routed-walkforward-BTCUSD_ETHUSD_SOLUSD-H1-2024-06-01-2026-06-01-f4.json',
+    runDate: '2026-06-11',
+    label: 'Regime-routed walk-forward',
+    disposition: 'shelved',
+    reason: 'Separate routing validation; the only adequately sampled routed cell was negative on all three symbols.',
+  },
+  {
+    file: 'regime-hmm-walkforward-BTCUSD_ETHUSD_SOLUSD-H1-2024-06-12-2026-06-11.json',
+    runDate: '2026-06-11',
+    label: 'Structural HMM diagnostic',
+    disposition: 'shelved',
+    reason: 'Model diagnostic with no standalone trading return; states separated volatility rather than directional drift.',
+  },
+  {
+    file: 'BTCUSD-H1-2024-06-10-2026-06-09-live-crypto-classic_regime-aware_hmm-top3_vwap-ema-bb_full-risk-f4.json',
+    runDate: '2026-06-10',
+    label: 'H1 five-preset production-cost comparison',
+    disposition: 'featured-source',
+    reason: 'Canonical source for three featured H1 cards. Window-capped HMM Top-3 and Full Risk variants remain in the artifact but are not production-comparable.',
+  },
+  {
+    file: 'BTCUSD-H1-2024-06-10-2026-06-09-legacy-zero-classic_regime-aware_hmm-top3_vwap-ema-bb_full-risk-f4.json',
+    runDate: '2026-06-10',
+    label: 'H1 five-preset zero-cost reference',
+    disposition: 'shelved',
+    reason: 'Legacy zero-cost reference; excluded from featured comparisons because it does not use the production cost model.',
+  },
+] as const;
+
+export function strategyArtifactUrl(file: string): string {
+  return `${EXPERIMENT_ARTIFACT_BASE}/${file}`;
+}
+
+export function getStrategyStudy(id: string | null | undefined): StrategyStudyRecord {
+  return (
+    FEATURED_STRATEGY_STUDIES.find((study) => study.id === id) ??
+    FEATURED_STRATEGY_STUDIES.find((study) => study.id === DEFAULT_STRATEGY_STUDY_ID) ??
+    FEATURED_STRATEGY_STUDIES[0]
+  );
+}

--- a/apps/web/tests/e2e/track-record/track-record.spec.ts
+++ b/apps/web/tests/e2e/track-record/track-record.spec.ts
@@ -84,20 +84,33 @@ test.describe('Track Record page', () => {
     await expect(page.locator('canvas')).toHaveCount(0);
   });
 
-  // Test 4: The separate study reports either a real curve or the explicit
-  // no-evidence state. A zero-return placeholder is intentionally omitted.
-  test('modeled study renders an evidence-backed state', async ({ page }) => {
+  // Test 4: The separate study defaults to the evidence-ranked strategy catalog
+  // while retaining the adverse aggregate curve or explicit no-evidence state.
+  test('modeled study renders the catalog and retained aggregate state', async ({ page }) => {
     await dismissStarMilestoneModal(page);
     await page.goto('/track-record/study');
     await dismissStarMilestoneModal(page);
 
     await expect(
       page.getByRole('heading', {
-        name: 'Signal Study — Sequential Simulation',
+        name: 'Strategy Study Catalog',
         exact: true,
         level: 1,
       })
     ).toBeVisible({ timeout: 15_000 });
+
+    await expect(page.locator('[data-study-id]')).toHaveCount(7);
+    await expect(page.locator('[data-study-id="d1-slow-gate"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(
+      page.getByRole('heading', {
+        name: 'Signal Study — Sequential Simulation',
+        exact: true,
+        level: 2,
+      })
+    ).toBeVisible();
 
     const canvas = page.locator('canvas').first();
     const noEvidence = page.getByText(/no approved observed-OHLCV outcomes.*no zero-return placeholder/i);


### PR DESCRIPTION
## What changed

- Adds seven fixed, artifact-backed strategy-study cards to `/track-record/study`.
- Defaults to the pre-registered D1 slow-gate paper-pass by evidence tier, validation date, and stable ID—not return.
- Preserves all 11 committed experiment artifacts in a reverse-chronological shelf with disposition reasons and source links.
- Keeps rejected, inconclusive, survivor-sensitive, and adverse aggregate results visible.
- Labels the D1 `+636.83%` figure as modeled historical performance, not live or broker performance.

## Why

The prior study surface showed only the aggregate losing signal-stream simulation. This adds the existing alternate-strategy evidence without selecting winners after seeing returns or deleting unfavorable studies.

## Boundaries

This PR changes evidence presentation only. It does not change the frozen D1 rule, signal generation, allocation, execution, database/schema, cron, authentication, billing, dependencies, Docker, or production activation. The observed `/track-record` remains canonical.

## Validation

- Full Jest: 235 suites, 1,852 tests passed; 3 suites / 26 tests skipped.
- Web TypeScript: passed.
- Lint: 0 errors; 23 pre-existing warnings.
- Strategy tests: 14 suites / 103 tests / 1 snapshot passed.
- Production build: passed, 325 pages.
- `STATE.yaml`: parses.
- Diff checks: passed.
- Prior CLI-first desktop/mobile Chromium QA and affected E2E: passed; protected Playwright remains authoritative for WebKit.