### PR TITLE
feat(ui): give dark and light themes real structure and per-theme elevation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,8 +14,30 @@ Visual system for TradeClaw. The token source of truth is `apps/web/app/globals.
 
 TradeClaw uses a near-black/near-white exchange canvas with crisp contrast, quiet borders, and small amounts of emerald light. Dark mode is the signature presentation; light mode is fully supported and must preserve the same hierarchy.
 
-- Dark canvas: `--background: #030506`; cards `#090c0e`; raised surface `#0e1316`; inset surface `#06090a`; borders `#1b2327` to `#303b40`.
-- Light canvas: `--background: #f4f7f8`; cards `#ffffff`; raised surface `#edf2f4`; inset surface `#e6ecef`; borders `#dce3e6` to `#c5d0d5`.
+- Dark canvas: `--background: #030506`; cards `#151c1f`; raised surface `#1d2529`; inset surface `#0b1013`; borders `#333e42` to `#556165`.
+- Light canvas: `--background: #f4f7f8`; cards `#fdfefe`; raised surface `#edf2f4`; inset surface `#e6ecef`; borders `#b9c4c8` to `#8d9a9e`.
+
+The two themes earn their definition differently, and this asymmetry is deliberate:
+
+- **Light is ink on paper.** Two near-whites can differ by at most ~1.1:1, so surfaces
+  stay close to the canvas and the border tiers carry the structure. `--border` is the
+  internal divider (~1.8:1 on a card) and `--border-strong` is the component frame
+  (~2.9:1, the WCAG 1.4.11 bar for boundaries that identify a component).
+- **Dark is emission.** Definition comes from lifting the surface off the canvas
+  (`--bg-card` sits ~1.18:1 above `--background`), so panels read without a bright
+  wireframe edge; borders stay quieter (~1.6:1 divider, ~2.7:1 frame).
+
+Never carry a dark-tuned effect onto the light canvas unchanged. Elevation is
+tokenised per theme — `--shadow-panel`, `--shadow-raised`, `--shadow-pop`,
+`--surface-highlight` — and primitives must consume those tokens rather than
+hardcoding a shadow. Light uses tight, low-alpha, hue-tinted shadows and sets
+`--surface-highlight: transparent`, because a white inset highlight only washes the
+top edge of a light surface. Dark keeps the deep diffuse shadow plus the lit top edge.
+
+`.premium-dark-chrome` marks regions that stay dark on a light page (nav, footer,
+mobile nav). It carries the whole dark palette, not just the brand tokens: a
+descendant reading `var(--text-secondary)` would otherwise get the light value and
+render near-invisible on the dark bar.
 - Prefer solid semantic surfaces and one-pixel borders. Glass, blur, glow, grids, and gradients are supporting atmosphere, never the default treatment for every panel.
 - The legacy light-mode utility remapping in `globals.css` exists for compatibility. New components must use semantic variables rather than depending on that layer.
 
@@ -116,6 +138,6 @@ Premium means precise, calm, and verifiable, not glossy. Trust is built through 
 
 WebGL is **data-only**. It may render a real dataset when depth or motion materially clarifies the finding; it is never a decorative hero background. Use one scene per page at most, lazy-loaded client-side with `next/dynamic`, no SSR, and `three` without react-three-fiber.
 
-For the Cost Field, each resolved sized trade is an instanced point, Y is the R multiple, and a neutral zero plane separates positive from negative. The gross-to-net interpolation applies modeled cost so the cloud visibly shifts. Emerald and rose retain their directional meaning; a neutral high-contrast cursor identifies selection without inventing another hue.
+For the Cost Field, each resolved sized trade is an instanced point, Y is the R multiple, and a neutral zero plane separates positive from negative. The dot colours stay fixed across themes, but the zero-plane grid reads from `--costfield-grid` / `--costfield-grid-opacity` and rebuilds on theme change: a mid grey at 0.14 that works on the near-black canvas disappears on the light inset surface. The gross-to-net interpolation applies modeled cost so the cloud visibly shifts. Emerald and rose retain their directional meaning; a neutral high-contrast cursor identifies selection without inventing another hue.
 
 Cap DPR at 2, instance points, pause offscreen and on hidden tabs, and fully dispose on unmount. Target less than 200KB gzipped for the Three.js chunk and less than 100KB for the data payload. The fallback chain is: WebGL scene -> static 2D rendering of the same data -> text summary of the same numbers. Reduced motion may skip interpolation, but it must not omit the evidence.

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -26,7 +26,10 @@
   --font-display: var(--font-geist-sans), system-ui, sans-serif;
 }
 
