### PR TITLE
feat: add prospective D1 alpha ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Demo](https://img.shields.io/badge/Demo-Live-10b981?style=flat-square)](https://tradeclaw.win/dashboard)
 
-**[Track Record](https://tradeclaw.win/track-record)** · **[Modeled Study](https://tradeclaw.win/track-record/study)** · **[Live Demo](https://tradeclaw.win/dashboard)** · **[API Docs](https://tradeclaw.win/api-docs)**
+**[Track Record](https://tradeclaw.win/track-record)** · **[Prospective Alpha Ledger](https://tradeclaw.win/track-record/alpha)** · **[Modeled Studies](https://tradeclaw.win/track-record/study)** · **[Live Demo](https://tradeclaw.win/dashboard)** · **[API Docs](https://tradeclaw.win/api-docs)**
 
 Read this in other languages: [日本語](README.ja.md) · [한국어](README.ko.md) · [中文](README.zh.md) · [more](LANGUAGES.md)
 
@@ -22,7 +22,7 @@ Read this in other languages: [日本語](README.ja.md) · [한국어](README.ko
 
 ---
 
-TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (RSI, MACD, EMA, Bollinger Bands, Stochastic, ADX, Volume). Eligible signals and their OHLCV-derived outcomes are recorded in PostgreSQL. The [track record](https://tradeclaw.win/track-record) exposes only observed outcome counts, rates, unsized price moves, exclusions, and row-level evidence. The separate [strategy study catalog](https://tradeclaw.win/track-record/study) shows seven artifact-backed modeled studies, keeps every committed experiment on an accessible shelf, and retains the aggregate fixed-fractional signal simulation. Its default is selected by evidence tier rather than return. Neither surface is a broker-fill or customer-portfolio ledger.
+TradeClaw generates BUY/SELL signals using multi-timeframe technical analysis (RSI, MACD, EMA, Bollinger Bands, Stochastic, ADX, Volume). Eligible signals and their OHLCV-derived outcomes are recorded in PostgreSQL. The [track record](https://tradeclaw.win/track-record) exposes only observed outcome counts, rates, unsized price moves, exclusions, and row-level evidence. The separate [strategy study catalog](https://tradeclaw.win/track-record/study) shows seven artifact-backed modeled studies, keeps every committed experiment on an accessible shelf, and retains the aggregate fixed-fractional signal simulation. Its default is selected by evidence tier rather than return. The [prospective D1 alpha ledger](https://tradeclaw.win/track-record/alpha) starts flat at its first post-deployment snapshot and evaluates one frozen BTCUSD/ETHUSD rule against a same-cost benchmark. It remains **collecting evidence** until the predeclared 365-day, 365-snapshot, 12-closed-trade, zero-gap integrity gate is complete; passing makes it eligible for review, never automatically current. None of these surfaces is a broker-fill or customer-portfolio ledger, and the losing historical archive remains published.
 
 > Status: pre-1.0 (`0.1.0`). The signal engine, dashboard, backtester, and self-host path are usable today; APIs and schema may still change between releases.
 
@@ -237,7 +237,7 @@ Docker Compose maps the documented `.env` variables into the relevant services t
 | `MARKET_DATA_HUB_URL` | Yes | Market data hub (primary quote/OHLCV/SSE source). Bare host accepted — `https://` is added if missing |
 | `CRON_SECRET` | Yes | Auth for `/api/cron/*` endpoints |
 | `SIGNAL_ENGINE_PRESET` | No | Strategy preset (default: `hmm-top3`) |
-| `D1_SLOW_GATE_MODE` | No | `paper` (default/fail-closed) or `active`; active records only newest-bar BTCUSD/ETHUSD D1 transitions as real tracked rows. It does not enable broker execution or bypass broadcast gates |
+| `D1_SLOW_GATE_MODE` | No | `paper` (default/fail-closed) or `active`; active records only newest-bar BTCUSD/ETHUSD D1 transitions as real tracked rows. The separate prospective alpha ledger collects one common closed D1 portfolio snapshot in either mode and never changes activation, broker execution, or broadcast gates |
 | `TELEGRAM_BOT_TOKEN` | No | Telegram bot for alerts |
 | `TELEGRAM_CHANNEL_ID` | No | Private channel (Pro alerts) |
 | `TELEGRAM_PUBLIC_CHANNEL_ID` | No | Public channel (delayed free alerts) |

--- a/STATE.yaml
+++ b/STATE.yaml
@@ -1,5 +1,5 @@
 project: tradeclaw
-updated: 2026-08-09T14:04:09+08:00
+updated: 2026-08-10T16:55:28+08:00
 
 description: >
   Open source self-hostable AI trading agent platform.
@@ -4509,3 +4509,72 @@ next_actions:
       update clears the protected path and establishes the exact final-main
       commit to deploy. No live claim is valid until Railway reaches SUCCESS and
       production browser, health, route, artifact, and bounded-log checks pass.
+
+  - id: TC-254
+    title: "Build a prospective D1 alpha ledger without backfill"
+    status: done
+    owner: pm-tradeclaw
+    notes: >
+      Started 2026-08-10 after the owner explicitly directed a prospective D1
+      alpha ledger and /track-record/alpha, required the D1 rule to remain
+      frozen, required the status "collecting evidence" until a predeclared
+      minimum is met, and prohibited deletion of the losing historical archive.
+      Work is isolated in branch agent/d1-alpha-ledger from exact final main
+      5cdc54d0f9369ddf9db7e33c375e58ca317f031a after TC-253's protected merge,
+      state closure, exact-main Railway deployment, and live verification; the
+      broad dirty primary checkout remains excluded. The protocol was frozen
+      before ledger outcomes exist in
+      docs/plans/2026-08-10-d1-alpha-ledger.md. Strategy version
+      d1-slow-gate-v1-2026-08-09 retains BTCUSD+ETHUSD D1 close-above-EMA200
+      long/flat, ATR14 x 2.5 with a 4.0% stop floor, fixed 50/50 independent
+      sleeves, 0.05% fee plus 0.15% slippage per side, fixed 0.01% funding per
+      eight hours, and the 30-change rolling-365-day ceiling. The normalized
+      rule-source SHA-256 is a9c222a33f3e1e0c70e8fb5f0bfa930dc6433297d9dcb27ef2b825f08da3b171
+      and the canonical artifact SHA-256 is
+      1a6b28e47f218fafd5134cb257e06f966f881bc5154be92135c06867f5026e90.
+      The ledger epoch will be its first successfully committed post-deployment
+      snapshot; both sleeves start flat and no prior position or NAV is replayed.
+      The predeclared minimum is 365 calendar days, 365 consecutive D1
+      snapshots, 12 prospectively closed sleeve trades, zero unresolved cadence
+      gaps, and complete fingerprint/source/hash-chain integrity. Only after that
+      minimum can positive net return, positive active return, non-worse drawdown,
+      and Calmar at least the benchmark make the candidate eligible for manual
+      review. Promotion is never automatic and requires a separate owner action.
+      The local build is complete without modifying
+      packages/strategies/src/d1-slow-gate.ts or running a new parameter search.
+      Migration 054 creates one immutable common BTC/ETH portfolio row per
+      closed D1 bar, pins the version, Binance source, rule and artifact hashes,
+      rejects UPDATE/DELETE, and stores a canonical payload plus previous/row
+      SHA-256. The writer uses a transaction-scoped advisory lock, exact-repeat
+      idempotency, strict next-day cadence, no historical insertion, and
+      recomputable state/cost integrity. Its prospective sleeves start flat;
+      the benchmark starts 50/50 and pays the same entry, terminal-exit, and
+      fixed-funding assumptions. The existing D1 cron lane supplies a row only
+      when both frozen Binance histories evaluate successfully on the same
+      closed bar; ledger failure is isolated from the existing signal path.
+      /track-record/alpha and /api/track-record/alpha expose status, gate
+      progress, positions, preliminary liquidation-adjusted strategy/benchmark
+      metrics, integrity, recent rows/raw JSON, and frozen fingerprints. Empty
+      evidence is an em dash, the public label is "collecting evidence", and
+      both the losing observed archive and retrospective study catalog remain
+      directly linked. Health, sitemap, self-hosting docs, OpenAPI, README, and
+      evidence navigation are aligned with migration 054 and the new surface.
+      Verification on exact base 5cdc54d0 passed nine focused suites (54 tests),
+      full Jest (241 suites and 1,878 tests passed; three suites and 26 tests
+      skipped; the known worker-exit warning remains), web typecheck, full lint
+      with zero errors and 23 pre-existing warnings, frozen strategy tests (14
+      suites, 103 tests, one snapshot), diff check, and the required 325-page
+      production build. Production-build Chromium E2E passed the new page after
+      one ambiguous test locator was narrowed; desktop 1440x1000 and mobile
+      390x844 browser QA showed no horizontal overflow, console warning, console
+      error, or page error. The rendered empty-state screenshots are retained in
+      ignored apps/web/test-results. Docker and psql are unavailable locally, so
+      migration execution was not applied to any database; SQL constraints and
+      append-only behavior have static contract coverage, and protected CI plus
+      an isolated database remain required before publication. At 2026-08-10
+      16:55 MPST the owner separately authorized the TC-254 release. Publication
+      is now in progress; no live claim is valid until the protected PR, real
+      PostgreSQL migration validation, exact-final-main deployment, health,
+      first-row, route, browser, and bounded-log checks pass. Before deployment
+      the ledger remains uncommitted to main and is collecting no observations.
+      The recovery stash remains available until the release handoff is accepted.

--- a/apps/web/app/api/cron/signals/__tests__/collect-new-signals.test.ts
+++ b/apps/web/app/api/cron/signals/__tests__/collect-new-signals.test.ts
@@ -316,6 +316,7 @@ describe('runD1LaneSafely', () => {
       processed: 0,
       candidates: 0,
       recorded: 0,
+      alphaLedger: null,
       failures: [{
         symbol: 'BTCUSD+ETHUSD',
         stage: 'lane',

--- a/apps/web/app/api/cron/signals/route.ts
+++ b/apps/web/app/api/cron/signals/route.ts
@@ -67,6 +67,7 @@ export async function runD1LaneSafely(): Promise<D1SlowGateLaneResult> {
       processed: 0,
       candidates: 0,
       recorded: 0,
+      alphaLedger: null,
       failures: [{
         symbol: 'BTCUSD+ETHUSD',
         stage: 'lane',

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -5,7 +5,7 @@ import { queryOne } from "../../../lib/db-pool";
 
 export const dynamic = "force-dynamic";
 
-export const REQUIRED_MIGRATION = "053_drop_monetization.sql";
+export const REQUIRED_MIGRATION = "054_d1_alpha_ledger.sql";
 
 type CheckStatus = "ok" | "error" | "unknown";
 

--- a/apps/web/app/api/track-record/alpha/route.test.ts
+++ b/apps/web/app/api/track-record/alpha/route.test.ts
@@ -1,0 +1,62 @@
+jest.mock('@/lib/d1-alpha-ledger', () => ({
+  readD1AlphaReport: jest.fn(),
+  unavailableD1AlphaReport: jest.fn(() => ({
+    status: 'collecting-evidence',
+    label: 'collecting evidence',
+    promotion: 'not-promoted',
+    metrics: null,
+  })),
+}));
+
+import {
+  readD1AlphaReport,
+  unavailableD1AlphaReport,
+} from '@/lib/d1-alpha-ledger';
+import { GET } from './route';
+
+const mockedRead = readD1AlphaReport as jest.MockedFunction<typeof readD1AlphaReport>;
+
+beforeEach(() => {
+  mockedRead.mockReset();
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('GET /api/track-record/alpha', () => {
+  it('returns the prospective report without pretending it is current', async () => {
+    mockedRead.mockResolvedValue({
+      status: 'collecting-evidence',
+      label: 'collecting evidence',
+      promotion: 'not-promoted',
+      metrics: null,
+    } as Awaited<ReturnType<typeof readD1AlphaReport>>);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: 'collecting-evidence',
+      label: 'collecting evidence',
+      promotion: 'not-promoted',
+      metrics: null,
+    });
+    expect(mockedRead).toHaveBeenCalledWith({ recentLimit: 5_000 });
+    expect(response.headers.get('cache-control')).toContain('s-maxage=300');
+  });
+
+  it('fails closed with a sanitized unavailable report', async () => {
+    mockedRead.mockRejectedValue(new Error('password=secret'));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(unavailableD1AlphaReport).toHaveBeenCalled();
+    expect(JSON.stringify(body)).not.toContain('secret');
+    expect(body.metrics).toBeNull();
+  });
+});

--- a/apps/web/app/api/track-record/alpha/route.ts
+++ b/apps/web/app/api/track-record/alpha/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import {
+  readD1AlphaReport,
+  unavailableD1AlphaReport,
+} from '@/lib/d1-alpha-ledger';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  try {
+    const report = await readD1AlphaReport({ recentLimit: 5_000 });
+    return NextResponse.json(report, {
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=60' },
+    });
+  } catch {
+    console.error('[track-record/alpha] prospective ledger unavailable; response failed closed');
+    return NextResponse.json(unavailableD1AlphaReport(), {
+      status: 503,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  }
+}

--- a/apps/web/app/docs/self-hosting/page.tsx
+++ b/apps/web/app/docs/self-hosting/page.tsx
@@ -191,7 +191,7 @@ sudo certbot renew --dry-run`} />
   "timestamp": "2026-03-27T10:00:00.000Z",
   "checks": {
     "database": { "status": "ok" },
-    "migrations": { "status": "ok", "required": "053_drop_monetization.sql" }
+    "migrations": { "status": "ok", "required": "054_d1_alpha_ledger.sql" }
   }
 }`} />
         <p className="text-zinc-400 leading-relaxed mt-4">

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -22,6 +22,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: base, lastModified: new Date(), changeFrequency: "daily", priority: 1, alternates: { languages: languageAlternates } },
     { url: `${base}/track-record`, lastModified: new Date(), changeFrequency: "daily", priority: 0.95 },
+    { url: `${base}/track-record/alpha`, lastModified: new Date(), changeFrequency: "daily", priority: 0.92 },
     { url: `${base}/track-record/study`, lastModified: new Date(), changeFrequency: "daily", priority: 0.9 },
     { url: `${base}/research`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
     { url: `${base}/methodology`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },

--- a/apps/web/app/track-record/alpha/page.tsx
+++ b/apps/web/app/track-record/alpha/page.tsx
@@ -1,0 +1,418 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { PageNavBar } from '@/components/PageNavBar';
+import { BackgroundDecor } from '@/components/background/BackgroundDecor';
+import { ProductHeroBackdrop } from '@/components/product-hero-backdrop';
+import {
+  readD1AlphaReport,
+  unavailableD1AlphaReport,
+  type D1AlphaLedgerSnapshot,
+  type D1AlphaReport,
+} from '@/lib/d1-alpha-ledger';
+import { EvidenceSurfaceNav } from '../evidence-controls';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: 'Prospective D1 Alpha Ledger | TradeClaw',
+  description:
+    'Append-only prospective evidence for the frozen BTCUSD and ETHUSD D1 slow-gate candidate, shown against a same-cost benchmark before any promotion decision.',
+  openGraph: {
+    title: 'Prospective D1 Alpha Ledger | TradeClaw',
+    description:
+      'A frozen-rule, append-only modeled-cost evidence ledger. Collecting evidence; not a current strategy or broker account.',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Prospective D1 Alpha Ledger | TradeClaw',
+    description: 'Collecting evidence under a predeclared 365-day / 365-snapshot / 12-trade gate.',
+  },
+};
+
+const EMPTY = '\u2014';
+
+function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return EMPTY;
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    signDisplay: 'always',
+  }).format(value);
+}
+
+function formatUnsignedPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return EMPTY;
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatNumber(value: number | null | undefined, digits = 3): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return EMPTY;
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  }).format(value);
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function statusTone(report: D1AlphaReport): string {
+  if (report.status === 'eligible-for-review') {
+    return 'border-emerald-500/35 bg-emerald-500/10 text-emerald-300';
+  }
+  if (report.status === 'failed-gate') {
+    return 'border-red-500/35 bg-red-500/10 text-red-300';
+  }
+  return 'border-amber-500/35 bg-amber-500/10 text-amber-200';
+}
+
+function MetricCard({
+  label,
+  value,
+  detail,
+  tone = 'neutral',
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  tone?: 'positive' | 'negative' | 'neutral';
+}) {
+  const toneClass = tone === 'positive'
+    ? 'text-emerald-400'
+    : tone === 'negative'
+      ? 'text-red-400'
+      : 'text-[var(--foreground)]';
+  return (
+    <div className="glass-card rounded-xl p-4">
+      <div className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">{label}</div>
+      <div className={`mt-2 font-mono text-2xl font-bold tabular-nums ${toneClass}`}>
+        <bdi dir="ltr">{value}</bdi>
+      </div>
+      <p className="mt-1 text-[10px] leading-relaxed text-[var(--text-secondary)]">{detail}</p>
+    </div>
+  );
+}
+
+function GateCard({
+  label,
+  current,
+  minimum,
+  passed,
+}: {
+  label: string;
+  current: string;
+  minimum: string;
+  passed: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.08] bg-black/20 px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">{label}</span>
+        <span className={`font-mono text-[9px] font-semibold ${passed ? 'text-emerald-400' : 'text-amber-300'}`}>
+          {passed ? 'PASS' : 'OPEN'}
+        </span>
+      </div>
+      <div className="mt-2 font-mono text-lg font-semibold tabular-nums text-[var(--foreground)]">
+        {current} <span className="text-xs font-normal text-[var(--text-secondary)]">/ {minimum}</span>
+      </div>
+    </div>
+  );
+}
+
+function transitionLabel(snapshot: D1AlphaLedgerSnapshot, symbol: 'btc' | 'eth'): string {
+  return snapshot.payload[symbol].transition?.action ?? EMPTY;
+}
+
+async function getReport(): Promise<D1AlphaReport> {
+  try {
+    return await readD1AlphaReport();
+  } catch {
+    console.error('[track-record/alpha page] ledger unavailable; page failed closed');
+    return unavailableD1AlphaReport();
+  }
+}
+
+export default async function D1AlphaTrackRecordPage() {
+  const report = await getReport();
+  const metrics = report.metrics;
+  const latest = report.recentSnapshots[0] ?? null;
+  const strategyReturn = metrics?.strategyNetReturn ?? null;
+  const activeReturn = metrics?.activeReturn ?? null;
+
+  return (
+    <div className="premium-product-shell relative isolate min-h-[100dvh] overflow-hidden text-[var(--foreground)]">
+      <BackgroundDecor variant="track-record" />
+      <PageNavBar />
+
+      <main className="mx-auto max-w-5xl px-4 py-8 pb-20 md:pb-8">
+        <EvidenceSurfaceNav active="alpha" />
+
+        <section className="relative isolate mb-7">
+          <ProductHeroBackdrop
+            src="/brand/hero/tradeclaw-replay-evidence-chamber-v1.webp"
+            testId="d1-alpha-hero-art"
+            className="product-hero-backdrop--quiet"
+          />
+          <div className="relative z-10">
+            <div className="mb-2 font-mono text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+              Prospective modeled-cost evidence / frozen D1 rule
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                Prospective D1 Alpha Ledger
+              </h1>
+              <span className={`rounded-full border px-3 py-1 font-mono text-[10px] font-semibold uppercase tracking-wider ${statusTone(report)}`}>
+                {report.label}
+              </span>
+            </div>
+            <p className="mt-3 max-w-4xl text-sm leading-relaxed text-[var(--text-secondary)]">
+              This append-only ledger measures the frozen BTCUSD + ETHUSD D1 slow-gate candidate
+              only from its first post-deployment snapshot. It starts flat, never backfills a
+              historical position, and compares liquidation-adjusted modeled NAV with a same-cost
+              50/50 buy-and-hold benchmark.
+            </p>
+            <p className="mt-4 rounded-lg border border-amber-500/25 bg-amber-500/[0.06] px-4 py-3 text-xs leading-relaxed text-amber-100/80">
+              <strong className="text-amber-200">Not the current strategy.</strong>{' '}
+              The rule is frozen and cannot be optimized after prospective outcomes arrive. Even a
+              cleared gate produces only “eligible for review”; promotion requires a separate owner
+              decision and cannot delete or relabel the losing historical archive.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="observation-gate" className="glass-card mb-6 rounded-2xl p-5 sm:p-6">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+                Predeclared minimum / return-independent
+              </p>
+              <h2 id="observation-gate" className="mt-1 text-xl font-semibold">Observation gate</h2>
+            </div>
+            <span className="font-mono text-[10px] text-[var(--text-secondary)]">
+              PROMOTION: {report.promotion.toUpperCase()}
+            </span>
+          </div>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <GateCard
+              label="Calendar days"
+              current={formatInteger(metrics?.calendarDays ?? 0)}
+              minimum={formatInteger(report.gate.minimums.calendarDays)}
+              passed={report.gate.observationChecks.calendarDays}
+            />
+            <GateCard
+              label="Consecutive snapshots"
+              current={formatInteger(metrics?.snapshots ?? 0)}
+              minimum={formatInteger(report.gate.minimums.snapshots)}
+              passed={report.gate.observationChecks.snapshots}
+            />
+            <GateCard
+              label="Closed sleeve trades"
+              current={formatInteger(metrics?.closedTrades ?? 0)}
+              minimum={formatInteger(report.gate.minimums.closedTrades)}
+              passed={report.gate.observationChecks.closedTrades}
+            />
+            <GateCard
+              label="Unresolved cadence gaps"
+              current={formatInteger(report.integrity.unresolvedCadenceGaps)}
+              minimum="0"
+              passed={report.gate.observationChecks.cadence}
+            />
+          </div>
+
+          <p className="mt-4 text-[11px] leading-relaxed text-[var(--text-secondary)]">
+            All four observation checks plus fingerprint and hash-chain integrity must pass before
+            returns are judged. The later performance gate requires positive strategy return,
+            positive active return, no worse drawdown, and Calmar at least equal to the benchmark.
+          </p>
+        </section>
+
+        <section aria-labelledby="prospective-metrics" className="mb-6">
+          <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+                Preliminary / not a promotion claim
+              </p>
+              <h2 id="prospective-metrics" className="mt-1 text-xl font-semibold">Prospective evidence</h2>
+            </div>
+            <span className="text-[10px] text-[var(--text-secondary)]">
+              Empty evidence is shown as {EMPTY}, never +0%.
+            </span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <MetricCard
+              label="Strategy net return"
+              value={formatPercent(strategyReturn)}
+              detail="Liquidation-adjusted modeled NAV from the prospective epoch."
+              tone={strategyReturn !== null && strategyReturn > 0 ? 'positive' : strategyReturn !== null && strategyReturn < 0 ? 'negative' : 'neutral'}
+            />
+            <MetricCard
+              label="Benchmark net return"
+              value={formatPercent(metrics?.benchmarkNetReturn)}
+              detail="50/50 BTC/ETH, same entry, exit, and funding assumptions."
+            />
+            <MetricCard
+              label="Active return"
+              value={formatPercent(activeReturn)}
+              detail="Strategy return minus benchmark return."
+              tone={activeReturn !== null && activeReturn > 0 ? 'positive' : activeReturn !== null && activeReturn < 0 ? 'negative' : 'neutral'}
+            />
+            <MetricCard
+              label="Strategy max drawdown"
+              value={formatUnsignedPercent(metrics?.strategyMaxDrawdown)}
+              detail="Peak-to-trough prospective modeled drawdown."
+              tone={metrics && metrics.strategyMaxDrawdown > 0 ? 'negative' : 'neutral'}
+            />
+            <MetricCard
+              label="Benchmark max drawdown"
+              value={formatUnsignedPercent(metrics?.benchmarkMaxDrawdown)}
+              detail="Same-window benchmark peak-to-trough drawdown."
+            />
+            <MetricCard
+              label="Calmar / benchmark"
+              value={metrics ? `${formatNumber(metrics.strategyCalmar, 2)} / ${formatNumber(metrics.benchmarkCalmar, 2)}` : EMPTY}
+              detail="Annualized return divided by maximum drawdown."
+            />
+          </div>
+        </section>
+
+        <section className="mb-6 grid gap-4 lg:grid-cols-2">
+          <div className="glass-card rounded-2xl p-5">
+            <h2 className="text-sm font-semibold">Current prospective state</h2>
+            <dl className="mt-4 grid grid-cols-2 gap-3 text-xs">
+              <div className="rounded-lg border border-white/[0.08] bg-black/20 p-3">
+                <dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">BTCUSD</dt>
+                <dd className="mt-1 font-mono font-semibold">{report.positions.BTCUSD ?? EMPTY}</dd>
+              </div>
+              <div className="rounded-lg border border-white/[0.08] bg-black/20 p-3">
+                <dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">ETHUSD</dt>
+                <dd className="mt-1 font-mono font-semibold">{report.positions.ETHUSD ?? EMPTY}</dd>
+              </div>
+              <div>
+                <dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Strategy NAV</dt>
+                <dd className="mt-1 font-mono">{latest ? formatNumber(latest.payload.strategyLiquidationNav) : EMPTY}</dd>
+              </div>
+              <div>
+                <dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Benchmark NAV</dt>
+                <dd className="mt-1 font-mono">{latest ? formatNumber(latest.payload.benchmarkLiquidationNav) : EMPTY}</dd>
+              </div>
+            </dl>
+          </div>
+          <div className="glass-card rounded-2xl p-5">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold">Ledger integrity</h2>
+              <span className={`font-mono text-[10px] font-semibold uppercase ${report.integrity.status === 'pass' ? 'text-emerald-400' : report.integrity.status === 'not-started' ? 'text-amber-300' : 'text-red-400'}`}>
+                {report.integrity.status}
+              </span>
+            </div>
+            <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2">
+              <div>
+                <dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Verified rows</dt>
+                <dd className="mt-1 font-mono">{formatInteger(report.integrity.verifiedRows)}</dd>
+              </div>
+              <div>
+                <dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Latest commit</dt>
+                <dd className="mt-1 font-mono text-[10px]">{report.observation.latestCommittedAt ?? EMPTY}</dd>
+              </div>
+            </dl>
+            {report.integrity.errors.length > 0 && (
+              <p className="mt-3 rounded-md border border-red-500/20 bg-red-500/[0.05] p-3 text-[10px] text-red-200/80">
+                Evidence is fail-closed: {report.integrity.errors[0]}
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section aria-labelledby="recent-alpha-rows" className="glass-card mb-6 overflow-hidden rounded-2xl">
+          <div className="border-b border-white/[0.08] p-5">
+            <h2 id="recent-alpha-rows" className="text-sm font-semibold">Recent append-only snapshots</h2>
+            <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
+              Newest first. Each row commits both symbols as one hash-chained portfolio observation.
+            </p>
+          </div>
+          {report.recentSnapshots.length === 0 ? (
+            <div className="p-8 text-center text-sm text-[var(--text-secondary)]">
+              {EMPTY} No post-deployment snapshot has been committed.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-left text-[10px]">
+                <thead className="bg-black/20 uppercase tracking-wider text-[var(--text-secondary)]">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">UTC bar</th>
+                    <th className="px-4 py-3 font-medium">BTC / ETH close</th>
+                    <th className="px-4 py-3 font-medium">Transitions</th>
+                    <th className="px-4 py-3 font-medium">Positions</th>
+                    <th className="px-4 py-3 font-medium">Strategy / benchmark NAV</th>
+                    <th className="px-4 py-3 font-medium">Row hash</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/[0.07]">
+                  {report.recentSnapshots.map((snapshot) => (
+                    <tr key={snapshot.rowHash}>
+                      <td className="whitespace-nowrap px-4 py-3 font-mono">
+                        {new Date(snapshot.payload.barTimestamp).toISOString().slice(0, 10)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 font-mono">
+                        {formatNumber(snapshot.payload.btc.close, 2)} / {formatNumber(snapshot.payload.eth.close, 2)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 font-mono">
+                        {transitionLabel(snapshot, 'btc')} / {transitionLabel(snapshot, 'eth')}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 font-mono">
+                        {snapshot.payload.btc.prospectivePosition} / {snapshot.payload.eth.prospectivePosition}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 font-mono">
+                        {formatNumber(snapshot.payload.strategyLiquidationNav)} / {formatNumber(snapshot.payload.benchmarkLiquidationNav)}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-[var(--text-secondary)]" title={snapshot.rowHash}>
+                        {snapshot.rowHash.slice(0, 12)}…
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        <section className="glass-card rounded-2xl border-s-2 border-emerald-500/50 p-5">
+          <h2 className="text-sm font-semibold">Frozen protocol and evidence boundaries</h2>
+          <dl className="mt-4 grid gap-x-6 gap-y-3 text-xs sm:grid-cols-2">
+            <div><dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Version</dt><dd className="mt-1 font-mono text-[10px]">{report.strategyVersion}</dd></div>
+            <div><dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Rule</dt><dd className="mt-1">{report.protocol.rule}</dd></div>
+            <div><dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">OHLCV source</dt><dd className="mt-1 font-mono text-[10px]">{report.protocol.dataSource}</dd></div>
+            <div><dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Rule SHA-256</dt><dd className="mt-1 break-all font-mono text-[9px]">{report.fingerprints.ruleSha256}</dd></div>
+            <div><dt className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)]">Artifact SHA-256</dt><dd className="mt-1 break-all font-mono text-[9px]">{report.fingerprints.artifactSha256}</dd></div>
+          </dl>
+          <div className="mt-5 flex flex-wrap gap-2">
+            <Link href="/track-record" className="rounded-lg bg-emerald-500/15 px-4 py-2 text-xs font-medium text-emerald-400 hover:bg-emerald-500/25">
+              Losing observed archive
+            </Link>
+            <Link href="/track-record/study" className="rounded-lg bg-white/[0.06] px-4 py-2 text-xs font-medium hover:bg-white/[0.1]">
+              Retrospective studies
+            </Link>
+            <a href="/api/track-record/alpha" className="rounded-lg bg-white/[0.06] px-4 py-2 text-xs font-medium hover:bg-white/[0.1]">
+              Raw ledger JSON
+            </a>
+            <a
+              href="https://github.com/naimkatiman/tradeclaw/blob/main/docs/plans/2026-08-10-d1-alpha-ledger.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg px-4 py-2 text-xs font-medium text-[var(--text-secondary)] hover:bg-white/[0.05] hover:text-[var(--foreground)]"
+            >
+              Predeclared protocol
+            </a>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/track-record/evidence-controls.tsx
+++ b/apps/web/app/track-record/evidence-controls.tsx
@@ -12,7 +12,7 @@ import { formatMessage } from '@/lib/product-i18n/format';
 
 export type EvidencePeriod = '7d' | '30d' | '90d' | '180d' | '1y' | '5y' | 'all';
 export type EvidenceScope = 'pro' | 'broadcast';
-export type EvidenceSurface = 'record' | 'study';
+export type EvidenceSurface = 'record' | 'study' | 'alpha';
 
 const PERIOD_OPTIONS: { value: EvidencePeriod; days: number | null }[] = [
   { value: '7d', days: 7 },
@@ -61,12 +61,18 @@ export function EvidenceSurfaceNav({ active }: { active: EvidenceSurface }) {
       label: t.studyLabel,
       description: t.studyDescription,
     },
+    {
+      value: 'alpha' as const,
+      href: '/track-record/alpha',
+      label: 'D1 Alpha Ledger',
+      description: 'Prospective frozen-rule evidence; not current',
+    },
   ];
 
   return (
     <nav
       aria-label={t.ariaLabel}
-      className="mb-6 grid gap-2 rounded-2xl border border-white/[0.07] bg-black/20 p-2 sm:grid-cols-2"
+      className="mb-6 grid gap-2 rounded-2xl border border-white/[0.07] bg-black/20 p-2 sm:grid-cols-3"
     >
       {items.map((item) => {
         const selected = item.value === active;

--- a/apps/web/lib/__tests__/d1-alpha-freeze.test.ts
+++ b/apps/web/lib/__tests__/d1-alpha-freeze.test.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  D1_ALPHA_ARTIFACT_SHA256,
+  D1_ALPHA_COST_MODEL,
+  D1_ALPHA_DATA_SOURCE,
+  D1_ALPHA_FREQUENCY_WINDOW_MS,
+  D1_ALPHA_MAX_DIRECTION_CHANGES,
+  D1_ALPHA_MIN_CALENDAR_DAYS,
+  D1_ALPHA_MIN_CLOSED_TRADES,
+  D1_ALPHA_MIN_SNAPSHOTS,
+  D1_ALPHA_RULE_SHA256,
+  D1_ALPHA_STRATEGY_VERSION,
+} from '../d1-alpha-protocol';
+
+function normalizedFileSha256(relativePath: string): string {
+  const contents = fs
+    .readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+    .replace(/\r\n?/g, '\n');
+  return createHash('sha256').update(contents).digest('hex');
+}
+
+describe('D1 alpha rule freeze', () => {
+  it('pins the strategy version, data source, costs, frequency ceiling, and observation minimum', () => {
+    expect(D1_ALPHA_STRATEGY_VERSION).toBe('d1-slow-gate-v1-2026-08-09');
+    expect(D1_ALPHA_DATA_SOURCE).toBe('binance');
+    expect(D1_ALPHA_COST_MODEL).toEqual({
+      feePctPerSide: 0.05,
+      slippagePctPerSide: 0.15,
+      fundingPctPer8h: 0.01,
+    });
+    expect(D1_ALPHA_MAX_DIRECTION_CHANGES).toBe(30);
+    expect(D1_ALPHA_FREQUENCY_WINDOW_MS).toBe(365 * 86_400_000);
+    expect(D1_ALPHA_MIN_CALENDAR_DAYS).toBe(365);
+    expect(D1_ALPHA_MIN_SNAPSHOTS).toBe(365);
+    expect(D1_ALPHA_MIN_CLOSED_TRADES).toBe(12);
+  });
+
+  it('pins the exact normalized strategy source before prospective outcomes exist', () => {
+    expect(normalizedFileSha256('packages/strategies/src/d1-slow-gate.ts')).toBe(
+      D1_ALPHA_RULE_SHA256,
+    );
+  });
+
+  it('pins the exact normalized historical decision artifact', () => {
+    expect(normalizedFileSha256(
+      'docs/research/experiments/d1-slow-gate-walk-forward-BTCUSD_ETHUSD-D1-2017-09-01-2026-07-16-f4.json',
+    )).toBe(D1_ALPHA_ARTIFACT_SHA256);
+  });
+});

--- a/apps/web/lib/__tests__/d1-alpha-ledger.test.ts
+++ b/apps/web/lib/__tests__/d1-alpha-ledger.test.ts
@@ -1,0 +1,216 @@
+jest.mock('../db-pool', () => ({
+  query: jest.fn(),
+  withClient: jest.fn(),
+}));
+
+import type { PoolClient } from 'pg';
+import { query, withClient } from '../db-pool';
+import {
+  appendD1AlphaSnapshot,
+  readD1AlphaReport,
+  unavailableD1AlphaReport,
+} from '../d1-alpha-ledger';
+import {
+  D1_ALPHA_ARTIFACT_SHA256,
+  D1_ALPHA_RULE_SHA256,
+  D1_ALPHA_STRATEGY_VERSION,
+  buildD1AlphaHashedSnapshot,
+  createInitialD1AlphaSnapshot,
+  type D1AlphaObservation,
+  type D1AlphaSnapshotPayload,
+} from '../d1-alpha-protocol';
+
+const BAR_TS = Date.UTC(2026, 7, 9);
+const COMMITTED_AT = '2026-08-10T00:00:10.000Z';
+const mockedWithClient = withClient as jest.MockedFunction<typeof withClient>;
+const mockedQuery = query as jest.MockedFunction<typeof query>;
+const client = { query: jest.fn() } as unknown as Pick<PoolClient, 'query'>;
+const mockedClientQuery = client.query as jest.MockedFunction<PoolClient['query']>;
+
+function observation(btcClose = 100): D1AlphaObservation {
+  return {
+    barTimestamp: BAR_TS,
+    symbols: {
+      BTCUSD: {
+        symbol: 'BTCUSD',
+        source: 'binance',
+        close: btcClose,
+        engineExposure: 0,
+        transition: null,
+      },
+      ETHUSD: {
+        symbol: 'ETHUSD',
+        source: 'binance',
+        close: 50,
+        engineExposure: 0,
+        transition: null,
+      },
+    },
+  };
+}
+
+function result(rows: unknown[] = []) {
+  return { rows, rowCount: rows.length };
+}
+
+function storedRow(payload: D1AlphaSnapshotPayload) {
+  const hashed = buildD1AlphaHashedSnapshot(payload, null);
+  return {
+    strategy_version: payload.strategyVersion,
+    bar_ts: String(payload.barTimestamp),
+    rule_sha256: payload.ruleSha256,
+    artifact_sha256: payload.artifactSha256,
+    btc_source: payload.btc.source,
+    btc_close: payload.btc.close,
+    btc_transition_action: payload.btc.transition?.action ?? null,
+    btc_transition_price: payload.btc.transition?.price ?? null,
+    btc_engine_exposure: payload.btc.engineExposure,
+    btc_position: payload.btc.prospectivePosition,
+    btc_synchronized: payload.btc.synchronized,
+    btc_strategy_nav: payload.btc.strategyNav,
+    btc_benchmark_nav: payload.btc.benchmarkNav,
+    eth_source: payload.eth.source,
+    eth_close: payload.eth.close,
+    eth_transition_action: payload.eth.transition?.action ?? null,
+    eth_transition_price: payload.eth.transition?.price ?? null,
+    eth_engine_exposure: payload.eth.engineExposure,
+    eth_position: payload.eth.prospectivePosition,
+    eth_synchronized: payload.eth.synchronized,
+    eth_strategy_nav: payload.eth.strategyNav,
+    eth_benchmark_nav: payload.eth.benchmarkNav,
+    strategy_nav: payload.strategyPortfolioNav,
+    benchmark_nav: payload.benchmarkPortfolioNav,
+    strategy_liquidation_nav: payload.strategyLiquidationNav,
+    benchmark_liquidation_nav: payload.benchmarkLiquidationNav,
+    strategy_cost_increment: payload.strategyCostIncrement,
+    strategy_funding_increment: payload.strategyFundingIncrement,
+    benchmark_cost_increment: payload.benchmarkCostIncrement,
+    benchmark_funding_increment: payload.benchmarkFundingIncrement,
+    closed_trades_increment: payload.closedTradesIncrement,
+    previous_hash: null,
+    row_hash: hashed.rowHash,
+    canonical_payload: payload,
+    committed_at: COMMITTED_AT,
+  };
+}
+
+beforeEach(() => {
+  mockedClientQuery.mockReset();
+  mockedWithClient.mockReset();
+  mockedQuery.mockReset();
+  mockedWithClient.mockImplementation(async (callback) => callback(client as PoolClient));
+});
+
+describe('readD1AlphaReport', () => {
+  it('recomputes the genesis state and reports an intact collecting-evidence ledger', async () => {
+    const row = storedRow(createInitialD1AlphaSnapshot(observation()));
+    mockedQuery.mockResolvedValue([row]);
+
+    const report = await readD1AlphaReport({
+      now: Date.UTC(2026, 7, 10, 12),
+      recentLimit: 30,
+    });
+
+    expect(report).toMatchObject({
+      label: 'collecting evidence',
+      status: 'collecting-evidence',
+      promotion: 'not-promoted',
+      integrity: { status: 'pass', verifiedRows: 1, unresolvedCadenceGaps: 0 },
+      observation: { firstBarTimestamp: BAR_TS, latestBarTimestamp: BAR_TS },
+      positions: { BTCUSD: 'FLAT', ETHUSD: 'FLAT' },
+      metrics: { snapshots: 1, closedTrades: 0, calendarDays: 0 },
+    });
+  });
+
+  it('fails integrity when a self-hashed row does not reproduce the frozen math', async () => {
+    const valid = createInitialD1AlphaSnapshot(observation());
+    const tampered: D1AlphaSnapshotPayload = {
+      ...valid,
+      strategyPortfolioNav: 0.9,
+      strategyLiquidationNav: 0.9,
+    };
+    mockedQuery.mockResolvedValue([storedRow(tampered)]);
+
+    const report = await readD1AlphaReport({ now: Date.UTC(2026, 7, 10, 12) });
+
+    expect(report.integrity.status).toBe('fail');
+    expect(report.integrity.verifiedRows).toBe(0);
+    expect(report.integrity.errors[0]).toContain('does not reproduce');
+    expect(report.metrics).toBeNull();
+  });
+});
+
+describe('appendD1AlphaSnapshot', () => {
+  it('serializes a genesis insert, hashes it, and uses conflict-safe append SQL', async () => {
+    mockedClientQuery
+      .mockResolvedValueOnce(result() as never) // BEGIN
+      .mockResolvedValueOnce(result() as never) // advisory xact lock
+      .mockResolvedValueOnce(result() as never) // existing row
+      .mockResolvedValueOnce(result() as never) // latest row
+      .mockResolvedValueOnce(result([{ committed_at: COMMITTED_AT }]) as never)
+      .mockResolvedValueOnce(result() as never); // COMMIT
+
+    const written = await appendD1AlphaSnapshot(observation());
+
+    expect(written).toMatchObject({
+      outcome: 'inserted',
+      barTimestamp: BAR_TS,
+      committedAt: COMMITTED_AT,
+    });
+    expect(written.rowHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(mockedClientQuery.mock.calls[1][0]).toContain('pg_advisory_xact_lock');
+    expect(mockedClientQuery.mock.calls[4][0]).toContain('ON CONFLICT (strategy_version, bar_ts) DO NOTHING');
+    expect(mockedClientQuery.mock.calls[4][0]).not.toContain('UPDATE');
+  });
+
+  it('returns the immutable existing row for an exact repeated observation', async () => {
+    const payload = createInitialD1AlphaSnapshot(observation());
+    const row = storedRow(payload);
+    mockedClientQuery
+      .mockResolvedValueOnce(result() as never)
+      .mockResolvedValueOnce(result() as never)
+      .mockResolvedValueOnce(result([row]) as never)
+      .mockResolvedValueOnce(result() as never);
+
+    const written = await appendD1AlphaSnapshot(observation());
+
+    expect(written).toEqual({
+      outcome: 'idempotent',
+      barTimestamp: BAR_TS,
+      rowHash: row.row_hash,
+      committedAt: COMMITTED_AT,
+    });
+    expect(mockedClientQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it('fails closed instead of rewriting when a repeated bar differs', async () => {
+    const row = storedRow(createInitialD1AlphaSnapshot(observation()));
+    mockedClientQuery
+      .mockResolvedValueOnce(result() as never)
+      .mockResolvedValueOnce(result() as never)
+      .mockResolvedValueOnce(result([row]) as never)
+      .mockResolvedValueOnce(result() as never); // ROLLBACK
+
+    await expect(appendD1AlphaSnapshot(observation(101))).rejects.toThrow(
+      'does not match the repeated observation',
+    );
+    expect(mockedClientQuery.mock.calls.at(-1)?.[0]).toBe('ROLLBACK');
+  });
+});
+
+describe('unavailableD1AlphaReport', () => {
+  it('never fabricates +0 performance or a current-strategy promotion', () => {
+    const report = unavailableD1AlphaReport();
+    expect(report).toMatchObject({
+      strategyVersion: D1_ALPHA_STRATEGY_VERSION,
+      label: 'collecting evidence',
+      status: 'collecting-evidence',
+      promotion: 'not-promoted',
+      metrics: null,
+      fingerprints: {
+        ruleSha256: D1_ALPHA_RULE_SHA256,
+        artifactSha256: D1_ALPHA_ARTIFACT_SHA256,
+      },
+    });
+  });
+});

--- a/apps/web/lib/__tests__/d1-alpha-migration.test.ts
+++ b/apps/web/lib/__tests__/d1-alpha-migration.test.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const migration = fs.readFileSync(
+  path.join(process.cwd(), 'apps/web/migrations/054_d1_alpha_ledger.sql'),
+  'utf8',
+);
+
+describe('054 D1 alpha ledger migration', () => {
+  it('creates one versioned portfolio row per bar with explicit evidence fields', () => {
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS d1_alpha_ledger');
+    expect(migration).toContain('PRIMARY KEY (strategy_version, bar_ts)');
+    expect(migration).toContain('canonical_payload');
+    expect(migration).toContain('previous_hash');
+    expect(migration).toContain('row_hash');
+    expect(migration).toContain('strategy_liquidation_nav');
+    expect(migration).toContain('benchmark_liquidation_nav');
+    expect(migration).toContain('closed_trades_increment');
+    expect(migration).toContain("CHECK (btc_source = 'binance')");
+    expect(migration).toContain("CHECK (eth_source = 'binance')");
+    expect(migration).toContain('canonical_payload ?& ARRAY[');
+  });
+
+  it('pins the frozen version and both predeclared fingerprints', () => {
+    expect(migration).toContain("strategy_version = 'd1-slow-gate-v1-2026-08-09'");
+    expect(migration).toContain(
+      "rule_sha256 = 'a9c222a33f3e1e0c70e8fb5f0bfa930dc6433297d9dcb27ef2b825f08da3b171'",
+    );
+    expect(migration).toContain(
+      "artifact_sha256 = '1a6b28e47f218fafd5134cb257e06f966f881bc5154be92135c06867f5026e90'",
+    );
+  });
+
+  it('rejects UPDATE and DELETE at the database layer', () => {
+    expect(migration).toContain('BEFORE UPDATE OR DELETE ON d1_alpha_ledger');
+    expect(migration).toContain("d1_alpha_ledger is append-only; % is forbidden");
+  });
+});

--- a/apps/web/lib/__tests__/d1-alpha-protocol.test.ts
+++ b/apps/web/lib/__tests__/d1-alpha-protocol.test.ts
@@ -1,0 +1,193 @@
+import {
+  D1_ALPHA_ARTIFACT_SHA256,
+  D1_ALPHA_DAY_MS,
+  D1_ALPHA_RULE_SHA256,
+  D1_ALPHA_SIDE_COST_FRACTION,
+  D1_ALPHA_STRATEGY_VERSION,
+  advanceD1AlphaSnapshot,
+  buildD1AlphaHashedSnapshot,
+  calculateD1AlphaMetrics,
+  createInitialD1AlphaSnapshot,
+  evaluateD1AlphaGate,
+  hashD1AlphaSnapshot,
+  type D1AlphaMetrics,
+  type D1AlphaObservation,
+  type D1AlphaTransitionObservation,
+} from '../d1-alpha-protocol';
+
+const START = Date.UTC(2026, 7, 1);
+
+function observation(
+  day: number,
+  options: {
+    btcClose?: number;
+    ethClose?: number;
+    btcExposure?: 0 | 1;
+    ethExposure?: 0 | 1;
+    btcTransition?: D1AlphaTransitionObservation | null;
+    ethTransition?: D1AlphaTransitionObservation | null;
+  } = {},
+): D1AlphaObservation {
+  return {
+    barTimestamp: START + day * D1_ALPHA_DAY_MS,
+    symbols: {
+      BTCUSD: {
+        symbol: 'BTCUSD',
+        source: 'binance',
+        close: options.btcClose ?? 100,
+        engineExposure: options.btcExposure ?? 0,
+        transition: options.btcTransition ?? null,
+      },
+      ETHUSD: {
+        symbol: 'ETHUSD',
+        source: 'binance',
+        close: options.ethClose ?? 50,
+        engineExposure: options.ethExposure ?? 0,
+        transition: options.ethTransition ?? null,
+      },
+    },
+  };
+}
+
+describe('D1 prospective alpha protocol', () => {
+  it('starts both strategy sleeves flat and treats the epoch transition as audit-only', () => {
+    const initial = createInitialD1AlphaSnapshot(observation(0, {
+      btcExposure: 1,
+      btcTransition: { action: 'ENTER_LONG', price: 100 },
+    }));
+
+    expect(initial).toMatchObject({
+      strategyVersion: D1_ALPHA_STRATEGY_VERSION,
+      ruleSha256: D1_ALPHA_RULE_SHA256,
+      artifactSha256: D1_ALPHA_ARTIFACT_SHA256,
+      strategyPortfolioNav: 1,
+      strategyCostIncrement: 0,
+      closedTradesIncrement: 0,
+      btc: { prospectivePosition: 'FLAT', synchronized: false, strategyNav: 0.5 },
+      eth: { prospectivePosition: 'FLAT', synchronized: true, strategyNav: 0.5 },
+    });
+    expect(initial.benchmarkPortfolioNav).toBeCloseTo(1 - D1_ALPHA_SIDE_COST_FRACTION, 12);
+    expect(initial.benchmarkLiquidationNav).toBeCloseTo(
+      (1 - D1_ALPHA_SIDE_COST_FRACTION) ** 2,
+      12,
+    );
+  });
+
+  it('opens only on a post-epoch transition, accrues daily funding, and closes at a stop fill', () => {
+    const initial = createInitialD1AlphaSnapshot(observation(0));
+    const entered = advanceD1AlphaSnapshot(initial, observation(1, {
+      btcExposure: 1,
+      btcTransition: { action: 'ENTER_LONG', price: 100 },
+    }));
+    expect(entered.btc.prospectivePosition).toBe('LONG');
+    expect(entered.btc.synchronized).toBe(true);
+    expect(entered.btc.strategyNav).toBeCloseTo(0.5 * (1 - D1_ALPHA_SIDE_COST_FRACTION), 12);
+    expect(entered.closedTradesIncrement).toBe(0);
+
+    const held = advanceD1AlphaSnapshot(entered, observation(2, {
+      btcClose: 110,
+      btcExposure: 1,
+    }));
+    expect(held.btc.strategyNav).toBeCloseTo(
+      entered.btc.strategyNav * 1.1 * (1 - 0.0003),
+      12,
+    );
+    expect(held.strategyFundingIncrement).toBeGreaterThan(0);
+
+    const exited = advanceD1AlphaSnapshot(held, observation(3, {
+      btcClose: 108,
+      btcExposure: 0,
+      btcTransition: { action: 'EXIT_STOP', price: 105 },
+    }));
+    expect(exited.btc.prospectivePosition).toBe('FLAT');
+    expect(exited.closedTradesIncrement).toBe(1);
+    expect(exited.strategyCostIncrement).toBeGreaterThan(0);
+    expect(exited.btc.strategyNav).toBeCloseTo(
+      held.btc.strategyNav * (105 / 110) * (1 - 0.0003) * (1 - D1_ALPHA_SIDE_COST_FRACTION),
+      12,
+    );
+  });
+
+  it('records a pre-entry exit for audit without manufacturing a trade', () => {
+    const initial = createInitialD1AlphaSnapshot(observation(0, { btcExposure: 1 }));
+    const exit = advanceD1AlphaSnapshot(initial, observation(1, {
+      btcExposure: 0,
+      btcTransition: { action: 'EXIT_GATE', price: 99 },
+      btcClose: 99,
+    }));
+
+    expect(exit.btc.prospectivePosition).toBe('FLAT');
+    expect(exit.btc.synchronized).toBe(true);
+    expect(exit.btc.strategyNav).toBe(0.5);
+    expect(exit.closedTradesIncrement).toBe(0);
+    expect(exit.strategyCostIncrement).toBe(0);
+  });
+
+  it('refuses cadence gaps and prospective/engine state divergence', () => {
+    const initial = createInitialD1AlphaSnapshot(observation(0));
+    expect(() => advanceD1AlphaSnapshot(initial, observation(2))).toThrow(
+      'refuses gaps and historical backfill',
+    );
+
+    const entered = advanceD1AlphaSnapshot(initial, observation(1, {
+      btcExposure: 1,
+      btcTransition: { action: 'ENTER_LONG', price: 100 },
+    }));
+    expect(() => advanceD1AlphaSnapshot(entered, observation(2, { btcExposure: 0 }))).toThrow(
+      'prospective/engine exposure diverged',
+    );
+
+    const inheritedLong = createInitialD1AlphaSnapshot(observation(0, { btcExposure: 1 }));
+    expect(() => advanceD1AlphaSnapshot(inheritedLong, observation(1, { btcExposure: 0 }))).toThrow(
+      'historical engine exposure changed without an exit',
+    );
+  });
+
+  it('produces deterministic, previous-row-bound hashes', () => {
+    const payload = createInitialD1AlphaSnapshot(observation(0));
+    const first = buildD1AlphaHashedSnapshot(payload, null);
+    const repeated = hashD1AlphaSnapshot(payload, null);
+    const chained = hashD1AlphaSnapshot(payload, 'b'.repeat(64));
+
+    expect(first.rowHash).toBe(repeated);
+    expect(first.rowHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(chained).not.toBe(first.rowHash);
+  });
+
+  it('keeps the status collecting-evidence until every predeclared minimum passes', () => {
+    const initial = createInitialD1AlphaSnapshot(observation(0));
+    const metrics = calculateD1AlphaMetrics([initial]);
+    const gate = evaluateD1AlphaGate(metrics, { cadencePassed: true, integrityPassed: true });
+
+    expect(gate.status).toBe('collecting-evidence');
+    expect(gate.performanceGateEvaluated).toBe(false);
+    expect(gate.performanceChecks.positiveStrategyReturn).toBeNull();
+  });
+
+  it('evaluates performance only after the observation minimum, without promoting current', () => {
+    const passing: D1AlphaMetrics = {
+      strategyNetReturn: 0.2,
+      benchmarkNetReturn: 0.1,
+      activeReturn: 0.1,
+      strategyMaxDrawdown: 0.1,
+      benchmarkMaxDrawdown: 0.2,
+      strategyCalmar: 2,
+      benchmarkCalmar: 0.5,
+      calendarDays: 365,
+      snapshots: 365,
+      closedTrades: 12,
+    };
+    const eligible = evaluateD1AlphaGate(passing, {
+      cadencePassed: true,
+      integrityPassed: true,
+    });
+    expect(eligible.status).toBe('eligible-for-review');
+    expect(eligible.observationMinimumMet).toBe(true);
+
+    const failed = evaluateD1AlphaGate(
+      { ...passing, activeReturn: -0.01 },
+      { cadencePassed: true, integrityPassed: true },
+    );
+    expect(failed.status).toBe('failed-gate');
+  });
+});

--- a/apps/web/lib/__tests__/d1-alpha-surface.test.ts
+++ b/apps/web/lib/__tests__/d1-alpha-surface.test.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+describe('prospective D1 alpha public surface', () => {
+  const page = read('apps/web/app/track-record/alpha/page.tsx');
+  const nav = read('apps/web/app/track-record/evidence-controls.tsx');
+  const sitemap = read('apps/web/app/sitemap.ts');
+  const protocol = read('docs/plans/2026-08-10-d1-alpha-ledger.md');
+
+  it('separates prospective evidence from the observed archive and retrospective studies', () => {
+    expect(page).toContain('Prospective D1 Alpha Ledger');
+    expect(page).toContain('Not the current strategy.');
+    expect(page).toContain('Losing observed archive');
+    expect(page).toContain('Retrospective studies');
+    expect(page).toContain('href="/track-record"');
+    expect(page).toContain('href="/track-record/study"');
+  });
+
+  it('publishes the route in evidence navigation and the sitemap', () => {
+    expect(nav).toContain("href: '/track-record/alpha'");
+    expect(nav).toContain("value: 'alpha'");
+    expect(sitemap).toContain('`${base}/track-record/alpha`');
+  });
+
+  it('states the predeclared gate, immutable epoch, and no-auto-promotion boundary', () => {
+    expect(protocol).toContain('at least 365 calendar days');
+    expect(protocol).toContain('at least 365 consecutive daily snapshots');
+    expect(protocol).toContain('at least 12 prospectively closed sleeve trades');
+    expect(protocol).toMatch(/Missing historical snapshots are\s+never inserted later\./);
+    expect(protocol).toContain('Neither state promotes the strategy automatically.');
+    expect(page).toContain('promotion requires a separate owner');
+    expect(page).toContain('Empty evidence is shown as');
+  });
+});

--- a/apps/web/lib/__tests__/d1-slow-gate-paper.test.ts
+++ b/apps/web/lib/__tests__/d1-slow-gate-paper.test.ts
@@ -8,6 +8,10 @@ jest.mock('../signal-history', () => ({
   recordSignalsAsync: jest.fn(),
 }));
 
+jest.mock('../d1-alpha-ledger', () => ({
+  appendD1AlphaSnapshot: jest.fn(),
+}));
+
 jest.mock('@tradeclaw/strategies', () => {
   const actual = jest.requireActual('@tradeclaw/strategies');
   return { ...actual, runD1SlowGate: jest.fn() };
@@ -26,6 +30,12 @@ import {
   type StoredCandle,
 } from '../candle-store';
 import { recordSignalsAsync } from '../signal-history';
+import { appendD1AlphaSnapshot } from '../d1-alpha-ledger';
+import {
+  D1_ALPHA_COST_MODEL,
+  D1_ALPHA_FREQUENCY_WINDOW_MS,
+  D1_ALPHA_MAX_DIRECTION_CHANGES,
+} from '../d1-alpha-protocol';
 import {
   D1_SLOW_GATE_PAPER_START_TS,
   resolveD1SlowGateLaneMode,
@@ -37,6 +47,7 @@ const mockedGetCandles = getCandlesSince as jest.MockedFunction<typeof getCandle
 const mockedRefresh = refreshDailyCandles as jest.MockedFunction<typeof refreshDailyCandles>;
 const mockedBackfill = backfillDailyCandles as jest.MockedFunction<typeof backfillDailyCandles>;
 const mockedRecord = recordSignalsAsync as jest.MockedFunction<typeof recordSignalsAsync>;
+const mockedAppendAlpha = appendD1AlphaSnapshot as jest.MockedFunction<typeof appendD1AlphaSnapshot>;
 
 const DAY_MS = 86_400_000;
 const NOW = Date.UTC(2026, 7, 8, 12);
@@ -45,7 +56,15 @@ function dailyBars(lastClosedOffsetDays = 0): StoredCandle[] {
   const latestOpen = Date.UTC(2026, 7, 7) - lastClosedOffsetDays * DAY_MS;
   const bars: StoredCandle[] = [];
   for (let ts = D1_SLOW_GATE_PAPER_START_TS; ts <= latestOpen; ts += DAY_MS) {
-    bars.push({ timestamp: ts, open: 100, high: 102, low: 98, close: 101, volume: 10 });
+    bars.push({
+      timestamp: ts,
+      open: 100,
+      high: 102,
+      low: 98,
+      close: 101,
+      volume: 10,
+      source: 'binance',
+    });
   }
   return bars;
 }
@@ -56,9 +75,11 @@ function runFor(
   frequencyCapPassed = true,
 ): D1SlowGateRun {
   const barIndex = latest ? bars.length - 1 : bars.length - 2;
+  const exposure: Array<0 | 1> = bars.map(() => 0);
+  exposure[barIndex] = 1;
   return {
     equity: bars.map(() => 1),
-    exposure: bars.map(() => 0),
+    exposure,
     transitions: [{
       barIndex,
       timestamp: bars[barIndex].timestamp,
@@ -88,6 +109,12 @@ beforeEach(() => {
   mockedRefresh.mockReset().mockResolvedValue(1);
   mockedBackfill.mockReset().mockResolvedValue(1);
   mockedRecord.mockReset().mockResolvedValue(1);
+  mockedAppendAlpha.mockReset().mockResolvedValue({
+    outcome: 'inserted',
+    barTimestamp: Date.UTC(2026, 7, 7),
+    rowHash: 'a'.repeat(64),
+    committedAt: '2026-08-08T12:00:00.000Z',
+  });
 });
 
 describe('runD1SlowGateLane', () => {
@@ -108,9 +135,26 @@ describe('runD1SlowGateLane', () => {
 
     const result = await runD1SlowGateLane({ now: NOW, mode: 'paper' });
 
-    expect(result).toEqual({ mode: 'paper', processed: 2, candidates: 1, recorded: 1, failures: [] });
+    expect(result).toEqual({
+      mode: 'paper',
+      processed: 2,
+      candidates: 1,
+      recorded: 1,
+      alphaLedger: expect.objectContaining({ outcome: 'inserted' }),
+      failures: [],
+    });
     expect(mockedRefresh).toHaveBeenCalledTimes(2);
     expect(mockedGetCandles).toHaveBeenCalledWith('BTCUSD', 'D1', D1_SLOW_GATE_PAPER_START_TS);
+    expect(mockedRun).toHaveBeenNthCalledWith(
+      1,
+      bars,
+      { symbol: 'BTCUSD', timeframe: 'D1' },
+      {
+        costs: D1_ALPHA_COST_MODEL,
+        maxDirectionChanges: D1_ALPHA_MAX_DIRECTION_CHANGES,
+        frequencyWindowMs: D1_ALPHA_FREQUENCY_WINDOW_MS,
+      },
+    );
     expect(mockedRecord).toHaveBeenCalledTimes(1);
     expect(mockedRecord.mock.calls[0][0]).toEqual([
       expect.objectContaining({
@@ -128,6 +172,23 @@ describe('runD1SlowGateLane', () => {
         isSimulated: true,
       }),
     ]);
+    expect(mockedAppendAlpha).toHaveBeenCalledWith({
+      barTimestamp: bars.at(-1)!.timestamp,
+      symbols: {
+        BTCUSD: expect.objectContaining({
+          symbol: 'BTCUSD',
+          source: 'binance',
+          close: 101,
+          transition: expect.objectContaining({ action: 'ENTER_LONG', price: 101 }),
+        }),
+        ETHUSD: expect.objectContaining({
+          symbol: 'ETHUSD',
+          source: 'binance',
+          close: 101,
+          transition: null,
+        }),
+      },
+    });
   });
 
   it('promotes an explicitly active newest-bar transition into the real tracked strategy', async () => {
@@ -139,7 +200,14 @@ describe('runD1SlowGateLane', () => {
 
     const result = await runD1SlowGateLane({ now: NOW, mode: 'active' });
 
-    expect(result).toEqual({ mode: 'active', processed: 2, candidates: 1, recorded: 1, failures: [] });
+    expect(result).toEqual({
+      mode: 'active',
+      processed: 2,
+      candidates: 1,
+      recorded: 1,
+      alphaLedger: expect.objectContaining({ outcome: 'inserted' }),
+      failures: [],
+    });
     expect(mockedRecord.mock.calls[0][0]).toEqual([
       expect.objectContaining({
         id: `d1-slow-gate:BTCUSD:ENTER_LONG:${bars.at(-1)!.timestamp}`,
@@ -159,7 +227,14 @@ describe('runD1SlowGateLane', () => {
 
     const result = await runD1SlowGateLane({ now: NOW, mode: 'active' });
 
-    expect(result).toEqual({ mode: 'active', processed: 2, candidates: 0, recorded: 0, failures: [] });
+    expect(result).toEqual({
+      mode: 'active',
+      processed: 2,
+      candidates: 0,
+      recorded: 0,
+      alphaLedger: expect.objectContaining({ outcome: 'inserted' }),
+      failures: [],
+    });
     expect(mockedBackfill).toHaveBeenCalledTimes(1);
     expect(mockedBackfill).toHaveBeenCalledWith('BTCUSD', D1_SLOW_GATE_PAPER_START_TS);
     expect(mockedGetCandles).toHaveBeenCalledTimes(3);
@@ -178,6 +253,20 @@ describe('runD1SlowGateLane', () => {
     expect(mockedRecord).not.toHaveBeenCalled();
   });
 
+  it('fails closed when any frozen-history candle changes provider', async () => {
+    const bars = dailyBars();
+    bars[100] = { ...bars[100], source: 'other-provider' };
+    mockedGetCandles.mockResolvedValue(bars);
+
+    const result = await runD1SlowGateLane({ now: NOW, mode: 'paper' });
+
+    expect(result.alphaLedger).toBeNull();
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures.every((failure) => failure.stage === 'data')).toBe(true);
+    expect(result.failures.every((failure) => failure.error.includes('source must remain binance'))).toBe(true);
+    expect(mockedRun).not.toHaveBeenCalled();
+  });
+
   it('fails closed when the rolling direction-change ceiling is breached', async () => {
     const bars = dailyBars();
     mockedGetCandles.mockResolvedValue(bars);
@@ -189,6 +278,24 @@ describe('runD1SlowGateLane', () => {
     expect(result.failures).toHaveLength(2);
     expect(result.failures.every((failure) => failure.stage === 'frequency')).toBe(true);
     expect(mockedRecord).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a ledger failure without altering the frozen signal result', async () => {
+    const bars = dailyBars();
+    mockedGetCandles.mockResolvedValue(bars);
+    mockedRun.mockImplementation(() => runFor(bars, false));
+    mockedAppendAlpha.mockRejectedValueOnce(new Error('ledger cadence gap'));
+
+    const result = await runD1SlowGateLane({ now: NOW, mode: 'paper' });
+
+    expect(result.recorded).toBe(0);
+    expect(result.alphaLedger).toBeNull();
+    expect(result.failures).toEqual([{
+      symbol: 'BTCUSD+ETHUSD',
+      stage: 'ledger',
+      error: 'ledger cadence gap',
+    }]);
+    expect(mockedRun).toHaveBeenCalledTimes(2);
   });
 
   it('isolates a refresh failure to the paper lane and the affected symbol', async () => {
@@ -206,6 +313,7 @@ describe('runD1SlowGateLane', () => {
       processed: 2,
       candidates: 0,
       recorded: 0,
+      alphaLedger: null,
       failures: [{ symbol: 'BTCUSD', stage: 'refresh', error: 'Binance unavailable' }],
     });
     expect(mockedGetCandles).toHaveBeenCalledTimes(1);

--- a/apps/web/lib/candle-store.ts
+++ b/apps/web/lib/candle-store.ts
@@ -48,6 +48,7 @@ export interface StoredCandle {
   low: number;
   close: number;
   volume: number;
+  source: string;
 }
 
 interface CandleRow {
@@ -57,6 +58,7 @@ interface CandleRow {
   low: number;
   close: number;
   volume: number;
+  source: string;
 }
 
 /** Latest `limit` stored bars for a symbol/timeframe, returned ascending by ts. */
@@ -66,9 +68,9 @@ export async function getRecentCandles(
   limit: number,
 ): Promise<StoredCandle[]> {
   const rows = await query<CandleRow>(
-    `SELECT ts, open, high, low, close, volume
+    `SELECT ts, open, high, low, close, volume, source
        FROM (
-         SELECT ts, open, high, low, close, volume
+         SELECT ts, open, high, low, close, volume, source
            FROM candles
           WHERE symbol = $1 AND timeframe = $2
           ORDER BY ts DESC
@@ -84,6 +86,7 @@ export async function getRecentCandles(
     low: Number(r.low),
     close: Number(r.close),
     volume: Number(r.volume),
+    source: r.source,
   }));
 }
 
@@ -97,7 +100,7 @@ export async function getCandlesSince(
   sinceTimestamp: number,
 ): Promise<StoredCandle[]> {
   const rows = await query<CandleRow>(
-    `SELECT ts, open, high, low, close, volume
+    `SELECT ts, open, high, low, close, volume, source
        FROM candles
       WHERE symbol = $1 AND timeframe = $2 AND ts >= $3
       ORDER BY ts ASC`,
@@ -110,6 +113,7 @@ export async function getCandlesSince(
     low: Number(r.low),
     close: Number(r.close),
     volume: Number(r.volume),
+    source: r.source,
   }));
 }
 

--- a/apps/web/lib/d1-alpha-ledger.ts
+++ b/apps/web/lib/d1-alpha-ledger.ts
@@ -1,0 +1,642 @@
+import type { PoolClient } from 'pg';
+import { withClient, query } from './db-pool';
+import {
+  D1_ALPHA_ARTIFACT_SHA256,
+  D1_ALPHA_DATA_SOURCE,
+  D1_ALPHA_DAY_MS,
+  D1_ALPHA_MIN_CALENDAR_DAYS,
+  D1_ALPHA_MIN_CLOSED_TRADES,
+  D1_ALPHA_MIN_SNAPSHOTS,
+  D1_ALPHA_RULE_SHA256,
+  D1_ALPHA_STRATEGY_VERSION,
+  advanceD1AlphaSnapshot,
+  buildD1AlphaHashedSnapshot,
+  calculateD1AlphaMetrics,
+  canonicalD1AlphaPayload,
+  createInitialD1AlphaSnapshot,
+  evaluateD1AlphaGate,
+  hashD1AlphaSnapshot,
+  validateD1AlphaObservation,
+  type D1AlphaGateEvaluation,
+  type D1AlphaHashedSnapshot,
+  type D1AlphaMetrics,
+  type D1AlphaObservation,
+  type D1AlphaSnapshotPayload,
+  type D1AlphaStatus,
+} from './d1-alpha-protocol';
+
+interface D1AlphaLedgerRow {
+  strategy_version: string;
+  bar_ts: string;
+  rule_sha256: string;
+  artifact_sha256: string;
+  btc_source: string;
+  btc_close: number;
+  btc_transition_action: string | null;
+  btc_transition_price: number | null;
+  btc_engine_exposure: number;
+  btc_position: string;
+  btc_synchronized: boolean;
+  btc_strategy_nav: number;
+  btc_benchmark_nav: number;
+  eth_source: string;
+  eth_close: number;
+  eth_transition_action: string | null;
+  eth_transition_price: number | null;
+  eth_engine_exposure: number;
+  eth_position: string;
+  eth_synchronized: boolean;
+  eth_strategy_nav: number;
+  eth_benchmark_nav: number;
+  strategy_nav: number;
+  benchmark_nav: number;
+  strategy_liquidation_nav: number;
+  benchmark_liquidation_nav: number;
+  strategy_cost_increment: number;
+  strategy_funding_increment: number;
+  benchmark_cost_increment: number;
+  benchmark_funding_increment: number;
+  closed_trades_increment: number;
+  previous_hash: string | null;
+  row_hash: string;
+  canonical_payload: unknown;
+  committed_at: string | Date;
+}
+
+export interface D1AlphaLedgerSnapshot extends D1AlphaHashedSnapshot {
+  committedAt: string;
+}
+
+export interface D1AlphaWriteResult {
+  outcome: 'inserted' | 'idempotent';
+  barTimestamp: number;
+  rowHash: string;
+  committedAt: string;
+}
+
+export interface D1AlphaReport {
+  strategyVersion: typeof D1_ALPHA_STRATEGY_VERSION;
+  label: 'collecting evidence' | 'eligible for review' | 'failed gate';
+  status: D1AlphaStatus;
+  promotion: 'not-promoted';
+  ruleFrozen: true;
+  fingerprints: {
+    ruleSha256: typeof D1_ALPHA_RULE_SHA256;
+    artifactSha256: typeof D1_ALPHA_ARTIFACT_SHA256;
+  };
+  protocol: {
+    symbols: ['BTCUSD', 'ETHUSD'];
+    timeframe: 'D1';
+    portfolio: '50/50 independent sleeves';
+    rule: 'close above EMA200, long/flat';
+    stop: 'ATR14 x 2.5 with 4.0% floor';
+    modeledCosts: '0.05% fee/side + 0.15% slippage/side + 0.01% funding/8h';
+    dataSource: typeof D1_ALPHA_DATA_SOURCE;
+  };
+  gate: D1AlphaGateEvaluation & {
+    minimums: {
+      calendarDays: typeof D1_ALPHA_MIN_CALENDAR_DAYS;
+      snapshots: typeof D1_ALPHA_MIN_SNAPSHOTS;
+      closedTrades: typeof D1_ALPHA_MIN_CLOSED_TRADES;
+      unresolvedCadenceGaps: 0;
+    };
+  };
+  integrity: {
+    status: 'pass' | 'fail' | 'not-started' | 'unavailable';
+    verifiedRows: number;
+    unresolvedCadenceGaps: number;
+    errors: string[];
+  };
+  observation: {
+    firstBarTimestamp: number | null;
+    latestBarTimestamp: number | null;
+    latestCommittedAt: string | null;
+  };
+  positions: { BTCUSD: 'FLAT' | 'LONG' | null; ETHUSD: 'FLAT' | 'LONG' | null };
+  metrics: D1AlphaMetrics | null;
+  recentSnapshots: D1AlphaLedgerSnapshot[];
+}
+
+const SELECT_COLUMNS = `
+  strategy_version, bar_ts, rule_sha256, artifact_sha256,
+  btc_source, btc_close, btc_transition_action, btc_transition_price,
+  btc_engine_exposure, btc_position, btc_synchronized,
+  btc_strategy_nav, btc_benchmark_nav,
+  eth_source, eth_close, eth_transition_action, eth_transition_price,
+  eth_engine_exposure, eth_position, eth_synchronized,
+  eth_strategy_nav, eth_benchmark_nav,
+  strategy_nav, benchmark_nav, strategy_liquidation_nav, benchmark_liquidation_nav,
+  strategy_cost_increment, strategy_funding_increment,
+  benchmark_cost_increment, benchmark_funding_increment,
+  closed_trades_increment, previous_hash, row_hash, canonical_payload, committed_at`;
+
+function asNumber(value: unknown, label: string): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${label} is not finite`);
+  return parsed;
+}
+
+function equalNumber(left: unknown, right: number): boolean {
+  return Math.abs(asNumber(left, 'ledger projection') - right) <= 1e-12;
+}
+
+function validateSnapshotPayload(value: unknown): D1AlphaSnapshotPayload {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('canonical payload is not an object');
+  }
+  const payload = value as D1AlphaSnapshotPayload;
+  if (payload.schemaVersion !== 1) throw new Error('canonical payload schema version mismatch');
+  if (payload.strategyVersion !== D1_ALPHA_STRATEGY_VERSION) {
+    throw new Error('strategy version fingerprint mismatch');
+  }
+  if (payload.ruleSha256 !== D1_ALPHA_RULE_SHA256) {
+    throw new Error('rule fingerprint mismatch');
+  }
+  if (payload.artifactSha256 !== D1_ALPHA_ARTIFACT_SHA256) {
+    throw new Error('artifact fingerprint mismatch');
+  }
+  if (
+    !Number.isSafeInteger(payload.barTimestamp)
+    || payload.barTimestamp <= 0
+    || payload.barTimestamp % D1_ALPHA_DAY_MS !== 0
+  ) {
+    throw new Error('payload bar timestamp is invalid');
+  }
+  for (const [label, sleeve] of [['BTCUSD', payload.btc], ['ETHUSD', payload.eth]] as const) {
+    if (!sleeve || sleeve.source !== D1_ALPHA_DATA_SOURCE) {
+      throw new Error(`${label} payload source is invalid`);
+    }
+    for (const [name, number] of [
+      ['close', sleeve.close],
+      ['strategy NAV', sleeve.strategyNav],
+      ['benchmark NAV', sleeve.benchmarkNav],
+    ] as const) {
+      if (!Number.isFinite(number) || number <= 0) {
+        throw new Error(`${label} payload ${name} is invalid`);
+      }
+    }
+    if (sleeve.engineExposure !== 0 && sleeve.engineExposure !== 1) {
+      throw new Error(`${label} payload engine exposure is invalid`);
+    }
+    if (sleeve.prospectivePosition !== 'FLAT' && sleeve.prospectivePosition !== 'LONG') {
+      throw new Error(`${label} payload position is invalid`);
+    }
+    if (typeof sleeve.synchronized !== 'boolean') {
+      throw new Error(`${label} payload synchronization flag is invalid`);
+    }
+    if (sleeve.transition !== null) {
+      if (!['ENTER_LONG', 'EXIT_GATE', 'EXIT_STOP'].includes(sleeve.transition.action)) {
+        throw new Error(`${label} payload transition action is invalid`);
+      }
+      if (!Number.isFinite(sleeve.transition.price) || sleeve.transition.price <= 0) {
+        throw new Error(`${label} payload transition price is invalid`);
+      }
+    }
+  }
+  for (const [label, number] of [
+    ['strategy NAV', payload.strategyPortfolioNav],
+    ['benchmark NAV', payload.benchmarkPortfolioNav],
+    ['strategy liquidation NAV', payload.strategyLiquidationNav],
+    ['benchmark liquidation NAV', payload.benchmarkLiquidationNav],
+  ] as const) {
+    if (!Number.isFinite(number) || number <= 0) throw new Error(`${label} is invalid`);
+  }
+  for (const [label, number] of [
+    ['strategy cost increment', payload.strategyCostIncrement],
+    ['strategy funding increment', payload.strategyFundingIncrement],
+    ['benchmark cost increment', payload.benchmarkCostIncrement],
+    ['benchmark funding increment', payload.benchmarkFundingIncrement],
+  ] as const) {
+    if (!Number.isFinite(number) || number < 0) throw new Error(`${label} is invalid`);
+  }
+  if (
+    !Number.isSafeInteger(payload.closedTradesIncrement)
+    || payload.closedTradesIncrement < 0
+    || payload.closedTradesIncrement > 2
+  ) {
+    throw new Error('closed-trade increment is invalid');
+  }
+  return payload;
+}
+
+function verifyProjection(row: D1AlphaLedgerRow, payload: D1AlphaSnapshotPayload): void {
+  const fields: Array<[unknown, unknown, string]> = [
+    [row.strategy_version, payload.strategyVersion, 'strategy version'],
+    [Number(row.bar_ts), payload.barTimestamp, 'bar timestamp'],
+    [row.rule_sha256, payload.ruleSha256, 'rule fingerprint'],
+    [row.artifact_sha256, payload.artifactSha256, 'artifact fingerprint'],
+    [row.btc_source, payload.btc.source, 'BTC source'],
+    [row.btc_transition_action, payload.btc.transition?.action ?? null, 'BTC transition'],
+    [row.btc_engine_exposure, payload.btc.engineExposure, 'BTC engine exposure'],
+    [row.btc_position, payload.btc.prospectivePosition, 'BTC position'],
+    [row.btc_synchronized, payload.btc.synchronized, 'BTC synchronization'],
+    [row.eth_source, payload.eth.source, 'ETH source'],
+    [row.eth_transition_action, payload.eth.transition?.action ?? null, 'ETH transition'],
+    [row.eth_engine_exposure, payload.eth.engineExposure, 'ETH engine exposure'],
+    [row.eth_position, payload.eth.prospectivePosition, 'ETH position'],
+    [row.eth_synchronized, payload.eth.synchronized, 'ETH synchronization'],
+    [row.closed_trades_increment, payload.closedTradesIncrement, 'closed-trade increment'],
+  ];
+  for (const [actual, expected, label] of fields) {
+    if (actual !== expected) throw new Error(`${label} projection mismatch`);
+  }
+  const numbers: Array<[unknown, number, string]> = [
+    [row.btc_close, payload.btc.close, 'BTC close'],
+    [row.btc_transition_price, payload.btc.transition?.price ?? 0, 'BTC transition price'],
+    [row.btc_strategy_nav, payload.btc.strategyNav, 'BTC strategy NAV'],
+    [row.btc_benchmark_nav, payload.btc.benchmarkNav, 'BTC benchmark NAV'],
+    [row.eth_close, payload.eth.close, 'ETH close'],
+    [row.eth_transition_price, payload.eth.transition?.price ?? 0, 'ETH transition price'],
+    [row.eth_strategy_nav, payload.eth.strategyNav, 'ETH strategy NAV'],
+    [row.eth_benchmark_nav, payload.eth.benchmarkNav, 'ETH benchmark NAV'],
+    [row.strategy_nav, payload.strategyPortfolioNav, 'strategy NAV'],
+    [row.benchmark_nav, payload.benchmarkPortfolioNav, 'benchmark NAV'],
+    [row.strategy_liquidation_nav, payload.strategyLiquidationNav, 'strategy liquidation NAV'],
+    [row.benchmark_liquidation_nav, payload.benchmarkLiquidationNav, 'benchmark liquidation NAV'],
+    [row.strategy_cost_increment, payload.strategyCostIncrement, 'strategy cost increment'],
+    [row.strategy_funding_increment, payload.strategyFundingIncrement, 'strategy funding increment'],
+    [row.benchmark_cost_increment, payload.benchmarkCostIncrement, 'benchmark cost increment'],
+    [row.benchmark_funding_increment, payload.benchmarkFundingIncrement, 'benchmark funding increment'],
+  ];
+  for (const [actual, expected, label] of numbers) {
+    if (actual === null && expected === 0 && label.includes('transition price')) continue;
+    if (!equalNumber(actual, expected)) throw new Error(`${label} projection mismatch`);
+  }
+}
+
+function decodeAndVerifyRow(row: D1AlphaLedgerRow): D1AlphaLedgerSnapshot {
+  const payload = validateSnapshotPayload(row.canonical_payload);
+  verifyProjection(row, payload);
+  const expectedHash = hashD1AlphaSnapshot(payload, row.previous_hash);
+  if (row.row_hash !== expectedHash) throw new Error('row hash mismatch');
+  const committedAt = new Date(row.committed_at);
+  if (
+    !Number.isFinite(committedAt.getTime())
+    || committedAt.getTime() < payload.barTimestamp + D1_ALPHA_DAY_MS
+  ) {
+    throw new Error('committed-at timestamp predates the D1 bar close');
+  }
+  return {
+    payload,
+    previousHash: row.previous_hash,
+    rowHash: row.row_hash,
+    committedAt: committedAt.toISOString(),
+  };
+}
+
+function observationMatchesPayload(
+  observation: D1AlphaObservation,
+  payload: D1AlphaSnapshotPayload,
+): boolean {
+  if (observation.barTimestamp !== payload.barTimestamp) return false;
+  for (const [symbol, key] of [['BTCUSD', 'btc'], ['ETHUSD', 'eth']] as const) {
+    const actual = observation.symbols[symbol];
+    const stored = payload[key];
+    const transitionPriceMatches = actual.transition === null && stored.transition === null
+      ? true
+      : actual.transition !== null && stored.transition !== null
+        && Math.abs(actual.transition.price - stored.transition.price) <= 1e-9;
+    if (
+      actual.source !== stored.source
+      || Math.abs(actual.close - stored.close) > 1e-9
+      || actual.engineExposure !== stored.engineExposure
+      || actual.transition?.action !== stored.transition?.action
+      || !transitionPriceMatches
+    ) return false;
+  }
+  return true;
+}
+
+function observationFromPayload(payload: D1AlphaSnapshotPayload): D1AlphaObservation {
+  return {
+    barTimestamp: payload.barTimestamp,
+    symbols: {
+      BTCUSD: {
+        symbol: 'BTCUSD',
+        source: payload.btc.source,
+        close: payload.btc.close,
+        engineExposure: payload.btc.engineExposure,
+        transition: payload.btc.transition,
+      },
+      ETHUSD: {
+        symbol: 'ETHUSD',
+        source: payload.eth.source,
+        close: payload.eth.close,
+        engineExposure: payload.eth.engineExposure,
+        transition: payload.eth.transition,
+      },
+    },
+  };
+}
+
+async function selectExisting(
+  client: PoolClient,
+  barTimestamp: number,
+): Promise<D1AlphaLedgerRow | null> {
+  const result = await client.query<D1AlphaLedgerRow>(
+    `SELECT ${SELECT_COLUMNS}
+       FROM d1_alpha_ledger
+      WHERE strategy_version = $1 AND bar_ts = $2`,
+    [D1_ALPHA_STRATEGY_VERSION, barTimestamp],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function selectLatest(client: PoolClient): Promise<D1AlphaLedgerRow | null> {
+  const result = await client.query<D1AlphaLedgerRow>(
+    `SELECT ${SELECT_COLUMNS}
+       FROM d1_alpha_ledger
+      WHERE strategy_version = $1
+      ORDER BY bar_ts DESC
+      LIMIT 1`,
+    [D1_ALPHA_STRATEGY_VERSION],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function insertSnapshot(
+  client: PoolClient,
+  snapshot: D1AlphaHashedSnapshot,
+): Promise<{ committed_at: string | Date } | null> {
+  const { payload } = snapshot;
+  const values: unknown[] = [
+    payload.strategyVersion,
+    payload.barTimestamp,
+    payload.ruleSha256,
+    payload.artifactSha256,
+    payload.btc.source,
+    payload.btc.close,
+    payload.btc.transition?.action ?? null,
+    payload.btc.transition?.price ?? null,
+    payload.btc.engineExposure,
+    payload.btc.prospectivePosition,
+    payload.btc.synchronized,
+    payload.btc.strategyNav,
+    payload.btc.benchmarkNav,
+    payload.eth.source,
+    payload.eth.close,
+    payload.eth.transition?.action ?? null,
+    payload.eth.transition?.price ?? null,
+    payload.eth.engineExposure,
+    payload.eth.prospectivePosition,
+    payload.eth.synchronized,
+    payload.eth.strategyNav,
+    payload.eth.benchmarkNav,
+    payload.strategyPortfolioNav,
+    payload.benchmarkPortfolioNav,
+    payload.strategyLiquidationNav,
+    payload.benchmarkLiquidationNav,
+    payload.strategyCostIncrement,
+    payload.strategyFundingIncrement,
+    payload.benchmarkCostIncrement,
+    payload.benchmarkFundingIncrement,
+    payload.closedTradesIncrement,
+    snapshot.previousHash,
+    snapshot.rowHash,
+    canonicalD1AlphaPayload(payload),
+  ];
+  const placeholders = values.map((_, index) => `$${index + 1}`).join(', ');
+  const result = await client.query<{ committed_at: string | Date }>(
+    `INSERT INTO d1_alpha_ledger (
+       strategy_version, bar_ts, rule_sha256, artifact_sha256,
+       btc_source, btc_close, btc_transition_action, btc_transition_price,
+       btc_engine_exposure, btc_position, btc_synchronized,
+       btc_strategy_nav, btc_benchmark_nav,
+       eth_source, eth_close, eth_transition_action, eth_transition_price,
+       eth_engine_exposure, eth_position, eth_synchronized,
+       eth_strategy_nav, eth_benchmark_nav,
+       strategy_nav, benchmark_nav, strategy_liquidation_nav, benchmark_liquidation_nav,
+       strategy_cost_increment, strategy_funding_increment,
+       benchmark_cost_increment, benchmark_funding_increment,
+       closed_trades_increment, previous_hash, row_hash, canonical_payload
+     ) VALUES (${placeholders})
+     ON CONFLICT (strategy_version, bar_ts) DO NOTHING
+     RETURNING committed_at`,
+    values,
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function appendD1AlphaSnapshot(
+  observation: D1AlphaObservation,
+): Promise<D1AlphaWriteResult> {
+  validateD1AlphaObservation(observation);
+  return withClient(async (client) => {
+    await client.query('BEGIN');
+    try {
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [D1_ALPHA_STRATEGY_VERSION]);
+
+      const existing = await selectExisting(client, observation.barTimestamp);
+      if (existing) {
+        const verified = decodeAndVerifyRow(existing);
+        if (!observationMatchesPayload(observation, verified.payload)) {
+          throw new Error('existing D1 alpha row does not match the repeated observation');
+        }
+        await client.query('COMMIT');
+        return {
+          outcome: 'idempotent' as const,
+          barTimestamp: verified.payload.barTimestamp,
+          rowHash: verified.rowHash,
+          committedAt: verified.committedAt,
+        };
+      }
+
+      const latestRow = await selectLatest(client);
+      let payload: D1AlphaSnapshotPayload;
+      let previousHash: string | null = null;
+      if (latestRow) {
+        const latest = decodeAndVerifyRow(latestRow);
+        if (observation.barTimestamp <= latest.payload.barTimestamp) {
+          throw new Error('D1 alpha ledger refuses historical insertion');
+        }
+        payload = advanceD1AlphaSnapshot(latest.payload, observation);
+        previousHash = latest.rowHash;
+      } else {
+        payload = createInitialD1AlphaSnapshot(observation);
+      }
+      const snapshot = buildD1AlphaHashedSnapshot(payload, previousHash);
+      const inserted = await insertSnapshot(client, snapshot);
+      if (!inserted) {
+        throw new Error('D1 alpha row conflicted after the ledger lock');
+      }
+      await client.query('COMMIT');
+      return {
+        outcome: 'inserted' as const,
+        barTimestamp: payload.barTimestamp,
+        rowHash: snapshot.rowHash,
+        committedAt: new Date(inserted.committed_at).toISOString(),
+      };
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the original ledger failure.
+      }
+      throw error;
+    }
+  });
+}
+
+function safeMetricNumber(value: number | null): number | null {
+  return value !== null && Number.isFinite(value) ? value : null;
+}
+
+function safeMetrics(metrics: D1AlphaMetrics | null): D1AlphaMetrics | null {
+  if (!metrics) return null;
+  return {
+    ...metrics,
+    strategyCalmar: safeMetricNumber(metrics.strategyCalmar),
+    benchmarkCalmar: safeMetricNumber(metrics.benchmarkCalmar),
+  };
+}
+
+function baseReport(
+  integrityStatus: D1AlphaReport['integrity']['status'],
+  errors: string[] = [],
+): D1AlphaReport {
+  const gate = evaluateD1AlphaGate(null, { cadencePassed: false, integrityPassed: false });
+  return {
+    strategyVersion: D1_ALPHA_STRATEGY_VERSION,
+    label: 'collecting evidence',
+    status: 'collecting-evidence',
+    promotion: 'not-promoted',
+    ruleFrozen: true,
+    fingerprints: { ruleSha256: D1_ALPHA_RULE_SHA256, artifactSha256: D1_ALPHA_ARTIFACT_SHA256 },
+    protocol: {
+      symbols: ['BTCUSD', 'ETHUSD'],
+      timeframe: 'D1',
+      portfolio: '50/50 independent sleeves',
+      rule: 'close above EMA200, long/flat',
+      stop: 'ATR14 x 2.5 with 4.0% floor',
+      modeledCosts: '0.05% fee/side + 0.15% slippage/side + 0.01% funding/8h',
+      dataSource: D1_ALPHA_DATA_SOURCE,
+    },
+    gate: {
+      ...gate,
+      minimums: {
+        calendarDays: D1_ALPHA_MIN_CALENDAR_DAYS,
+        snapshots: D1_ALPHA_MIN_SNAPSHOTS,
+        closedTrades: D1_ALPHA_MIN_CLOSED_TRADES,
+        unresolvedCadenceGaps: 0,
+      },
+    },
+    integrity: {
+      status: integrityStatus,
+      verifiedRows: 0,
+      unresolvedCadenceGaps: 0,
+      errors,
+    },
+    observation: { firstBarTimestamp: null, latestBarTimestamp: null, latestCommittedAt: null },
+    positions: { BTCUSD: null, ETHUSD: null },
+    metrics: null,
+    recentSnapshots: [],
+  };
+}
+
+export function unavailableD1AlphaReport(): D1AlphaReport {
+  return baseReport('unavailable', ['ledger unavailable; no evidence was inferred']);
+}
+
+export async function readD1AlphaReport(
+  options: { now?: number; recentLimit?: number } = {},
+): Promise<D1AlphaReport> {
+  const now = options.now ?? Date.now();
+  const recentLimit = options.recentLimit ?? 30;
+  if (!Number.isSafeInteger(now) || now <= 0) throw new Error('report time is invalid');
+  if (!Number.isSafeInteger(recentLimit) || recentLimit < 1 || recentLimit > 5_000) {
+    throw new Error('recent snapshot limit must be between 1 and 5000');
+  }
+  const rows = await query<D1AlphaLedgerRow>(
+    `SELECT ${SELECT_COLUMNS}
+       FROM d1_alpha_ledger
+      WHERE strategy_version = $1
+      ORDER BY bar_ts ASC`,
+    [D1_ALPHA_STRATEGY_VERSION],
+  );
+  if (rows.length === 0) return baseReport('not-started');
+
+  const verified: D1AlphaLedgerSnapshot[] = [];
+  const errors: string[] = [];
+  let unresolvedCadenceGaps = 0;
+  for (let index = 0; index < rows.length; index++) {
+    try {
+      const snapshot = decodeAndVerifyRow(rows[index]);
+      if (index === 0 && snapshot.previousHash !== null) {
+        throw new Error('genesis row has a previous hash');
+      }
+      if (index > 0) {
+        const previous = verified[index - 1];
+        if (!previous || snapshot.previousHash !== previous.rowHash) {
+          throw new Error('hash chain does not link to the prior row');
+        }
+        const gap = snapshot.payload.barTimestamp - previous.payload.barTimestamp;
+        if (gap !== D1_ALPHA_DAY_MS) {
+          unresolvedCadenceGaps += Math.max(1, Math.floor(gap / D1_ALPHA_DAY_MS) - 1);
+          throw new Error('stored snapshot cadence is not consecutive');
+        }
+      }
+      const recomputedPayload = index === 0
+        ? createInitialD1AlphaSnapshot(observationFromPayload(snapshot.payload))
+        : advanceD1AlphaSnapshot(
+            verified[index - 1].payload,
+            observationFromPayload(snapshot.payload),
+          );
+      if (canonicalD1AlphaPayload(recomputedPayload) !== canonicalD1AlphaPayload(snapshot.payload)) {
+        throw new Error('snapshot state or modeled-cost math does not reproduce');
+      }
+      verified.push(snapshot);
+    } catch (error) {
+      errors.push(`row ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
+      break;
+    }
+  }
+
+  const latest = verified.at(-1) ?? null;
+  if (latest) {
+    const expectedLatestClosedBar = Math.floor(now / D1_ALPHA_DAY_MS) * D1_ALPHA_DAY_MS - D1_ALPHA_DAY_MS;
+    if (latest.payload.barTimestamp < expectedLatestClosedBar) {
+      unresolvedCadenceGaps += Math.floor(
+        (expectedLatestClosedBar - latest.payload.barTimestamp) / D1_ALPHA_DAY_MS,
+      );
+    }
+  }
+  const integrityPassed = verified.length === rows.length && errors.length === 0;
+  const cadencePassed = unresolvedCadenceGaps === 0 && integrityPassed;
+  const metricsForGate = calculateD1AlphaMetrics(verified.map((snapshot) => snapshot.payload));
+  const gate = evaluateD1AlphaGate(metricsForGate, { cadencePassed, integrityPassed });
+  const report = baseReport(integrityPassed ? 'pass' : 'fail', errors);
+  return {
+    ...report,
+    label: gate.status === 'eligible-for-review'
+      ? 'eligible for review'
+      : gate.status === 'failed-gate'
+        ? 'failed gate'
+        : 'collecting evidence',
+    status: gate.status,
+    gate: { ...gate, minimums: report.gate.minimums },
+    integrity: {
+      status: integrityPassed ? 'pass' : 'fail',
+      verifiedRows: verified.length,
+      unresolvedCadenceGaps,
+      errors,
+    },
+    observation: {
+      firstBarTimestamp: verified[0]?.payload.barTimestamp ?? null,
+      latestBarTimestamp: latest?.payload.barTimestamp ?? null,
+      latestCommittedAt: latest?.committedAt ?? null,
+    },
+    positions: {
+      BTCUSD: latest?.payload.btc.prospectivePosition ?? null,
+      ETHUSD: latest?.payload.eth.prospectivePosition ?? null,
+    },
+    metrics: safeMetrics(metricsForGate),
+    recentSnapshots: verified.slice(-recentLimit).reverse(),
+  };
+}
+
+export const _d1AlphaLedgerInternal = {
+  decodeAndVerifyRow,
+  observationMatchesPayload,
+  validateSnapshotPayload,
+  verifyProjection,
+};

--- a/apps/web/lib/d1-alpha-protocol.ts
+++ b/apps/web/lib/d1-alpha-protocol.ts
@@ -1,0 +1,494 @@
+import { createHash } from 'node:crypto';
+import type { D1SlowGateAction } from '@tradeclaw/strategies';
+
+export const D1_ALPHA_DAY_MS = 86_400_000;
+export const D1_ALPHA_STRATEGY_VERSION = 'd1-slow-gate-v1-2026-08-09' as const;
+export const D1_ALPHA_RULE_SHA256 =
+  'a9c222a33f3e1e0c70e8fb5f0bfa930dc6433297d9dcb27ef2b825f08da3b171' as const;
+export const D1_ALPHA_ARTIFACT_SHA256 =
+  '1a6b28e47f218fafd5134cb257e06f966f881bc5154be92135c06867f5026e90' as const;
+export const D1_ALPHA_DATA_SOURCE = 'binance' as const;
+
+export const D1_ALPHA_MIN_CALENDAR_DAYS = 365;
+export const D1_ALPHA_MIN_SNAPSHOTS = 365;
+export const D1_ALPHA_MIN_CLOSED_TRADES = 12;
+
+export const D1_ALPHA_FEE_PCT_PER_SIDE = 0.05;
+export const D1_ALPHA_SLIPPAGE_PCT_PER_SIDE = 0.15;
+export const D1_ALPHA_FUNDING_PCT_PER_8H = 0.01;
+export const D1_ALPHA_MAX_DIRECTION_CHANGES = 30;
+export const D1_ALPHA_FREQUENCY_WINDOW_MS = 365 * D1_ALPHA_DAY_MS;
+export const D1_ALPHA_COST_MODEL = Object.freeze({
+  feePctPerSide: D1_ALPHA_FEE_PCT_PER_SIDE,
+  slippagePctPerSide: D1_ALPHA_SLIPPAGE_PCT_PER_SIDE,
+  fundingPctPer8h: D1_ALPHA_FUNDING_PCT_PER_8H,
+});
+
+/** Frozen crypto-perpetual assumptions: 0.05% fee + 0.15% slippage per side. */
+export const D1_ALPHA_SIDE_COST_FRACTION =
+  (D1_ALPHA_FEE_PCT_PER_SIDE + D1_ALPHA_SLIPPAGE_PCT_PER_SIDE) / 100;
+/** Frozen funding assumption: 0.01% every eight hours, three times per day. */
+export const D1_ALPHA_DAILY_FUNDING_FRACTION =
+  (D1_ALPHA_FUNDING_PCT_PER_8H * 3) / 100;
+
+export type D1AlphaSymbol = 'BTCUSD' | 'ETHUSD';
+export type D1AlphaPosition = 'FLAT' | 'LONG';
+export type D1AlphaStatus = 'collecting-evidence' | 'eligible-for-review' | 'failed-gate';
+
+export interface D1AlphaTransitionObservation {
+  action: D1SlowGateAction;
+  price: number;
+}
+
+export interface D1AlphaSymbolObservation {
+  symbol: D1AlphaSymbol;
+  source: string;
+  close: number;
+  engineExposure: 0 | 1;
+  transition: D1AlphaTransitionObservation | null;
+}
+
+export interface D1AlphaObservation {
+  barTimestamp: number;
+  symbols: Record<D1AlphaSymbol, D1AlphaSymbolObservation>;
+}
+
+export interface D1AlphaSleeveSnapshot {
+  source: string;
+  close: number;
+  engineExposure: 0 | 1;
+  transition: D1AlphaTransitionObservation | null;
+  prospectivePosition: D1AlphaPosition;
+  synchronized: boolean;
+  strategyNav: number;
+  benchmarkNav: number;
+}
+
+export interface D1AlphaSnapshotPayload {
+  schemaVersion: 1;
+  strategyVersion: typeof D1_ALPHA_STRATEGY_VERSION;
+  ruleSha256: typeof D1_ALPHA_RULE_SHA256;
+  artifactSha256: typeof D1_ALPHA_ARTIFACT_SHA256;
+  barTimestamp: number;
+  btc: D1AlphaSleeveSnapshot;
+  eth: D1AlphaSleeveSnapshot;
+  strategyPortfolioNav: number;
+  benchmarkPortfolioNav: number;
+  strategyLiquidationNav: number;
+  benchmarkLiquidationNav: number;
+  strategyCostIncrement: number;
+  strategyFundingIncrement: number;
+  benchmarkCostIncrement: number;
+  benchmarkFundingIncrement: number;
+  closedTradesIncrement: number;
+}
+
+export interface D1AlphaHashedSnapshot {
+  payload: D1AlphaSnapshotPayload;
+  previousHash: string | null;
+  rowHash: string;
+}
+
+export interface D1AlphaMetrics {
+  strategyNetReturn: number;
+  benchmarkNetReturn: number;
+  activeReturn: number;
+  strategyMaxDrawdown: number;
+  benchmarkMaxDrawdown: number;
+  strategyCalmar: number | null;
+  benchmarkCalmar: number | null;
+  calendarDays: number;
+  snapshots: number;
+  closedTrades: number;
+}
+
+export interface D1AlphaGateEvaluation {
+  status: D1AlphaStatus;
+  observationMinimumMet: boolean;
+  performanceGateEvaluated: boolean;
+  observationChecks: {
+    calendarDays: boolean;
+    snapshots: boolean;
+    closedTrades: boolean;
+    cadence: boolean;
+    integrity: boolean;
+  };
+  performanceChecks: {
+    positiveStrategyReturn: boolean | null;
+    positiveActiveReturn: boolean | null;
+    drawdownNoWorse: boolean | null;
+    calmarNoWorse: boolean | null;
+  };
+}
+
+function assertFinitePositive(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be finite and positive`);
+  }
+}
+
+function roundLedgerNumber(value: number): number {
+  if (!Number.isFinite(value)) throw new Error('ledger value must be finite');
+  return Math.round(value * 1e12) / 1e12;
+}
+
+function validateTransition(
+  transition: D1AlphaTransitionObservation | null,
+  label: string,
+): void {
+  if (transition === null) return;
+  if (!['ENTER_LONG', 'EXIT_GATE', 'EXIT_STOP'].includes(transition.action)) {
+    throw new Error(`${label} transition action is invalid`);
+  }
+  assertFinitePositive(transition.price, `${label} transition price`);
+}
+
+export function validateD1AlphaObservation(observation: D1AlphaObservation): void {
+  if (
+    !Number.isSafeInteger(observation.barTimestamp)
+    || observation.barTimestamp <= 0
+    || observation.barTimestamp % D1_ALPHA_DAY_MS !== 0
+  ) {
+    throw new Error('D1 alpha bar timestamp must be a positive UTC-day safe integer');
+  }
+
+  for (const symbol of ['BTCUSD', 'ETHUSD'] as const) {
+    const sleeve = observation.symbols[symbol];
+    if (!sleeve || sleeve.symbol !== symbol) {
+      throw new Error(`D1 alpha observation is missing ${symbol}`);
+    }
+    if (sleeve.source !== D1_ALPHA_DATA_SOURCE) {
+      throw new Error(`${symbol} source must remain ${D1_ALPHA_DATA_SOURCE}`);
+    }
+    assertFinitePositive(sleeve.close, `${symbol} close`);
+    if (sleeve.engineExposure !== 0 && sleeve.engineExposure !== 1) {
+      throw new Error(`${symbol} engine exposure must be 0 or 1`);
+    }
+    validateTransition(sleeve.transition, symbol);
+    if (sleeve.transition?.action === 'ENTER_LONG' && sleeve.engineExposure !== 1) {
+      throw new Error(`${symbol} ENTER_LONG did not produce engine exposure`);
+    }
+    if (
+      (sleeve.transition?.action === 'EXIT_GATE' || sleeve.transition?.action === 'EXIT_STOP')
+      && sleeve.engineExposure !== 0
+    ) {
+      throw new Error(`${symbol} exit did not produce flat engine exposure`);
+    }
+  }
+}
+
+function canonicalise(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalise);
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[key] = canonicalise((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+export function canonicalD1AlphaPayload(payload: D1AlphaSnapshotPayload): string {
+  return JSON.stringify(canonicalise(payload));
+}
+
+export function hashD1AlphaSnapshot(
+  payload: D1AlphaSnapshotPayload,
+  previousHash: string | null,
+): string {
+  return createHash('sha256')
+    .update(`${previousHash ?? 'GENESIS'}\n${canonicalD1AlphaPayload(payload)}`)
+    .digest('hex');
+}
+
+function initialSleeve(
+  observation: D1AlphaSymbolObservation,
+): D1AlphaSleeveSnapshot {
+  const benchmarkBeforeCost = 0.5;
+  return {
+    source: observation.source,
+    close: roundLedgerNumber(observation.close),
+    engineExposure: observation.engineExposure,
+    transition: observation.transition
+      ? { ...observation.transition, price: roundLedgerNumber(observation.transition.price) }
+      : null,
+    // The epoch is deliberately flat. A transition on this boundary is audit-only.
+    prospectivePosition: 'FLAT',
+    // If the historical engine is also flat, state alignment is already known.
+    // If it is long, wait for an observed exit and later entry; never inherit it.
+    synchronized: observation.engineExposure === 0,
+    strategyNav: 0.5,
+    benchmarkNav: roundLedgerNumber(benchmarkBeforeCost * (1 - D1_ALPHA_SIDE_COST_FRACTION)),
+  };
+}
+
+function advanceStrategySleeve(
+  previous: D1AlphaSleeveSnapshot,
+  observation: D1AlphaSymbolObservation,
+): {
+  snapshot: D1AlphaSleeveSnapshot;
+  cost: number;
+  funding: number;
+  closedTrades: number;
+} {
+  const transition = observation.transition;
+  let nav = previous.strategyNav;
+  let position = previous.prospectivePosition;
+  let synchronized = previous.synchronized;
+  let cost = 0;
+  let funding = 0;
+  let closedTrades = 0;
+
+  if (position === 'LONG') {
+    if (transition?.action === 'ENTER_LONG') {
+      throw new Error(`${observation.symbol} emitted ENTER_LONG while prospectively long`);
+    }
+    const exitPrice = transition?.action === 'EXIT_STOP'
+      ? transition.price
+      : observation.close;
+    const gross = nav * (exitPrice / previous.close);
+    funding = gross * D1_ALPHA_DAILY_FUNDING_FRACTION;
+    nav = gross - funding;
+
+    if (transition?.action === 'EXIT_GATE' || transition?.action === 'EXIT_STOP') {
+      cost = nav * D1_ALPHA_SIDE_COST_FRACTION;
+      nav -= cost;
+      position = 'FLAT';
+      closedTrades = 1;
+    } else if (observation.engineExposure !== 1) {
+      throw new Error(`${observation.symbol} prospective/engine exposure diverged while long`);
+    }
+  } else if (transition?.action === 'ENTER_LONG') {
+    if (observation.engineExposure !== 1) {
+      throw new Error(`${observation.symbol} ENTER_LONG did not produce engine exposure`);
+    }
+    cost = nav * D1_ALPHA_SIDE_COST_FRACTION;
+    nav -= cost;
+    position = 'LONG';
+    synchronized = true;
+  } else if (synchronized) {
+    if (transition?.action === 'EXIT_GATE' || transition?.action === 'EXIT_STOP') {
+      throw new Error(`${observation.symbol} emitted a second exit while prospectively flat`);
+    }
+    if (observation.engineExposure !== 0) {
+      throw new Error(`${observation.symbol} prospective/engine exposure diverged while flat`);
+    }
+  } else if (transition?.action === 'EXIT_GATE' || transition?.action === 'EXIT_STOP') {
+    // The inherited historical position has now closed without creating a
+    // prospective trade. Both state machines are provably flat from here.
+    synchronized = true;
+  } else if (observation.engineExposure === 0) {
+    throw new Error(`${observation.symbol} historical engine exposure changed without an exit`);
+  }
+
+  return {
+    snapshot: {
+      source: observation.source,
+      close: roundLedgerNumber(observation.close),
+      engineExposure: observation.engineExposure,
+      transition: transition
+        ? { ...transition, price: roundLedgerNumber(transition.price) }
+        : null,
+      prospectivePosition: position,
+      synchronized,
+      strategyNav: roundLedgerNumber(nav),
+      benchmarkNav: 0, // Filled by advanceBenchmarkSleeve below.
+    },
+    cost: roundLedgerNumber(cost),
+    funding: roundLedgerNumber(funding),
+    closedTrades,
+  };
+}
+
+function advanceBenchmarkSleeve(
+  previous: D1AlphaSleeveSnapshot,
+  observation: D1AlphaSymbolObservation,
+): { nav: number; funding: number } {
+  const gross = previous.benchmarkNav * (observation.close / previous.close);
+  const funding = gross * D1_ALPHA_DAILY_FUNDING_FRACTION;
+  return {
+    nav: roundLedgerNumber(gross - funding),
+    funding: roundLedgerNumber(funding),
+  };
+}
+
+function completePayload(
+  barTimestamp: number,
+  btc: D1AlphaSleeveSnapshot,
+  eth: D1AlphaSleeveSnapshot,
+  increments: Pick<
+    D1AlphaSnapshotPayload,
+    | 'strategyCostIncrement'
+    | 'strategyFundingIncrement'
+    | 'benchmarkCostIncrement'
+    | 'benchmarkFundingIncrement'
+    | 'closedTradesIncrement'
+  >,
+): D1AlphaSnapshotPayload {
+  const strategyPortfolioNav = roundLedgerNumber(btc.strategyNav + eth.strategyNav);
+  const benchmarkPortfolioNav = roundLedgerNumber(btc.benchmarkNav + eth.benchmarkNav);
+  const strategyLiquidationNav = roundLedgerNumber(
+    btc.strategyNav * (btc.prospectivePosition === 'LONG' ? 1 - D1_ALPHA_SIDE_COST_FRACTION : 1)
+    + eth.strategyNav * (eth.prospectivePosition === 'LONG' ? 1 - D1_ALPHA_SIDE_COST_FRACTION : 1),
+  );
+  const benchmarkLiquidationNav = roundLedgerNumber(
+    benchmarkPortfolioNav * (1 - D1_ALPHA_SIDE_COST_FRACTION),
+  );
+  return {
+    schemaVersion: 1,
+    strategyVersion: D1_ALPHA_STRATEGY_VERSION,
+    ruleSha256: D1_ALPHA_RULE_SHA256,
+    artifactSha256: D1_ALPHA_ARTIFACT_SHA256,
+    barTimestamp,
+    btc,
+    eth,
+    strategyPortfolioNav,
+    benchmarkPortfolioNav,
+    strategyLiquidationNav,
+    benchmarkLiquidationNav,
+    ...increments,
+  };
+}
+
+export function createInitialD1AlphaSnapshot(
+  observation: D1AlphaObservation,
+): D1AlphaSnapshotPayload {
+  validateD1AlphaObservation(observation);
+  const btc = initialSleeve(observation.symbols.BTCUSD);
+  const eth = initialSleeve(observation.symbols.ETHUSD);
+  return completePayload(observation.barTimestamp, btc, eth, {
+    strategyCostIncrement: 0,
+    strategyFundingIncrement: 0,
+    benchmarkCostIncrement: roundLedgerNumber(D1_ALPHA_SIDE_COST_FRACTION),
+    benchmarkFundingIncrement: 0,
+    closedTradesIncrement: 0,
+  });
+}
+
+export function advanceD1AlphaSnapshot(
+  previous: D1AlphaSnapshotPayload,
+  observation: D1AlphaObservation,
+): D1AlphaSnapshotPayload {
+  validateD1AlphaObservation(observation);
+  if (observation.barTimestamp !== previous.barTimestamp + D1_ALPHA_DAY_MS) {
+    throw new Error('D1 alpha ledger refuses gaps and historical backfill');
+  }
+  const btcStrategy = advanceStrategySleeve(previous.btc, observation.symbols.BTCUSD);
+  const ethStrategy = advanceStrategySleeve(previous.eth, observation.symbols.ETHUSD);
+  const btcBenchmark = advanceBenchmarkSleeve(previous.btc, observation.symbols.BTCUSD);
+  const ethBenchmark = advanceBenchmarkSleeve(previous.eth, observation.symbols.ETHUSD);
+  btcStrategy.snapshot.benchmarkNav = btcBenchmark.nav;
+  ethStrategy.snapshot.benchmarkNav = ethBenchmark.nav;
+
+  return completePayload(observation.barTimestamp, btcStrategy.snapshot, ethStrategy.snapshot, {
+    strategyCostIncrement: roundLedgerNumber(btcStrategy.cost + ethStrategy.cost),
+    strategyFundingIncrement: roundLedgerNumber(btcStrategy.funding + ethStrategy.funding),
+    benchmarkCostIncrement: 0,
+    benchmarkFundingIncrement: roundLedgerNumber(btcBenchmark.funding + ethBenchmark.funding),
+    closedTradesIncrement: btcStrategy.closedTrades + ethStrategy.closedTrades,
+  });
+}
+
+function maxDrawdown(values: number[]): number {
+  let peak = values[0] ?? 1;
+  let maximum = 0;
+  for (const value of values) {
+    peak = Math.max(peak, value);
+    maximum = Math.max(maximum, peak > 0 ? (peak - value) / peak : 0);
+  }
+  return maximum;
+}
+
+function calmar(netReturn: number, maxDrawdownValue: number, calendarDays: number): number | null {
+  if (calendarDays <= 0 || netReturn <= -1) return null;
+  const annualizedReturn = Math.pow(1 + netReturn, 365 / calendarDays) - 1;
+  if (maxDrawdownValue === 0) {
+    return annualizedReturn > 0 ? Number.POSITIVE_INFINITY : null;
+  }
+  return annualizedReturn / maxDrawdownValue;
+}
+
+export function calculateD1AlphaMetrics(
+  snapshots: D1AlphaSnapshotPayload[],
+): D1AlphaMetrics | null {
+  if (snapshots.length === 0) return null;
+  const first = snapshots[0];
+  const latest = snapshots[snapshots.length - 1];
+  // Include the common 1.0 pre-entry baseline so first-snapshot entry and
+  // liquidation costs contribute to drawdown for both portfolios.
+  const strategyValues = [1, ...snapshots.map((snapshot) => snapshot.strategyLiquidationNav)];
+  const benchmarkValues = [1, ...snapshots.map((snapshot) => snapshot.benchmarkLiquidationNav)];
+  const strategyNetReturn = latest.strategyLiquidationNav - 1;
+  const benchmarkNetReturn = latest.benchmarkLiquidationNav - 1;
+  const strategyMaxDrawdown = maxDrawdown(strategyValues);
+  const benchmarkMaxDrawdown = maxDrawdown(benchmarkValues);
+  const calendarDays = Math.floor((latest.barTimestamp - first.barTimestamp) / D1_ALPHA_DAY_MS);
+  return {
+    strategyNetReturn,
+    benchmarkNetReturn,
+    activeReturn: strategyNetReturn - benchmarkNetReturn,
+    strategyMaxDrawdown,
+    benchmarkMaxDrawdown,
+    strategyCalmar: calmar(strategyNetReturn, strategyMaxDrawdown, calendarDays),
+    benchmarkCalmar: calmar(benchmarkNetReturn, benchmarkMaxDrawdown, calendarDays),
+    calendarDays,
+    snapshots: snapshots.length,
+    closedTrades: snapshots.reduce((sum, snapshot) => sum + snapshot.closedTradesIncrement, 0),
+  };
+}
+
+function calmarAtLeast(strategy: number | null, benchmark: number | null): boolean {
+  if (strategy === null || benchmark === null) return false;
+  return strategy >= benchmark;
+}
+
+export function evaluateD1AlphaGate(
+  metrics: D1AlphaMetrics | null,
+  options: { cadencePassed: boolean; integrityPassed: boolean },
+): D1AlphaGateEvaluation {
+  const observationChecks = {
+    calendarDays: (metrics?.calendarDays ?? 0) >= D1_ALPHA_MIN_CALENDAR_DAYS,
+    snapshots: (metrics?.snapshots ?? 0) >= D1_ALPHA_MIN_SNAPSHOTS,
+    closedTrades: (metrics?.closedTrades ?? 0) >= D1_ALPHA_MIN_CLOSED_TRADES,
+    cadence: options.cadencePassed,
+    integrity: options.integrityPassed,
+  };
+  const observationMinimumMet = Object.values(observationChecks).every(Boolean);
+  if (!observationMinimumMet || metrics === null) {
+    return {
+      status: 'collecting-evidence',
+      observationMinimumMet: false,
+      performanceGateEvaluated: false,
+      observationChecks,
+      performanceChecks: {
+        positiveStrategyReturn: null,
+        positiveActiveReturn: null,
+        drawdownNoWorse: null,
+        calmarNoWorse: null,
+      },
+    };
+  }
+
+  const performanceChecks = {
+    positiveStrategyReturn: metrics.strategyNetReturn > 0,
+    positiveActiveReturn: metrics.activeReturn > 0,
+    drawdownNoWorse: metrics.strategyMaxDrawdown <= metrics.benchmarkMaxDrawdown,
+    calmarNoWorse: calmarAtLeast(metrics.strategyCalmar, metrics.benchmarkCalmar),
+  };
+  const passed = Object.values(performanceChecks).every(Boolean);
+  return {
+    status: passed ? 'eligible-for-review' : 'failed-gate',
+    observationMinimumMet: true,
+    performanceGateEvaluated: true,
+    observationChecks,
+    performanceChecks,
+  };
+}
+
+export function buildD1AlphaHashedSnapshot(
+  payload: D1AlphaSnapshotPayload,
+  previousHash: string | null,
+): D1AlphaHashedSnapshot {
+  return { payload, previousHash, rowHash: hashD1AlphaSnapshot(payload, previousHash) };
+}
+
+export const _d1AlphaInternal = { canonicalise, roundLedgerNumber, maxDrawdown, calmar };

--- a/apps/web/lib/d1-slow-gate-paper.ts
+++ b/apps/web/lib/d1-slow-gate-paper.ts
@@ -13,6 +13,18 @@ import {
   type StoredCandle,
 } from './candle-store';
 import { recordSignalsAsync, type TrackedSignalInput } from './signal-history';
+import {
+  appendD1AlphaSnapshot,
+  type D1AlphaWriteResult,
+} from './d1-alpha-ledger';
+import {
+  D1_ALPHA_COST_MODEL,
+  D1_ALPHA_DATA_SOURCE,
+  D1_ALPHA_FREQUENCY_WINDOW_MS,
+  D1_ALPHA_MAX_DIRECTION_CHANGES,
+  type D1AlphaSymbol,
+  type D1AlphaSymbolObservation,
+} from './d1-alpha-protocol';
 
 const DAY_MS = 86_400_000;
 const MIN_D1_BARS = 200;
@@ -34,6 +46,7 @@ export type D1SlowGatePaperFailureStage =
   | 'strategy'
   | 'frequency'
   | 'persist'
+  | 'ledger'
   | 'lane';
 
 export interface D1SlowGatePaperFailure {
@@ -47,6 +60,7 @@ export interface D1SlowGateLaneResult {
   processed: number;
   candidates: number;
   recorded: number;
+  alphaLedger: D1AlphaWriteResult | null;
   failures: D1SlowGatePaperFailure[];
 }
 
@@ -64,6 +78,9 @@ function validatePaperCandles(candles: StoredCandle[], now: number): void {
     );
   }
   for (let index = 0; index < candles.length; index++) {
+    if (candles[index].source !== D1_ALPHA_DATA_SOURCE) {
+      throw new Error(`D1 bar ${index} source must remain ${D1_ALPHA_DATA_SOURCE}`);
+    }
     const timestamp = candles[index].timestamp;
     if (timestamp % DAY_MS !== 0) {
       throw new Error(`D1 bar ${index} is not aligned to a UTC day boundary`);
@@ -127,6 +144,9 @@ export async function runD1SlowGateLane(
 
   const failures: D1SlowGatePaperFailure[] = [];
   const candidates: TrackedSignalInput[] = [];
+  const alphaObservations: Partial<
+    Record<D1AlphaSymbol, { barTimestamp: number; observation: D1AlphaSymbolObservation }>
+  > = {};
   let processed = 0;
 
   for (const symbol of D1_SLOW_GATE_SYMBOLS) {
@@ -156,7 +176,15 @@ export async function runD1SlowGateLane(
     }
 
     try {
-      const run = runD1SlowGate(candles, { symbol, timeframe: D1_SLOW_GATE_TIMEFRAME });
+      const run = runD1SlowGate(
+        candles,
+        { symbol, timeframe: D1_SLOW_GATE_TIMEFRAME },
+        {
+          costs: D1_ALPHA_COST_MODEL,
+          maxDirectionChanges: D1_ALPHA_MAX_DIRECTION_CHANGES,
+          frequencyWindowMs: D1_ALPHA_FREQUENCY_WINDOW_MS,
+        },
+      );
       if (!run.frequencyCapPassed) {
         failures.push({
           symbol,
@@ -168,6 +196,20 @@ export async function runD1SlowGateLane(
 
       const latestBarIndex = candles.length - 1;
       const transition = run.transitions.findLast((item) => item.barIndex === latestBarIndex);
+      const latest = candles[latestBarIndex];
+      const alphaSymbol = symbol as D1AlphaSymbol;
+      alphaObservations[alphaSymbol] = {
+        barTimestamp: latest.timestamp,
+        observation: {
+          symbol: alphaSymbol,
+          source: latest.source,
+          close: latest.close,
+          engineExposure: run.exposure[latestBarIndex],
+          transition: transition
+            ? { action: transition.action, price: transition.price }
+            : null,
+        },
+      };
       if (transition) candidates.push(toTrackedSignal(symbol, transition, mode));
     } catch (error) {
       failures.push({ symbol, stage: 'strategy', error: message(error) });
@@ -185,7 +227,36 @@ export async function runD1SlowGateLane(
     }
   }
 
-  return { mode, processed, candidates: candidates.length, recorded, failures };
+  let alphaLedger: D1AlphaWriteResult | null = null;
+  const btc = alphaObservations.BTCUSD;
+  const eth = alphaObservations.ETHUSD;
+  if (btc && eth) {
+    if (btc.barTimestamp !== eth.barTimestamp) {
+      failures.push({
+        symbol: 'BTCUSD+ETHUSD',
+        stage: 'ledger',
+        error: 'D1 alpha ledger requires one common closed portfolio bar',
+      });
+    } else {
+      try {
+        alphaLedger = await appendD1AlphaSnapshot({
+          barTimestamp: btc.barTimestamp,
+          symbols: { BTCUSD: btc.observation, ETHUSD: eth.observation },
+        });
+      } catch (error) {
+        failures.push({ symbol: 'BTCUSD+ETHUSD', stage: 'ledger', error: message(error) });
+      }
+    }
+  }
+
+  return {
+    mode,
+    processed,
+    candidates: candidates.length,
+    recorded,
+    alphaLedger,
+    failures,
+  };
 }
 
 /** Backward-compatible explicit paper entry point for internal callers. */

--- a/apps/web/lib/openapi.ts
+++ b/apps/web/lib/openapi.ts
@@ -245,7 +245,7 @@ export function buildOpenApiSpec(): OpenApiSpec {
                   required: ["status", "required"],
                   properties: {
                     status: { type: "string", enum: ["ok", "error", "unknown"] },
-                    required: { type: "string", example: "053_drop_monetization.sql" },
+                    required: { type: "string", example: "054_d1_alpha_ledger.sql" },
                   },
                 },
               },

--- a/apps/web/migrations/054_d1_alpha_ledger.sql
+++ b/apps/web/migrations/054_d1_alpha_ledger.sql
@@ -1,0 +1,148 @@
+-- 054: Prospective D1 alpha evidence ledger.
+--
+-- This is a research ledger, not the observed signal archive and not a broker
+-- account. It begins at the first post-deployment snapshot, refuses historical
+-- insertion, and is immutable at the database layer. Application writes are
+-- serialized and hash-chained by apps/web/lib/d1-alpha-ledger.ts.
+
+CREATE TABLE IF NOT EXISTS d1_alpha_ledger (
+  strategy_version              TEXT             NOT NULL,
+  bar_ts                        BIGINT           NOT NULL,
+  rule_sha256                   TEXT             NOT NULL,
+  artifact_sha256               TEXT             NOT NULL,
+
+  btc_source                    VARCHAR(24)      NOT NULL,
+  btc_close                     DOUBLE PRECISION NOT NULL,
+  btc_transition_action         VARCHAR(16),
+  btc_transition_price          DOUBLE PRECISION,
+  btc_engine_exposure           SMALLINT         NOT NULL,
+  btc_position                  VARCHAR(4)       NOT NULL,
+  btc_synchronized              BOOLEAN          NOT NULL,
+  btc_strategy_nav              DOUBLE PRECISION NOT NULL,
+  btc_benchmark_nav             DOUBLE PRECISION NOT NULL,
+
+  eth_source                    VARCHAR(24)      NOT NULL,
+  eth_close                     DOUBLE PRECISION NOT NULL,
+  eth_transition_action         VARCHAR(16),
+  eth_transition_price          DOUBLE PRECISION,
+  eth_engine_exposure           SMALLINT         NOT NULL,
+  eth_position                  VARCHAR(4)       NOT NULL,
+  eth_synchronized              BOOLEAN          NOT NULL,
+  eth_strategy_nav              DOUBLE PRECISION NOT NULL,
+  eth_benchmark_nav             DOUBLE PRECISION NOT NULL,
+
+  strategy_nav                  DOUBLE PRECISION NOT NULL,
+  benchmark_nav                 DOUBLE PRECISION NOT NULL,
+  strategy_liquidation_nav      DOUBLE PRECISION NOT NULL,
+  benchmark_liquidation_nav     DOUBLE PRECISION NOT NULL,
+  strategy_cost_increment       DOUBLE PRECISION NOT NULL,
+  strategy_funding_increment    DOUBLE PRECISION NOT NULL,
+  benchmark_cost_increment      DOUBLE PRECISION NOT NULL,
+  benchmark_funding_increment   DOUBLE PRECISION NOT NULL,
+  closed_trades_increment       SMALLINT         NOT NULL,
+
+  previous_hash                 TEXT,
+  row_hash                      TEXT             NOT NULL,
+  canonical_payload             JSONB            NOT NULL,
+  committed_at                  TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (strategy_version, bar_ts),
+  UNIQUE (strategy_version, row_hash),
+
+  CONSTRAINT d1_alpha_strategy_version_check
+    CHECK (strategy_version = 'd1-slow-gate-v1-2026-08-09'),
+  CONSTRAINT d1_alpha_rule_hash_check
+    CHECK (rule_sha256 = 'a9c222a33f3e1e0c70e8fb5f0bfa930dc6433297d9dcb27ef2b825f08da3b171'),
+  CONSTRAINT d1_alpha_artifact_hash_check
+    CHECK (artifact_sha256 = '1a6b28e47f218fafd5134cb257e06f966f881bc5154be92135c06867f5026e90'),
+  CONSTRAINT d1_alpha_bar_alignment_check
+    CHECK (bar_ts > 0 AND MOD(bar_ts, 86400000) = 0),
+  CONSTRAINT d1_alpha_hash_shape_check
+    CHECK (
+      row_hash ~ '^[0-9a-f]{64}$'
+      AND (previous_hash IS NULL OR previous_hash ~ '^[0-9a-f]{64}$')
+    ),
+  CONSTRAINT d1_alpha_btc_source_check
+    CHECK (btc_source = 'binance'),
+  CONSTRAINT d1_alpha_eth_source_check
+    CHECK (eth_source = 'binance'),
+  CONSTRAINT d1_alpha_btc_transition_check
+    CHECK (
+      (btc_transition_action IS NULL AND btc_transition_price IS NULL)
+      OR (
+        btc_transition_action IN ('ENTER_LONG', 'EXIT_GATE', 'EXIT_STOP')
+        AND btc_transition_price > 0
+        AND btc_transition_price < 'Infinity'::DOUBLE PRECISION
+      )
+    ),
+  CONSTRAINT d1_alpha_eth_transition_check
+    CHECK (
+      (eth_transition_action IS NULL AND eth_transition_price IS NULL)
+      OR (
+        eth_transition_action IN ('ENTER_LONG', 'EXIT_GATE', 'EXIT_STOP')
+        AND eth_transition_price > 0
+        AND eth_transition_price < 'Infinity'::DOUBLE PRECISION
+      )
+    ),
+  CONSTRAINT d1_alpha_position_check
+    CHECK (btc_position IN ('FLAT', 'LONG') AND eth_position IN ('FLAT', 'LONG')),
+  CONSTRAINT d1_alpha_exposure_check
+    CHECK (btc_engine_exposure IN (0, 1) AND eth_engine_exposure IN (0, 1)),
+  CONSTRAINT d1_alpha_positive_values_check
+    CHECK (
+      btc_close > 0 AND btc_close < 'Infinity'::DOUBLE PRECISION
+      AND eth_close > 0 AND eth_close < 'Infinity'::DOUBLE PRECISION
+      AND btc_strategy_nav > 0 AND btc_strategy_nav < 'Infinity'::DOUBLE PRECISION
+      AND btc_benchmark_nav > 0 AND btc_benchmark_nav < 'Infinity'::DOUBLE PRECISION
+      AND eth_strategy_nav > 0 AND eth_strategy_nav < 'Infinity'::DOUBLE PRECISION
+      AND eth_benchmark_nav > 0 AND eth_benchmark_nav < 'Infinity'::DOUBLE PRECISION
+      AND strategy_nav > 0 AND strategy_nav < 'Infinity'::DOUBLE PRECISION
+      AND benchmark_nav > 0 AND benchmark_nav < 'Infinity'::DOUBLE PRECISION
+      AND strategy_liquidation_nav > 0 AND strategy_liquidation_nav < 'Infinity'::DOUBLE PRECISION
+      AND benchmark_liquidation_nav > 0 AND benchmark_liquidation_nav < 'Infinity'::DOUBLE PRECISION
+    ),
+  CONSTRAINT d1_alpha_increment_check
+    CHECK (
+      strategy_cost_increment >= 0 AND strategy_cost_increment < 'Infinity'::DOUBLE PRECISION
+      AND strategy_funding_increment >= 0 AND strategy_funding_increment < 'Infinity'::DOUBLE PRECISION
+      AND benchmark_cost_increment >= 0 AND benchmark_cost_increment < 'Infinity'::DOUBLE PRECISION
+      AND benchmark_funding_increment >= 0 AND benchmark_funding_increment < 'Infinity'::DOUBLE PRECISION
+      AND closed_trades_increment BETWEEN 0 AND 2
+    ),
+  CONSTRAINT d1_alpha_payload_identity_check
+    CHECK (
+      jsonb_typeof(canonical_payload) = 'object'
+      AND canonical_payload ?& ARRAY[
+        'schemaVersion', 'strategyVersion', 'ruleSha256', 'artifactSha256',
+        'barTimestamp', 'btc', 'eth', 'strategyPortfolioNav',
+        'benchmarkPortfolioNav', 'strategyLiquidationNav',
+        'benchmarkLiquidationNav', 'strategyCostIncrement',
+        'strategyFundingIncrement', 'benchmarkCostIncrement',
+        'benchmarkFundingIncrement', 'closedTradesIncrement'
+      ]::TEXT[]
+      AND canonical_payload->>'schemaVersion' = '1'
+      AND canonical_payload->>'strategyVersion' = strategy_version
+      AND canonical_payload->>'ruleSha256' = rule_sha256
+      AND canonical_payload->>'artifactSha256' = artifact_sha256
+      AND (canonical_payload->>'barTimestamp')::BIGINT = bar_ts
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_d1_alpha_ledger_latest
+  ON d1_alpha_ledger (strategy_version, bar_ts DESC);
+
+CREATE OR REPLACE FUNCTION reject_d1_alpha_ledger_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'd1_alpha_ledger is append-only; % is forbidden', TG_OP
+    USING ERRCODE = '55000';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS d1_alpha_ledger_reject_mutation ON d1_alpha_ledger;
+CREATE TRIGGER d1_alpha_ledger_reject_mutation
+  BEFORE UPDATE OR DELETE ON d1_alpha_ledger
+  FOR EACH ROW EXECUTE FUNCTION reject_d1_alpha_ledger_mutation();
+
+COMMENT ON TABLE d1_alpha_ledger IS
+  'Append-only prospective modeled-cost D1 strategy/benchmark snapshots; not broker returns.';

--- a/apps/web/tests/e2e/track-record/track-record.spec.ts
+++ b/apps/web/tests/e2e/track-record/track-record.spec.ts
@@ -117,6 +117,32 @@ test.describe('Track Record page', () => {
     await expect(canvas.or(noEvidence)).toBeVisible({ timeout: 20_000 });
   });
 
+  test('prospective alpha ledger stays separate and collecting evidence', async ({ page }) => {
+    await dismissStarMilestoneModal(page);
+    await page.goto('/track-record/alpha');
+    await dismissStarMilestoneModal(page);
+
+    await expect(page.getByRole('heading', {
+      name: 'Prospective D1 Alpha Ledger',
+      exact: true,
+      level: 1,
+    })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('collecting evidence', { exact: true })).toBeVisible();
+    await expect(page.getByText('Not the current strategy.', { exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Losing observed archive' })).toHaveAttribute(
+      'href',
+      '/track-record',
+    );
+    await expect(page.getByRole('link', { name: 'Retrospective studies' })).toHaveAttribute(
+      'href',
+      '/track-record/study',
+    );
+    await expect(page.getByText(
+      'Newest first. Each row commits both symbols as one hash-chained portfolio observation.',
+      { exact: true },
+    )).toBeVisible();
+  });
+
   // Test 5: Category breakdown buttons (All / Majors / Thematic) are present.
   // No "strategy breakdown" section exists on this page. The closest equivalent
   // is CategoryBreakdownRow, which renders 3 clickable cells for category segmentation.

--- a/docs/plans/2026-08-10-d1-alpha-ledger.md
+++ b/docs/plans/2026-08-10-d1-alpha-ledger.md
@@ -1,0 +1,125 @@
+# D1 Prospective Alpha Ledger — Frozen Protocol
+
+Date frozen: 2026-08-10
+
+## Objective
+
+Measure whether the already-approved BTCUSD + ETHUSD D1 slow-gate candidate
+produces prospective, modeled-cost excess performance after the ledger is
+deployed. This protocol does not alter the strategy and does not convert its
+historical simulation into a live-performance claim.
+
+## Frozen strategy identity
+
+- Strategy version: `d1-slow-gate-v1-2026-08-09`
+- Symbols: `BTCUSD`, `ETHUSD`
+- Timeframe: UTC daily bars
+- OHLCV source: Binance spot (`BTCUSDT`, `ETHUSDT`), stored as `binance`
+- Portfolio: fixed 50/50 independent sleeves, no cross-rebalancing
+- Rule: close above EMA200, long/flat
+- Stop: ATR14 × 2.5 with a 4.0% minimum distance
+- Fee: 0.05% per side
+- Slippage: 0.15% per side
+- Funding: fixed 0.01% per eight hours while long
+- Frequency ceiling: 30 direction changes in any rolling 365 days
+- Normalized strategy-source SHA-256:
+  `a9c222a33f3e1e0c70e8fb5f0bfa930dc6433297d9dcb27ef2b825f08da3b171`
+- Canonical frozen-artifact SHA-256:
+  `1a6b28e47f218fafd5134cb257e06f966f881bc5154be92135c06867f5026e90`
+
+Changing any strategy input, rule source, cost assumption, symbol, timeframe,
+or portfolio weight requires a new version and a new prospective ledger. It
+must never rewrite this version.
+
+## Observation boundary
+
+The observation epoch is the first successfully committed daily snapshot after
+the ledger migration is deployed. The ledger starts both strategy sleeves flat,
+even when the historical state machine is already long at that moment. It does
+not replay or manufacture positions from bars that predate the first snapshot.
+Collection runs in the isolated research ledger whether the signal lane is in
+`paper` or `active` mode; it does not change that mode or promote the strategy.
+
+Only a transition observed after the first snapshot may open or close a tracked
+position. An exit seen while the prospective sleeve is flat is recorded for
+audit but cannot create a trade or change NAV. Missing historical snapshots are
+never inserted later.
+
+The benchmark enters a fixed 50/50 BTCUSD + ETHUSD long portfolio at the first
+snapshot, pays the same per-side entry cost, and accrues the same fixed funding
+assumption. It is a modeled comparator, not a broker account.
+
+## Append-only daily snapshot
+
+One row is eligible for each common, provably closed UTC-D1 bar after the
+observation epoch. Both symbols must be present, source-backed, cadence-aligned,
+and evaluated by the frozen state machine. Otherwise the entire date fails
+closed and no partial portfolio row is written.
+
+Each row records:
+
+- strategy version and rule/artifact fingerprints
+- bar timestamp and committed-at timestamp
+- source-backed BTCUSD and ETHUSD closes
+- observed transition action and price for each sleeve
+- prospective position state for each sleeve
+- per-sleeve and portfolio strategy NAV
+- per-sleeve and portfolio benchmark NAV
+- modeled cost and funding increments
+- closed-trade increment
+- a deterministic row hash chained to the previous row
+
+Rows use `INSERT ... ON CONFLICT DO NOTHING`. An existing row must byte-match
+the recomputed snapshot or the writer fails closed. Updates and deletes are
+rejected by a database trigger.
+
+## Predeclared observation gate
+
+Status remains exactly `collecting-evidence` until every minimum is true:
+
+- at least 365 calendar days since the first snapshot
+- at least 365 consecutive daily snapshots
+- at least 12 prospectively closed sleeve trades across BTCUSD and ETHUSD
+- zero unresolved cadence gaps
+- every stored row passes rule fingerprint, source, finite-value, and hash-chain
+  integrity checks
+
+The gate is based on time, sample size, and integrity—not return.
+
+## Performance gate after the minimum
+
+Passing the observation minimum is necessary but not sufficient. The candidate
+is `eligible-for-review` only when all prospective modeled-cost conditions are
+also true:
+
+- strategy net return is positive
+- active return versus the benchmark is positive
+- strategy maximum drawdown is no worse than the benchmark
+- strategy Calmar is at least the benchmark Calmar
+
+If the observation minimum is complete and any performance condition fails,
+status is `failed-gate`. Neither state promotes the strategy automatically.
+Promotion to `current` requires a separate owner decision and code/config
+change after reviewing the frozen evidence.
+
+## Public surface
+
+`/track-record/alpha` must show the status, gate progress, start boundary,
+current positions, modeled strategy and benchmark NAV, active return, drawdown,
+Calmar, closed trades, integrity state, recent append-only rows, raw JSON link,
+and frozen fingerprints. Empty evidence renders as an em dash, never `+0%`.
+
+The page must link to both the immutable observed archive at `/track-record` and
+the retrospective modeled studies at `/track-record/study`. Neither existing
+surface is deleted or relabeled as this prospective ledger.
+
+## Out of scope
+
+- D1 rule or parameter changes
+- new strategy search or optimization
+- historical position or NAV backfill
+- deletion or rewriting of the losing observed archive
+- broker execution or broker-return claims
+- signal broadcast eligibility
+- portfolio allocation outside the frozen research ledger
+- automatic promotion


### PR DESCRIPTION
## What changed

- adds migration 054 and an immutable, hash-chained BTCUSD/ETHUSD D1 prospective ledger
- integrates one common closed-bar snapshot into the existing D1 cron lane
- adds `/api/track-record/alpha` and `/track-record/alpha`
- publishes the frozen protocol, fingerprints, gate progress, and evidence navigation
- preserves the observed losing archive and retrospective study catalog

## Evidence boundary

The existing D1 rule is unchanged. The ledger starts both strategy sleeves flat at its first successfully committed post-deployment snapshot and refuses historical backfill.

Status remains **collecting evidence** until all predeclared minimums pass:

- 365 calendar days
- 365 consecutive snapshots
- 12 prospectively closed sleeve trades
- zero unresolved cadence gaps
- complete source, fingerprint, hash-chain, and recomputation integrity

Only then is the performance gate evaluated. Passing yields **eligible for review**, never automatic promotion. Promotion requires a separate owner code/config action.

## Validation

- focused Jest: 9 suites / 54 tests
- full Jest: 241 suites / 1,878 tests; 3 suites / 26 tests skipped
- strategy tests: 14 suites / 103 tests / 1 snapshot
- web typecheck: pass
- lint: 0 errors / 23 pre-existing warnings
- production build: pass, including `/track-record/alpha`
- Chromium E2E: 2/2
- desktop/mobile browser QA: no overflow or console/page errors
- frozen strategy source diff: zero
- `STATE.yaml` and patch integrity: pass

## Release gate

Real PostgreSQL migration execution, protected CI, exact-final-main deployment, first-row verification, health, routes, browser, and bounded logs remain required before calling this live.