-/* Light theme (default) */
+/* Light theme (default).
+   Light is ink on paper: definition comes from the border tiers, not from
+   surface separation. Two near-whites can only ever differ by ~1.1:1, so the
+   panels stay close to the canvas and the lines carry the structure. */
 :root {
   --background: #f4f7f8;
   --foreground: #090d0f;
@@ -36,11 +39,16 @@
   --color-up-soft: rgba(4, 120, 87, 0.12);
   --color-down: #be123c;
   --color-down-soft: rgba(190, 18, 60, 0.12);
-  --bg-card: #ffffff;
+  /* Tinted toward the brand hue rather than pure white. */
+  --bg-card: #fdfefe;
   --surface-raised: #edf2f4;
   --surface-inset: #e6ecef;
-  --border: #dce3e6;
-  --border-strong: #c5d0d5;
+  /* Structural tiers. --border is the internal divider (~1.8:1 on card),
+     --border-strong is the component frame (~2.9:1, the WCAG 1.4.11 bar).
+     Previously 1.30 / 1.57, which left the ledger and explore grids with no
+     visible structure. */
+  --border: #b9c4c8;
+  --border-strong: #8d9a9e;
   --brand: #047857;
   --brand-bright: #10b981;
   --brand-soft: rgba(16, 185, 129, 0.11);
@@ -58,14 +66,38 @@
   --scrollbar: rgba(0, 0, 0, 0.18);
   --scrollbar-hover: rgba(0, 0, 0, 0.32);
   --glass-nav-bg: rgba(244, 247, 248, 0.9);
-  --hero-grid-dot: rgba(16, 185, 129, 0.09);
+  /* The bright decorative emerald disappears on a near-white canvas; the
+     accessible dark emerald reads as a drawn line instead of a haze. */
+  --hero-grid-dot: rgba(4, 120, 87, 0.14);
   --glass-nav-shadow:
     0 12px 40px rgba(15, 31, 36, 0.08), inset 0 -1px 0 rgba(255, 255, 255, 0.8);
+
+  /* Cost Field WebGL zero-plane grid. The dot colours stay #10b981 / #f43f5e
+     in both themes (DESIGN.md, "canvas/WebGL mark"); only the grid adapts,
+     because a mid grey at 0.14 vanishes on the light inset surface. */
+  --costfield-grid: #55666c;
+  --costfield-grid-opacity: 0.3;
+
+  /* Elevation — paper. Tight, low-alpha, tinted toward the canvas hue.
+     No white inset: on a light surface it only washes the top edge. */
+  --surface-highlight: transparent;
+  /* Light cards are flat: the border and shadow carry them. Tinting the
+     top-left would put the shading on the side the light comes from. */
+  --card-gradient-top: var(--bg-card);
+  --shadow-panel:
+    0 1px 2px rgba(15, 31, 36, 0.05), 0 8px 20px -8px rgba(15, 31, 36, 0.10);
+  --shadow-raised:
+    0 2px 4px rgba(15, 31, 36, 0.05), 0 18px 40px -16px rgba(15, 31, 36, 0.16);
+  --shadow-pop: 0 10px 24px -8px rgba(15, 31, 36, 0.22);
+
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-/* Dark theme */
+/* Dark theme.
+   Dark is emission: definition comes from lifting the surface off the canvas,
+   so panels read without a bright wireframe edge. Borders then only need to be
+   quiet-but-present rather than doing all the structural work. */
 .dark {
   --background: #030506;
   --foreground: #f4f7f8;
@@ -74,11 +106,14 @@
   --color-up-soft: rgba(52, 211, 153, 0.14);
   --color-down: #fb7185;
   --color-down-soft: rgba(251, 113, 133, 0.14);
-  --bg-card: #090c0e;
-  --surface-raised: #0e1316;
-  --surface-inset: #06090a;
-  --border: #1b2327;
-  --border-strong: #303b40;
+  /* Lifted from #090c0e: at 1.04:1 against the canvas the panels were
+     indistinguishable from the page. Now ~1.18:1. */
+  --bg-card: #151c1f;
+  --surface-raised: #1d2529;
+  --surface-inset: #0b1013;
+  /* ~1.6:1 divider / ~2.7:1 frame on the card, up from 1.23 / 1.71. */
+  --border: #333e42;
+  --border-strong: #556165;
   --brand: #34d399;
   --brand-bright: #10b981;
   --brand-soft: rgba(16, 185, 129, 0.13);
@@ -99,6 +134,17 @@
   --glass-nav-shadow:
     0 18px 50px rgba(0, 0, 0, 0.46), inset 0 -1px 0 rgba(255, 255, 255, 0.025);
   --hero-grid-dot: rgba(52, 211, 153, 0.08);
+
+  --costfield-grid: #9ca3af;
+  --costfield-grid-opacity: 0.14;
+
+  /* Elevation — emission. Deep diffuse shadow plus a lit top edge. */
+  --surface-highlight: rgba(255, 255, 255, 0.055);
+  /* Dark cards lift toward the top-left, matching the light source. */
+  --card-gradient-top: var(--surface-raised);
+  --shadow-panel: 0 16px 40px rgba(0, 0, 0, 0.42);
+  --shadow-raised: 0 28px 72px rgba(0, 0, 0, 0.5);
+  --shadow-pop: 0 14px 34px rgba(0, 0, 0, 0.55);
 }
 
 * {
@@ -118,14 +164,34 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
-/* Forced-dark navigation and footer chrome must keep the bright emerald token
-   even when the page itself is using the light theme. */
+/* Forced-dark navigation and footer chrome. These regions stay dark on a light
+   page, so they need the whole dark palette, not just the brand tokens: any
+   descendant reading var(--text-secondary) or var(--border) would otherwise get
+   the light-theme value and render near-invisible on the dark bar (measured at
+   1.35:1 for the nav clock before this block was completed). */
 .premium-dark-chrome {
+  --foreground: #f4f7f8;
+  --text-secondary: #8d9aa0;
+  --bg-card: #151c1f;
+  --surface-raised: #1d2529;
+  --surface-inset: #0b1013;
+  --border: #333e42;
+  --border-strong: #303b40;
+  --color-up: #34d399;
+  --color-up-soft: rgba(52, 211, 153, 0.14);
+  --color-down: #fb7185;
+  --color-down-soft: rgba(251, 113, 133, 0.14);
   --brand: #34d399;
   --brand-bright: #10b981;
   --brand-soft: rgba(16, 185, 129, 0.13);
-  --border-strong: #303b40;
+  --glass-bg: rgba(255, 255, 255, 0.025);
+  --glass-border: rgba(255, 255, 255, 0.08);
   --ring: rgba(52, 211, 153, 0.52);
+  --surface-highlight: rgba(255, 255, 255, 0.055);
+  --card-gradient-top: var(--surface-raised);
+  --shadow-panel: 0 16px 40px rgba(0, 0, 0, 0.42);
+  --shadow-raised: 0 28px 72px rgba(0, 0, 0, 0.5);
+  --shadow-pop: 0 14px 34px rgba(0, 0, 0, 0.55);
 }
 
 ::selection {
@@ -232,12 +298,11 @@ html:not(.dark) .text-white\/20 { color: rgb(0 0 0 / 0.3); }
 }
 
 .glass-card {
-  background:
-    linear-gradient(145deg, color-mix(in srgb, var(--bg-card) 96%, white 4%), var(--bg-card));
+  background: linear-gradient(145deg, var(--card-gradient-top), var(--bg-card) 62%);
   border: 1px solid var(--border);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.035),
-    0 14px 42px rgba(0, 0, 0, 0.08);
+    inset 0 1px 0 var(--surface-highlight),
+    var(--shadow-panel);
   transition:
     border-color 500ms cubic-bezier(0.32, 0.72, 0, 1),
     box-shadow 500ms cubic-bezier(0.32, 0.72, 0, 1),
@@ -247,8 +312,8 @@ html:not(.dark) .text-white\/20 { color: rgb(0 0 0 / 0.3); }
 .glass-card:hover {
   border-color: var(--glass-border-accent);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.045),
-    0 18px 48px rgba(0, 0, 0, 0.16);
+    inset 0 1px 0 var(--surface-highlight),
+    var(--shadow-raised);
   transform: translateY(-2px);
 }
 
@@ -351,6 +416,13 @@ html:not(.dark) .explore-card:hover .explore-card-art {
   opacity: 0.09;
   pointer-events: none;
   user-select: none;
+  /* The frame overhangs the section on purpose, so without a vertical fade the
+     raster terminates in a hard horizontal edge at this clip boundary — which
+     reads as a grey slab behind the hero on the light canvas. Masking the
+     clipping layer keeps each variant's horizontal mask on the image itself,
+     so neither element needs mask-composite. */
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, #000 15%, #000 74%, transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0%, #000 15%, #000 74%, transparent 100%);
 }
 
 .product-hero-backdrop__frame {
@@ -445,7 +517,10 @@ html:not(.dark) .product-hero-backdrop--quiet {
     linear-gradient(to right, var(--hero-grid-dot) 1px, transparent 1px),
     linear-gradient(to bottom, var(--hero-grid-dot) 1px, transparent 1px);
   background-size: 44px 44px;
-  mask-image: linear-gradient(to bottom, black, transparent 76%);
+  /* Fades on both axes. A bottom-only fade left the grid's rectangular extent
+     cut off hard at the shell edges, which reads as a seam now that the light
+     theme renders the grid at a visible alpha. */
+  mask-image: radial-gradient(86% 76% at 44% -6%, black 0%, black 8%, transparent 70%);
 }
 
 .premium-button-primary {
@@ -465,7 +540,7 @@ html:not(.dark) .product-hero-backdrop--quiet {
 
 .premium-button-primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+  box-shadow: var(--shadow-pop);
 }
 
 .premium-button-secondary {
@@ -522,8 +597,8 @@ html:not(.dark) .product-hero-backdrop--quiet {
     linear-gradient(150deg, color-mix(in srgb, var(--surface-raised) 64%, transparent), transparent 52%),
     var(--surface-inset);
   box-shadow:
-    0 30px 90px rgba(0, 0, 0, 0.34),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    var(--shadow-raised),
+    inset 0 1px 0 var(--surface-highlight);
 }
 
 .premium-terminal::after {

--- a/apps/web/components/landing/cost-field/CostFieldScene.tsx
+++ b/apps/web/components/landing/cost-field/CostFieldScene.tsx
@@ -154,12 +154,53 @@ export function CostFieldScene({ data, mode, onPhaseChange }: CostFieldSceneProp
     const points = new THREE.Points(geometry, material);
     scene.add(points);
 
-    const grid = new THREE.GridHelper(FIELD_WIDTH + 6, 22, 0x9ca3af, 0x9ca3af);
-    const gridMaterial = grid.material as THREE.Material;
-    gridMaterial.transparent = true;
-    gridMaterial.opacity = 0.14;
-    gridMaterial.depthWrite = false;
-    scene.add(grid);
+    // The zero-plane grid is the only themed part of the scene: a mid grey at
+    // 0.14 reads on the near-black canvas and vanishes on the light inset
+    // surface. Dot colours stay fixed in both themes (DESIGN.md). GridHelper
+    // bakes its colours into geometry vertex colours, so a theme switch
+    // rebuilds it rather than tinting the material.
+    let grid: THREE.GridHelper | null = null;
+    let appliedGridKey = '';
+
+    const disposeGrid = () => {
+      if (!grid) return;
+      scene.remove(grid);
+      grid.geometry.dispose();
+      (grid.material as THREE.Material).dispose();
+      grid = null;
+    };
+
+    const syncGrid = () => {
+      const styles = getComputedStyle(document.documentElement);
+      const color = styles.getPropertyValue('--costfield-grid').trim() || '#9ca3af';
+      const parsedOpacity = Number.parseFloat(
+        styles.getPropertyValue('--costfield-grid-opacity'),
+      );
+      const opacity = Number.isFinite(parsedOpacity) ? parsedOpacity : 0.14;
+
+      // The observer fires on any html class change, not just the theme swap.
+      // Rebuild only when the resolved tokens actually differ.
+      const key = `${color}|${opacity}`;
+      if (key === appliedGridKey) return;
+      appliedGridKey = key;
+
+      disposeGrid();
+      const gridColor = new THREE.Color(color);
+      grid = new THREE.GridHelper(FIELD_WIDTH + 6, 22, gridColor, gridColor);
+      const gridMaterial = grid.material as THREE.Material;
+      gridMaterial.transparent = true;
+      gridMaterial.opacity = opacity;
+      gridMaterial.depthWrite = false;
+      scene.add(grid);
+    };
+
+    syncGrid();
+
+    const themeObserver = new MutationObserver(syncGrid);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
 
     const resize = () => {
       const w = container.clientWidth;
@@ -247,11 +288,12 @@ export function CostFieldScene({ data, mode, onPhaseChange }: CostFieldSceneProp
     return () => {
       stop();
       document.removeEventListener('visibilitychange', onVisibility);
+      themeObserver.disconnect();
       intersection.disconnect();
       resizeObserver.disconnect();
       geometry.dispose();
       material.dispose();
-      gridMaterial.dispose();
+      disposeGrid();
       renderer.dispose();
       container.removeChild(renderer.domElement);
     };

--- a/docs/plans/2026-08-11-dark-light-theme-craft.md
+++ b/docs/plans/2026-08-11-dark-light-theme-craft.md
@@ -1,0 +1,97 @@
+# Dark + light theme craft pass
+
+Date: 2026-08-11
+Surface: the shared token layer in `apps/web/app/globals.css` (all routes inherit)
+Register: brand (PRODUCT.md)
+
+## Problem
+
+Measured in a real browser at 1600x900 (contrast ratios, WCAG 2.x formula):
+
+| pair | light | dark | note |
+|---|---|---|---|
+| `--border` on `--bg-card` | 1.30 | 1.23 | dividers that carry the ledger/explore grid structure |
+| `--border-strong` on `--bg-card` | 1.57 | 1.71 | component frames (terminal, ledger, explore) |
+| `--bg-card` on `--background` | 1.08 | 1.04 | panels do not read as their own plane |
+| `--surface-inset` on `--background` | 1.11 | 1.02 | terminal interior |
+| `--text-secondary` on `--background` | 5.30 | 7.06 | passes |
+| `--brand` on `--bg-card` | 5.48 | 10.20 | passes |
+
+Text colour is not the problem. **Structure and elevation are.** Surfaces do not
+separate from the canvas, and the lines meant to do the separating sit at
+1.2-1.7:1 in both themes. The page reads as one flat sheet.
+
+Compounding it: every atmospheric primitive was calibrated against the near-black
+canvas and applied unchanged to light.
+
+- `.premium-terminal` — `0 30px 90px rgba(0,0,0,0.34)` plus a white inset
+  highlight. On a near-white canvas that 90px black blur is a muddy grey halo
+  around the hero terminal, and the white inset is invisible.
+- `.glass-card` — same white inset, plus a `white 4%` gradient lift that is a
+  no-op on a white card.
+- `.premium-button-primary:hover` — `0 12px 30px rgba(0,0,0,0.24)`.
+- `--hero-grid-dot` light is `rgba(16,185,129,0.09)`; on `#f4f7f8` it is
+  effectively invisible, so the hero loses its grid entirely in light.
+- `CostFieldScene` grid is hardcoded `0x9ca3af @ 0.14` in both themes. The hero's
+  primary imagery does not respond to the theme at all.
+- `.premium-dark-chrome` overrides only 5 tokens, so a descendant of the
+  forced-dark nav reading `var(--text-secondary)` gets the *light* value on a
+  light page: measured 1.35:1 for the nav clock.
+
+## Approach
+
+Fix at the token and primitive layer so all routes inherit it. No component
+restructuring, no copy changes, no data-layer changes.
+
+Light and dark get different definition strategies, because they behave
+differently:
+
+- **Light = ink on paper.** Definition comes from borders. Surfaces stay close
+  together (contrast ratio is a poor metric for near-white separation), and the
+  border tiers carry the structure.
+- **Dark = emission.** Definition comes from surface luminance lift. `--bg-card`
+  is raised off the canvas so panels read without a bright wireframe edge, and
+  borders rise to a quiet-but-present tier.
+
+1. **Border + surface retune.** Same token names, so every existing consumer
+   inherits it. `--border` ~1.6-1.8:1, `--border-strong` ~2.7-2.9:1, dark
+   `--bg-card` `#090c0e` -> `#151c1f` (1.04 -> 1.18 vs canvas).
+2. **Theme-split elevation.** New `--shadow-panel` / `--shadow-raised` /
+   `--shadow-pop` / `--surface-highlight` / `--card-gradient-top`, consumed by
+   `.premium-terminal`, `.glass-card`, `.premium-button-primary`. Light sets
+   `--surface-highlight: transparent` so the white inset stops washing top edges.
+3. **Light-mode atmosphere.** `--hero-grid-dot` moves to the accessible dark
+   emerald so the hero grid reads; the grid mask becomes radial so it dissolves
+   on every side instead of cutting off at the shell edge.
+4. **Theme-aware Cost Field.** `CostFieldScene` reads its grid colour/opacity
+   from the live theme and rebuilds on theme change (MutationObserver on the
+   `dark` class, guarded so it only rebuilds when the resolved tokens differ).
+   Dot colours stay `#10b981` / `#f43f5e` per DESIGN.md in both themes.
+5. **Complete `.premium-dark-chrome`** with the full dark palette.
+
+## Non-goals
+
+- The forced-dark navbar and footer stay dark. That is a shipped identity
+  decision in DESIGN.md, not a defect.
+- No change to signals, ledger maths, copy, routes, deps, or schema.
+
+## Known-remaining (not addressed here)
+
+Auditing `/dashboard` in light mode found ~40 sub-AA text nodes that predate this
+change and are not token-driven. Two distinct causes:
+
+1. The light-mode override layer remaps `text-white/60` to dark text but also
+   applies **inside** `.premium-dark-chrome`, so dark text lands on the dark nav
+   (1.04:1). The clean selector fix (`:not(.premium-dark-chrome *)`) silently
+   drops the whole rule on Safari <16.4; the zero-risk alternative is ~50
+   explicit restore rules. Deferred as its own change.
+2. Components hardcode `text-white` (e.g. `guided-tour.tsx`), which the override
+   layer deliberately never remaps — white on a light card.
+
+## Verification
+
+1. Re-measure all token pairs in-browser, both themes, against the new floors.
+2. Homepage at 1600x900 and 390x844, both themes: no overflow, no console errors.
+3. Layer-2 routes (`/research`, `/dashboard`) in both themes to confirm the token
+   change does not regress product surfaces.
+4. `next build` green; web typecheck green; lint no new errors.


### PR DESCRIPTION
## What

Both themes were a token swap rather than two designed themes. Measured in a real browser at 1600x900:

| pair | light | dark | after (light / dark) |
|---|---|---|---|
| `--border` on `--bg-card` | 1.30 | 1.23 | **1.76 / 1.57** |
| `--border-strong` on `--bg-card` | 1.57 | 1.71 | **2.87 / 2.70** |
| `--bg-card` on `--background` | 1.08 | 1.04 | 1.07 / **1.18** |

Text contrast was already passing (5.3-10.2:1), so this is a **structure and elevation** fix, not a colour fix. Panels dissolved into the canvas and the lines meant to separate them sat at 1.2-1.7:1.

## Approach

The two themes now earn definition differently, on purpose:

- **Light is ink on paper.** Two near-whites cannot separate on luminance (max ~1.1:1), so surfaces stay close and the border tiers carry the structure.
- **Dark is emission.** `--bg-card` lifts off the canvas (1.04 -> 1.18) so panels read without a bright wireframe edge, and borders stay quieter.

Everything is fixed at the token/primitive layer, so all routes inherit it.

- Elevation is tokenised per theme (`--shadow-panel` / `--shadow-raised` / `--shadow-pop` / `--surface-highlight` / `--card-gradient-top`). `.premium-terminal` was carrying `0 30px 90px rgba(0,0,0,0.34)` plus a white inset highlight onto the light canvas: that 90px black blur was the muddy grey halo around the hero terminal.
- `.premium-dark-chrome` now carries the full dark palette. It previously overrode 5 tokens, so a descendant of the forced-dark nav reading `var(--text-secondary)` got the *light* value on a light page (nav clock measured **1.35:1**).
- `CostFieldScene` reads its zero-plane grid from `--costfield-grid` and rebuilds on theme change. It was hardcoded `0x9ca3af @ 0.14` in both themes, which vanishes on the light inset surface. Dot colours stay `#10b981` / `#f43f5e` per DESIGN.md.
- Hero grid and hero backdrop masks fade out instead of terminating on a hard clip edge (the grey slab behind the headline in light mode).

## Verification

- `next build` green, **325/325** pages
- `typecheck:web` clean
- lint **0 errors / 23 warnings** (unchanged pre-existing baseline)
- Homepage at 1600x900 and 390x844, both themes: no horizontal overflow (386px doc in a 390px viewport), 0 console errors/warnings
- `/research` and `/dashboard` checked in both themes for token regressions
- All text stays AA: light 5.43-6.22, dark 5.96-8.97

## Not in this PR

Auditing `/dashboard` in light mode surfaced ~40 sub-AA text nodes that predate this change and are not token-driven. Two causes, both deferred as their own change:

1. The light-mode override layer remaps `text-white/60` to dark text but also applies **inside** `.premium-dark-chrome`, so dark text lands on the dark nav (1.04:1). The clean selector fix (`:not(.premium-dark-chrome *)`) silently drops the whole rule on Safari <16.4; the zero-risk alternative is ~50 explicit restore rules.
2. Components hardcode `text-white` (e.g. `guided-tour.tsx`), which the override layer deliberately never remaps.

No change to signals, ledger maths, copy, routes, dependencies, or schema.
